### PR TITLE
Rust driver refinements

### DIFF
--- a/rust/BUILD
+++ b/rust/BUILD
@@ -53,7 +53,7 @@ rust_library(
     deps = typedb_driver_deps,
     proc_macro_deps = typedb_driver_proc_macro_deps,
     tags = typedb_driver_tags,
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
 )
 
 rust_library(

--- a/rust/src/connection/server_connection.rs
+++ b/rust/src/connection/server_connection.rs
@@ -329,6 +329,7 @@ impl LatencyTracker {
     pub(crate) fn update_latency(&self, latency_millis: Duration) {
         let previous_latency = self.latency_millis.load(Ordering::Relaxed);
         // TODO: this is a strange but simple averaging scheme
+        //       it might actually be useful as it weights the recent measurement the same as the entire history
         self.latency_millis.store((latency_millis.as_millis() as u64 + previous_latency) / 2, Ordering::Relaxed);
     }
 

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -24,7 +24,6 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use itertools::Itertools;
-
 use log::{debug, error};
 
 use crate::{common::{
@@ -107,7 +106,6 @@ impl Database {
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn delete(self: Arc<Self>) -> Result {
         self.run_on_primary_replica(|database| database.delete()).await
-        // TODO: set flag
     }
 
     /// Returns a full schema text as a valid TypeQL define query string.

--- a/rust/src/driver.rs
+++ b/rust/src/driver.rs
@@ -45,6 +45,12 @@ impl TypeDBDriver {
 }
 
 impl TypeDBDriver {
+    // const VERSION: &'static str = include_str!("../VERSION");
+    const VERSION: &'static str = match option_env!("CARGO_PKG_VERSION"){
+        None => "0.0.0",
+        Some(version) => version
+    };
+
     /// Creates a new TypeDB Server connection.
     ///
     /// # Arguments
@@ -59,8 +65,7 @@ impl TypeDBDriver {
     /// ```
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn new_core(address: impl AsRef<str>) -> Result<Self> {
-        // TODO: pass correct version number automatically
-        Self::new_core_with_description(address, "rust", "3.0.0-alpha-0").await
+        Self::new_core_with_description(address, "rust", TypeDBDriver::VERSION).await
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]

--- a/rust/src/driver.rs
+++ b/rust/src/driver.rs
@@ -45,7 +45,6 @@ impl TypeDBDriver {
 }
 
 impl TypeDBDriver {
-    // const VERSION: &'static str = include_str!("../VERSION");
     const VERSION: &'static str = match option_env!("CARGO_PKG_VERSION"){
         None => "0.0.0",
         Some(version) => version

--- a/rust/src/driver.rs
+++ b/rust/src/driver.rs
@@ -65,11 +65,11 @@ impl TypeDBDriver {
     /// ```
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn new_core(address: impl AsRef<str>) -> Result<Self> {
-        Self::new_core_with_description(address, "rust", TypeDBDriver::VERSION).await
+        Self::new_core_with_description(address, "rust").await
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub async fn new_core_with_description(address: impl AsRef<str>, driver_lang: impl AsRef<str>, driver_version: impl AsRef<str>) -> Result<Self> {
+    pub async fn new_core_with_description(address: impl AsRef<str>, driver_lang: impl AsRef<str>) -> Result<Self> {
         let id = address.as_ref().to_string();
         let address: Address = id.parse()?;
         let background_runtime = Arc::new(BackgroundRuntime::new()?);
@@ -78,7 +78,7 @@ impl TypeDBDriver {
             background_runtime.clone(),
             address.clone(),
             driver_lang.as_ref(),
-            driver_version.as_ref()
+            TypeDBDriver::VERSION
         ).await?;
 
         // // validate


### PR DESCRIPTION
## Usage and product changes
We fix major issues:

1. correctly passing the driver version string into the driver via the build system, instead of hard-coding it into the sources. This use a Cargo environment variable, which will always be available in released versions and is provided from the crate's Cargo.toml. During development, we just set the version to `0.0.0` because we don't particularly care about it!
2. correctly request more answers from the query stream once a BatchContinue flag has been read by the user, as they consume the query answer stream. Previously, we immediately request more answers from the server as soon as we see the StreamContinue signal, in the network layer, which meant the whole stream was actually not lazy at all!