### PR TITLE
Fix native object ownership checks in python driver

### DIFF
--- a/python/typedb/connection/database.py
+++ b/python/typedb/connection/database.py
@@ -69,7 +69,7 @@ class _Database(Database, NativeWrapper[NativeDatabase]):
 
     def delete(self) -> None:
         try:
-            self.native_object.thisown = 0
+            self._native_object.thisown = 0
             database_delete(self._native_object)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e)

--- a/python/typedb/connection/transaction.py
+++ b/python/typedb/connection/transaction.py
@@ -77,7 +77,7 @@ class _Transaction(TypeDBTransaction, NativeWrapper[NativeTransaction]):
         return self._query_manager
 
     def is_open(self) -> bool:
-        if not self.native_object.thisown:
+        if not self._native_object.thisown:
             return False
         return transaction_is_open(self.native_object)
 
@@ -95,7 +95,7 @@ class _Transaction(TypeDBTransaction, NativeWrapper[NativeTransaction]):
 
     def commit(self):
         try:
-            self.native_object.thisown = 0
+            self._native_object.thisown = 0
             void_promise_resolve(transaction_commit(self._native_object))
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e)


### PR DESCRIPTION
## Usage and product changes
Fixes native object ownership checks in python driver

## Implementation
Replaces usages of `self.native_object.is_own` (which invokes  a `@property` getter, throwing an exception) with `self._native_object.is_own`
