### PR TITLE
Build and deploy for Python 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ commands:
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip39 -- snapshot
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip310 -- snapshot
           bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip311 -- snapshot
+          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //python:deploy-pip312 -- snapshot
 
   test-pip-snapshot-unix:
     steps:
@@ -161,6 +162,7 @@ commands:
           bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip39 --compilation_mode=opt -- release
           bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip310 --compilation_mode=opt -- release
           bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip311 --compilation_mode=opt -- release
+          bazel run --jobs=8 --define version=$(cat VERSION) //python:deploy-pip312 --compilation_mode=opt -- release
 
 
   #########################

--- a/.circleci/windows/python/deploy_release.bat
+++ b/.circleci/windows/python/deploy_release.bat
@@ -37,3 +37,6 @@ IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
 bazel --output_user_root=C:/tmp run --verbose_failures --define version=%VER% //python:deploy-pip311 --compilation_mode=opt -- release
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
+
+bazel --output_user_root=C:/tmp run --verbose_failures --define version=%VER% //python:deploy-pip312 --compilation_mode=opt -- release
+IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/.circleci/windows/python/deploy_snapshot.bat
+++ b/.circleci/windows/python/deploy_snapshot.bat
@@ -38,3 +38,6 @@ IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
 
 bazel --output_user_root=C:/tmp run --verbose_failures --define version=%VER% //python:deploy-pip311 -- snapshot
 IF %errorlevel% NEQ 0 EXIT /b %errorlevel%
+
+bazel --output_user_root=C:/tmp run --verbose_failures --define version=%VER% //python:deploy-pip312 -- snapshot
+IF %errorlevel% NEQ 0 EXIT /b %errorlevel%

--- a/python/python_versions.bzl
+++ b/python/python_versions.bzl
@@ -48,6 +48,13 @@ python_versions = [
         "libpython": "@python311//:libpython",
         "suffix": "311",
     },
+    {
+        "name": "python312",
+        "python_version": "3.12",
+        "python_headers": "@python312//:python_headers",
+        "libpython": "@python312//:libpython",
+        "suffix": "312",
+    },
 ]
 
 def register_all_toolchains():


### PR DESCRIPTION
## Usage and product changes

We enable support for python 3.12 driver build.