### PR TITLE
Rearchitect pulse mechanism

### DIFF
--- a/TypeDB.java
+++ b/TypeDB.java
@@ -35,27 +35,27 @@ public class TypeDB {
     public static final String DEFAULT_ADDRESS = "localhost:1729";
 
     public static TypeDBClient coreClient(String address) {
-        return CoreClient.create(address);
+        return new CoreClient(address);
     }
 
     public static TypeDBClient coreClient(String address, int parallelisation) {
-        return CoreClient.create(address, parallelisation);
+        return new CoreClient(address, parallelisation);
     }
 
     public static TypeDBClient.Cluster clusterClient(String address, TypeDBCredential credential) {
-        return ClusterClient.create(set(address), credential);
+        return new ClusterClient(set(address), credential);
     }
 
     public static TypeDBClient.Cluster clusterClient(String address, TypeDBCredential credential, int parallelisation) {
-        return ClusterClient.create(set(address), credential, parallelisation);
+        return new ClusterClient(set(address), credential, parallelisation);
     }
 
     public static TypeDBClient.Cluster clusterClient(Set<String> addresses, TypeDBCredential credential) {
-        return ClusterClient.create(addresses, credential);
+        return new ClusterClient(addresses, credential);
     }
 
     public static TypeDBClient.Cluster clusterClient(Set<String> addresses, TypeDBCredential credential, int parallelisation) {
-        return ClusterClient.create(addresses, credential, parallelisation);
+        return new ClusterClient(addresses, credential, parallelisation);
     }
 
 }

--- a/api/concept/Concept.java
+++ b/api/concept/Concept.java
@@ -21,7 +21,6 @@
 
 package com.vaticle.typedb.client.api.concept;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Attribute;
 import com.vaticle.typedb.client.api.concept.thing.Entity;
 import com.vaticle.typedb.client.api.concept.thing.Relation;
@@ -32,6 +31,7 @@ import com.vaticle.typedb.client.api.concept.type.RelationType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
 import com.vaticle.typedb.client.api.concept.type.Type;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 
 import javax.annotation.CheckReturnValue;
 

--- a/api/concept/thing/Attribute.java
+++ b/api/concept/thing/Attribute.java
@@ -21,9 +21,9 @@
 
 package com.vaticle.typedb.client.api.concept.thing;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 
 import javax.annotation.CheckReturnValue;
 import java.time.LocalDateTime;

--- a/api/concept/thing/Entity.java
+++ b/api/concept/thing/Entity.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.api.concept.thing;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.EntityType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 
 import javax.annotation.CheckReturnValue;
 

--- a/api/concept/thing/Relation.java
+++ b/api/concept/thing/Relation.java
@@ -21,9 +21,9 @@
 
 package com.vaticle.typedb.client.api.concept.thing;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.RelationType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 
 import javax.annotation.CheckReturnValue;
 import java.util.List;

--- a/api/concept/thing/Thing.java
+++ b/api/concept/thing/Thing.java
@@ -21,11 +21,11 @@
 
 package com.vaticle.typedb.client.api.concept.thing;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.Concept;
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 
 import javax.annotation.CheckReturnValue;
 import java.util.stream.Stream;

--- a/api/concept/type/AttributeType.java
+++ b/api/concept/type/AttributeType.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.api.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Attribute;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.protocol.ConceptProto;
 

--- a/api/concept/type/EntityType.java
+++ b/api/concept/type/EntityType.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.api.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Entity;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 
 import javax.annotation.CheckReturnValue;
 import java.util.stream.Stream;

--- a/api/concept/type/RelationType.java
+++ b/api/concept/type/RelationType.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.api.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Relation;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;

--- a/api/concept/type/ThingType.java
+++ b/api/concept/type/ThingType.java
@@ -21,9 +21,9 @@
 
 package com.vaticle.typedb.client.api.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Thing;
 import com.vaticle.typedb.client.api.concept.type.AttributeType.ValueType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 
 import javax.annotation.CheckReturnValue;
 import java.util.stream.Stream;

--- a/api/concept/type/Type.java
+++ b/api/concept/type/Type.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.api.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.Concept;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.Label;
 
 import javax.annotation.CheckReturnValue;

--- a/api/connection/TypeDBOptions.java
+++ b/api/connection/TypeDBOptions.java
@@ -162,7 +162,6 @@ public class TypeDBOptions {
         parallel().ifPresent(builder::setParallel);
         prefetchSize().ifPresent(builder::setPrefetchSize);
         prefetch().ifPresent(builder::setPrefetch);
-        sessionIdleTimeoutMillis().ifPresent(builder::setSessionIdleTimeoutMillis);
         schemaLockAcquireTimeoutMillis().ifPresent(builder::setSchemaLockAcquireTimeoutMillis);
         if (isCluster()) asCluster().readAnyReplica().ifPresent(builder::setReadAnyReplica);
 

--- a/api/query/QueryManager.java
+++ b/api/query/QueryManager.java
@@ -21,11 +21,11 @@
 
 package com.vaticle.typedb.client.api.query;
 
-import com.vaticle.typedb.client.api.connection.TypeDBOptions;
 import com.vaticle.typedb.client.api.answer.ConceptMap;
 import com.vaticle.typedb.client.api.answer.ConceptMapGroup;
 import com.vaticle.typedb.client.api.answer.Numeric;
 import com.vaticle.typedb.client.api.answer.NumericGroup;
+import com.vaticle.typedb.client.api.connection.TypeDBOptions;
 import com.vaticle.typedb.client.api.logic.Explanation;
 import com.vaticle.typeql.lang.query.TypeQLDefine;
 import com.vaticle.typeql.lang.query.TypeQLDelete;

--- a/common/rpc/RequestBuilder.java
+++ b/common/rpc/RequestBuilder.java
@@ -191,8 +191,8 @@ public class RequestBuilder {
                     .setType(type).setOptions(options).build();
         }
 
-        public static SessionProto.Session.Close.Req closeReq(ByteString sessionID) {
-            return SessionProto.Session.Close.Req.newBuilder().setSessionId(sessionID).build();
+        public static SessionProto.Session.Close.Req closeReq(ByteString clientID, ByteString sessionID) {
+            return SessionProto.Session.Close.Req.newBuilder().setClientId(clientID).setSessionId(sessionID).build();
         }
     }
 

--- a/common/rpc/TypeDBStub.java
+++ b/common/rpc/TypeDBStub.java
@@ -21,16 +21,14 @@
 
 package com.vaticle.typedb.client.common.rpc;
 
-import com.vaticle.typedb.client.common.exception.TypeDBClientException;
+import com.vaticle.typedb.protocol.ClientProto.Client;
 import com.vaticle.typedb.protocol.CoreDatabaseProto.CoreDatabase;
 import com.vaticle.typedb.protocol.CoreDatabaseProto.CoreDatabaseManager;
-import com.vaticle.typedb.protocol.ClientProto.Client;
 import com.vaticle.typedb.protocol.SessionProto.Session;
 import com.vaticle.typedb.protocol.TransactionProto;
 import com.vaticle.typedb.protocol.TypeDBGrpc;
 import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 import java.util.function.Supplier;

--- a/common/rpc/TypeDBStub.java
+++ b/common/rpc/TypeDBStub.java
@@ -24,6 +24,7 @@ package com.vaticle.typedb.client.common.rpc;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.protocol.CoreDatabaseProto.CoreDatabase;
 import com.vaticle.typedb.protocol.CoreDatabaseProto.CoreDatabaseManager;
+import com.vaticle.typedb.protocol.ClientProto.Client;
 import com.vaticle.typedb.protocol.SessionProto.Session;
 import com.vaticle.typedb.protocol.TransactionProto;
 import com.vaticle.typedb.protocol.TypeDBGrpc;
@@ -35,6 +36,18 @@ import io.grpc.stub.StreamObserver;
 import java.util.function.Supplier;
 
 public abstract class TypeDBStub {
+
+    public Client.Open.Res clientOpen(Client.Open.Req request) {
+        return resilientCall(() -> blockingStub().clientOpen(request));
+    }
+
+    public Client.Close.Res clientClose(Client.Close.Req request) {
+        return resilientCall(() -> blockingStub().clientClose(request));
+    }
+
+    public Client.Pulse.Res clientPulse(Client.Pulse.Req request) {
+        return resilientCall(() -> blockingStub().clientPulse(request));
+    }
 
     public CoreDatabaseManager.Contains.Res databasesContains(CoreDatabaseManager.Contains.Req request) {
         return resilientCall(() -> blockingStub().databasesContains(request));
@@ -62,10 +75,6 @@ public abstract class TypeDBStub {
 
     public Session.Close.Res sessionClose(Session.Close.Req request) {
         return resilientCall(() -> blockingStub().sessionClose(request));
-    }
-
-    public Session.Pulse.Res sessionPulse(Session.Pulse.Req request) {
-        return resilientCall(() -> blockingStub().sessionPulse(request));
     }
 
     public StreamObserver<TransactionProto.Transaction.Client> transaction(StreamObserver<TransactionProto.Transaction.Server> responseObserver) {

--- a/concept/ConceptManagerImpl.java
+++ b/concept/ConceptManagerImpl.java
@@ -21,13 +21,13 @@
 
 package com.vaticle.typedb.client.concept;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.ConceptManager;
 import com.vaticle.typedb.client.api.concept.thing.Thing;
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
 import com.vaticle.typedb.client.api.concept.type.EntityType;
 import com.vaticle.typedb.client.api.concept.type.RelationType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.concept.thing.ThingImpl;
 import com.vaticle.typedb.client.concept.type.AttributeTypeImpl;
 import com.vaticle.typedb.client.concept.type.EntityTypeImpl;

--- a/concept/thing/AttributeImpl.java
+++ b/concept/thing/AttributeImpl.java
@@ -21,9 +21,9 @@
 
 package com.vaticle.typedb.client.concept.thing;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Attribute;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.client.concept.type.AttributeTypeImpl;
 import com.vaticle.typedb.protocol.ConceptProto;

--- a/concept/thing/EntityImpl.java
+++ b/concept/thing/EntityImpl.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.concept.thing;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Entity;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.concept.type.EntityTypeImpl;
 import com.vaticle.typedb.common.collection.Bytes;
 import com.vaticle.typedb.protocol.ConceptProto;

--- a/concept/thing/RelationImpl.java
+++ b/concept/thing/RelationImpl.java
@@ -21,10 +21,10 @@
 
 package com.vaticle.typedb.client.concept.thing;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Relation;
 import com.vaticle.typedb.client.api.concept.thing.Thing;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.concept.type.RelationTypeImpl;
 import com.vaticle.typedb.client.concept.type.RoleTypeImpl;
 import com.vaticle.typedb.client.concept.type.TypeImpl;

--- a/concept/thing/ThingImpl.java
+++ b/concept/thing/ThingImpl.java
@@ -21,11 +21,11 @@
 
 package com.vaticle.typedb.client.concept.thing;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Attribute;
 import com.vaticle.typedb.client.api.concept.thing.Thing;
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.client.concept.ConceptImpl;
 import com.vaticle.typedb.client.concept.type.RoleTypeImpl;

--- a/concept/type/AttributeTypeImpl.java
+++ b/concept/type/AttributeTypeImpl.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.Label;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.client.concept.thing.AttributeImpl;

--- a/concept/type/EntityTypeImpl.java
+++ b/concept/type/EntityTypeImpl.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.EntityType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.Label;
 import com.vaticle.typedb.client.concept.thing.EntityImpl;
 import com.vaticle.typedb.client.concept.thing.ThingImpl;

--- a/concept/type/RelationTypeImpl.java
+++ b/concept/type/RelationTypeImpl.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.RelationType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.Label;
 import com.vaticle.typedb.client.concept.thing.RelationImpl;
 import com.vaticle.typedb.client.concept.thing.ThingImpl;

--- a/concept/type/RoleTypeImpl.java
+++ b/concept/type/RoleTypeImpl.java
@@ -21,9 +21,9 @@
 
 package com.vaticle.typedb.client.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.RelationType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.Label;
 import com.vaticle.typedb.client.common.rpc.RequestBuilder;
 import com.vaticle.typedb.protocol.ConceptProto;

--- a/concept/type/ThingTypeImpl.java
+++ b/concept/type/ThingTypeImpl.java
@@ -21,11 +21,11 @@
 
 package com.vaticle.typedb.client.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.AttributeType;
 import com.vaticle.typedb.client.api.concept.type.AttributeType.ValueType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.Label;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.client.common.rpc.RequestBuilder;

--- a/concept/type/TypeImpl.java
+++ b/concept/type/TypeImpl.java
@@ -21,7 +21,6 @@
 
 package com.vaticle.typedb.client.concept.type;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.thing.Attribute;
 import com.vaticle.typedb.client.api.concept.thing.Entity;
 import com.vaticle.typedb.client.api.concept.thing.Relation;
@@ -32,6 +31,7 @@ import com.vaticle.typedb.client.api.concept.type.RelationType;
 import com.vaticle.typedb.client.api.concept.type.RoleType;
 import com.vaticle.typedb.client.api.concept.type.ThingType;
 import com.vaticle.typedb.client.api.concept.type.Type;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.Label;
 import com.vaticle.typedb.client.common.exception.TypeDBClientException;
 import com.vaticle.typedb.client.concept.ConceptImpl;

--- a/connection/TypeDBClientImpl.java
+++ b/connection/TypeDBClientImpl.java
@@ -157,7 +157,6 @@ public abstract class TypeDBClientImpl implements TypeDBClient {
             boolean alive;
             try {
                 alive = stub().clientPulse(pulseReq(ID())).getAlive();
-                System.out.println("client pulse - alive: " + alive);
             } catch (TypeDBClientException exception) {
                 alive = false;
             }

--- a/connection/TypeDBSessionImpl.java
+++ b/connection/TypeDBSessionImpl.java
@@ -120,7 +120,7 @@ public class TypeDBSessionImpl implements TypeDBSession {
                 transactions.forEach(TypeDBTransaction.Extended::close);
                 client.removeSession(this);
                 try {
-                    stub().sessionClose(closeReq(sessionID));
+                    stub().sessionClose(closeReq(client.ID(), sessionID));
                 } catch (TypeDBClientException e) {
                     // Most likely the session is already closed or the server is no longer running.
                 }

--- a/connection/TypeDBTransactionImpl.java
+++ b/connection/TypeDBTransactionImpl.java
@@ -22,9 +22,9 @@
 package com.vaticle.typedb.client.connection;
 
 import com.google.protobuf.ByteString;
+import com.vaticle.typedb.client.api.concept.ConceptManager;
 import com.vaticle.typedb.client.api.connection.TypeDBOptions;
 import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
-import com.vaticle.typedb.client.api.concept.ConceptManager;
 import com.vaticle.typedb.client.api.logic.LogicManager;
 import com.vaticle.typedb.client.api.query.QueryFuture;
 import com.vaticle.typedb.client.api.query.QueryManager;

--- a/connection/TypeDBTransactionImpl.java
+++ b/connection/TypeDBTransactionImpl.java
@@ -54,33 +54,15 @@ public class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
 
     private final BidirectionalStream bidirectionalStream;
 
-    TypeDBTransactionImpl(TypeDBSessionImpl session, ByteString sessionId, Type type, TypeDBOptions options) {
+    TypeDBTransactionImpl(ByteString clientID, TypeDBSessionImpl session, Type type, TypeDBOptions options) {
         this.type = type;
         this.options = options;
         conceptMgr = new ConceptManagerImpl(this);
         logicMgr = new LogicManagerImpl(this);
         queryMgr = new QueryManagerImpl(this);
         bidirectionalStream = new BidirectionalStream(session.stub(), session.transmitter());
-        execute(openReq(sessionId, type.proto(), options.proto(), session.networkLatencyMillis()), false);
+        execute(openReq(clientID, session.ID(), type.proto(), options.proto(), session.networkLatencyMillis()), false);
     }
-
-    @Override
-    public Type type() { return type; }
-
-    @Override
-    public TypeDBOptions options() { return options; }
-
-    @Override
-    public boolean isOpen() { return bidirectionalStream.isOpen(); }
-
-    @Override
-    public ConceptManager concepts() { return conceptMgr; }
-
-    @Override
-    public LogicManager logic() { return logicMgr; }
-
-    @Override
-    public QueryManager query() { return queryMgr; }
 
     @Override
     public Res execute(Req.Builder request) {
@@ -107,6 +89,24 @@ public class TypeDBTransactionImpl implements TypeDBTransaction.Extended {
         if (!isOpen()) throw new TypeDBClientException(TRANSACTION_CLOSED);
         return bidirectionalStream.stream(request);
     }
+
+    @Override
+    public boolean isOpen() { return bidirectionalStream.isOpen(); }
+
+    @Override
+    public Type type() { return type; }
+
+    @Override
+    public TypeDBOptions options() { return options; }
+
+    @Override
+    public ConceptManager concepts() { return conceptMgr; }
+
+    @Override
+    public LogicManager logic() { return logicMgr; }
+
+    @Override
+    public QueryManager query() { return queryMgr; }
 
     @Override
     public void commit() {

--- a/connection/cluster/ClusterServerClient.java
+++ b/connection/cluster/ClusterServerClient.java
@@ -93,4 +93,10 @@ class ClusterServerClient extends TypeDBClientImpl {
             throw new TypeDBClientException(e.getMessage(), e);
         }
     }
+
+    @Override
+    protected void closeResources() {
+        pulseDeactivate();
+        super.closeResources();
+    }
 }

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -30,8 +30,6 @@ import io.grpc.netty.NettyChannelBuilder;
 
 import javax.annotation.Nullable;
 
-import java.util.Timer;
-
 import static com.vaticle.typedb.client.common.rpc.RequestBuilder.Client.openReq;
 
 public class CoreClient extends TypeDBClientImpl {
@@ -70,5 +68,11 @@ public class CoreClient extends TypeDBClientImpl {
     @Override
     public TypeDBStub stub() {
         return stub;
+    }
+
+    @Override
+    protected void closeResources() {
+        pulseDeactivate();
+        super.closeResources();
     }
 }

--- a/connection/core/CoreClient.java
+++ b/connection/core/CoreClient.java
@@ -48,7 +48,7 @@ public class CoreClient extends TypeDBClientImpl {
         this(address, null, parallelisation);
     }
 
-    public CoreClient(String address, @Nullable Integer idleTimeoutMillis, int parallelisation) {
+    private CoreClient(String address, @Nullable Integer idleTimeoutMillis, int parallelisation) {
         super(idleTimeoutMillis, parallelisation);
         channel = NettyChannelBuilder.forTarget(address).usePlaintext().build();
         stub = CoreStub.create(channel);

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "d399a43fe967ed92730f4d989660e35d85953c45"
+        commit = "e619e91b53ecd6e06ace5984c26bad807be4330e"
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "e619e91b53ecd6e06ace5984c26bad807be4330e"
+        commit = "f9eed93b3e11d862102c97fc427d1d1e1158f6a3"
     )
 
 def vaticle_typedb_cluster_artifact():
@@ -39,5 +39,5 @@ def vaticle_typedb_cluster_artifact():
         artifact_name = "typedb-cluster-all-{platform}-{version}.{ext}",
         tag_source = deployment_private["artifact.release"],
         commit_source = deployment_private["artifact.snapshot"],
-        commit = "467639bb384a52ee41dbb4b6eaa1348fced8e67b",
+        commit = "52d36e6cc91778bf7a961a92784e3258de1cc1f5",
     )

--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -29,7 +29,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-server-{platform}-{version}.{ext}",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "6ed020e52fe379d1100f64511805ed344c7a68db"
+        commit = "d399a43fe967ed92730f4d989660e35d85953c45"
     )
 
 def vaticle_typedb_cluster_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -46,7 +46,7 @@ def vaticle_typedb_protocol():
     git_repository(
         name = "vaticle_typedb_protocol",
         remote = "https://github.com/lolski/typedb-protocol",
-        commit = "e784fb7a9a5d0ae78817174876904916a43b2d8b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        commit = "469413e45ef9e0be03702f52890d01f3ae43ea06", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -43,10 +43,15 @@ def vaticle_dependencies():
     )
 
 def vaticle_typedb_protocol():
-    git_repository(
+#    git_repository(
+#        name = "vaticle_typedb_protocol",
+#        remote = "https://github.com/vaticle/typedb-protocol",
+#        commit = "3300d136a35f35bed58137bb79a6e3774dd170b9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+#    )
+
+    native.local_repository(
         name = "vaticle_typedb_protocol",
-        remote = "https://github.com/vaticle/typedb-protocol",
-        tag = "2.4.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
+        path = "../typedb-protocol",
     )
 
 def vaticle_typedb_behaviour():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -43,15 +43,10 @@ def vaticle_dependencies():
     )
 
 def vaticle_typedb_protocol():
-#    git_repository(
-#        name = "vaticle_typedb_protocol",
-#        remote = "https://github.com/vaticle/typedb-protocol",
-#        commit = "3300d136a35f35bed58137bb79a6e3774dd170b9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
-#    )
-
-    native.local_repository(
+    git_repository(
         name = "vaticle_typedb_protocol",
-        path = "../typedb-protocol",
+        remote = "https://github.com/lolski/typedb-protocol",
+        commit = "e784fb7a9a5d0ae78817174876904916a43b2d8b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_protocol
     )
 
 def vaticle_typedb_behaviour():

--- a/query/QueryManagerImpl.java
+++ b/query/QueryManagerImpl.java
@@ -21,12 +21,12 @@
 
 package com.vaticle.typedb.client.query;
 
-import com.vaticle.typedb.client.api.connection.TypeDBOptions;
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.answer.ConceptMap;
 import com.vaticle.typedb.client.api.answer.ConceptMapGroup;
 import com.vaticle.typedb.client.api.answer.Numeric;
 import com.vaticle.typedb.client.api.answer.NumericGroup;
+import com.vaticle.typedb.client.api.connection.TypeDBOptions;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.logic.Explanation;
 import com.vaticle.typedb.client.api.query.QueryFuture;
 import com.vaticle.typedb.client.api.query.QueryManager;

--- a/test/behaviour/config/Parameters.java
+++ b/test/behaviour/config/Parameters.java
@@ -21,8 +21,8 @@
 
 package com.vaticle.typedb.client.test.behaviour.config;
 
-import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.api.concept.type.AttributeType.ValueType;
+import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
 import com.vaticle.typedb.client.common.Label;
 import io.cucumber.java.DataTableType;
 import io.cucumber.java.ParameterType;

--- a/test/deployment/src/test/java/application/MavenApplicationTest.java
+++ b/test/deployment/src/test/java/application/MavenApplicationTest.java
@@ -22,10 +22,10 @@
 package application;
 
 import com.vaticle.typedb.client.TypeDB;
+import com.vaticle.typedb.client.api.concept.type.ThingType;
 import com.vaticle.typedb.client.api.connection.TypeDBClient;
 import com.vaticle.typedb.client.api.connection.TypeDBSession;
 import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
-import com.vaticle.typedb.client.api.concept.type.ThingType;
 import org.junit.Test;
 
 import java.util.stream.Collectors;

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -59,13 +59,27 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("Duplicates")
+
+class ClientQueryTest2 {
+    @Test
+    public void simple() {
+        TypeDBClient typedbClient = TypeDB.coreClient("127.0.0.1:1729");
+
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+
 public class ClientQueryTest {
     private static final Logger LOG = LoggerFactory.getLogger(ClientQueryTest.class);
     private static TypeDBCoreRunner typedb;
     private static TypeDBClient typedbClient;
 
     @BeforeClass
-    public static void setUpClass() throws InterruptedException, IOException, TimeoutException {
+    public static void setup() throws InterruptedException, IOException, TimeoutException {
         typedb = new TypeDBCoreRunner();
         typedb.start();
         typedbClient = TypeDB.coreClient(typedb.address());
@@ -74,7 +88,7 @@ public class ClientQueryTest {
     }
 
     @AfterClass
-    public static void closeSession() {
+    public static void teardown() {
         typedbClient.close();
         typedb.stop();
     }

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -60,19 +60,6 @@ import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("Duplicates")
 
-class ClientQueryTest2 {
-    @Test
-    public void simple() {
-        TypeDBClient typedbClient = TypeDB.coreClient("127.0.0.1:1729");
-
-        try {
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-}
-
 public class ClientQueryTest {
     private static final Logger LOG = LoggerFactory.getLogger(ClientQueryTest.class);
     private static TypeDBCoreRunner typedb;

--- a/test/integration/ClientQueryTest.java
+++ b/test/integration/ClientQueryTest.java
@@ -22,11 +22,11 @@
 package com.vaticle.typedb.client.test.integration;
 
 import com.vaticle.typedb.client.TypeDB;
+import com.vaticle.typedb.client.api.answer.ConceptMap;
 import com.vaticle.typedb.client.api.connection.TypeDBClient;
 import com.vaticle.typedb.client.api.connection.TypeDBOptions;
 import com.vaticle.typedb.client.api.connection.TypeDBSession;
 import com.vaticle.typedb.client.api.connection.TypeDBTransaction;
-import com.vaticle.typedb.client.api.answer.ConceptMap;
 import com.vaticle.typedb.client.api.logic.Explanation;
 import com.vaticle.typedb.common.test.server.TypeDBCoreRunner;
 import com.vaticle.typeql.lang.TypeQL;


### PR DESCRIPTION
## What is the goal of this PR?

We've moved the pulse mechanism from session to client. Architecturally it makes more sense - the pulse is a mechanism to detect liveness and it's the client that may crash or gets cut off from the network, not any particular individual session instance owned by the client.

## What are the changes implemented in this PR?

- Move the pulse mechanism from session to client
- Replace various superfluous `create` methods with regular constructors