### PR TITLE
Fix CircleCI jobs for Maven installation and python builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,9 @@ commands:
         type: string
     steps:
       - run: |
-          amazon-linux-extras install python3.9 java-openjdk11 -y
+          amazon-linux-extras install python3.8 java-openjdk11 -y
           yum install -y git tar gcc gcc-c++ file lsof which procps
-          ln -s /usr/bin/python3.9 /usr/bin/python3
+          ln -s /usr/bin/python3.8 /usr/bin/python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
@@ -90,7 +90,7 @@ commands:
         type: string
     steps:
       - run: |
-          brew install python@3.9
+          brew install python@3.8
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-<<parameters.bazel-arch>>"
           sudo mv "bazelisk-darwin-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
@@ -819,32 +819,32 @@ workflows:
       - deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [development, master, "3.0"]
+              only: [development, master, "3.0-circleci-python-fix"]
 
       - deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [development, master, "3.0"]
+              only: [development, master, "3.0-circleci-python-fix"]
 
       - deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [development, master, "3.0"]
+              only: [development, master, "3.0-circleci-python-fix"]
 
       - deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [development, master, "3.0"]
+              only: [development, master, "3.0-circleci-python-fix"]
 
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [development, master, "3.0"]
+              only: [development, master, "3.0-circleci-python-fix"]
 
       - deploy-snapshot-any:
           filters:
             branches:
-              only: [development, master, "3.0"]
+              only: [development, master, "3.0-circleci-python-fix"]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64
@@ -866,7 +866,7 @@ workflows:
       - test-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master, "3.0"]
+              only: [master, "3.0-circleci-python-fix"]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-any
@@ -875,7 +875,7 @@ workflows:
       - test-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master, "3.0"]
+              only: [master, "3.0-circleci-python-fix"]
           requires:
             - deploy-snapshot-linux-x86_64
             - deploy-snapshot-any
@@ -884,7 +884,7 @@ workflows:
       - test-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master, "3.0"]
+              only: [master, "3.0-circleci-python-fix"]
           requires:
             - deploy-snapshot-mac-arm64
             - deploy-snapshot-any
@@ -893,7 +893,7 @@ workflows:
       - test-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, "3.0"]
+              only: [master, "3.0-circleci-python-fix"]
           requires:
             - deploy-snapshot-mac-x86_64
             - deploy-snapshot-any
@@ -903,7 +903,7 @@ workflows:
 #      - test-snapshot-windows-x86_64:
 #          filters:
 #            branches:
-#              only: [master, "3.0"]
+#              only: [master, "3.0-circleci-python-fix"]
 #          requires:
 #            - deploy-snapshot-windows-x86_64
 #            - deploy-snapshot-any
@@ -913,7 +913,7 @@ workflows:
 #      - test-snapshot-any:
 #          filters:
 #            branches:
-#              only: [master, "3.0"]
+#              only: [master, "3.0-circleci-python-fix"]
 #          requires:
 #            - deploy-snapshot-any
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ commands:
           cd Python-3.9.6
           ./configure --enable-optimizations --enable-shared
           make altinstall
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
           ln -s /usr/local/bin/python3.9 /usr/bin/python3
           
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
@@ -134,7 +135,6 @@ commands:
       - install-pip-requirements
       - run: |
           tool/test/start-core-server.sh
-          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
           python3.9 -m pip install wheel 
           python3.9 -m pip install --extra-index-url https://repo.typedb.com/public/public-snapshot/python/simple typedb-driver==0.0.0+$(git rev-parse HEAD)
           sleep 5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,14 @@ commands:
           amazon-linux-extras install java-openjdk11 -y
           yum install wget make gcc gcc-c++ openssl-devel bzip2-devel libffi-devel zlib-devel file lsof which procps tar git -y
           
-          # python3.9:
           cd /tmp
           wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
           tar -xvf Python-3.9.6.tgz
           cd Python-3.9.6
           ./configure --enable-optimizations --enable-shared
           make altinstall
-          sudo echo "/usr/local/lib" >> /etc/ld.so.conf.d/python3.9.conf
-          sudo ldconfig
+          echo "/usr/local/lib" >> /etc/ld.so.conf.d/python3.9.conf
+          ldconfig
           ln -s /usr/local/bin/python3.9 /usr/bin/python3
           
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,9 @@ commands:
     steps:
       - run: |
           amazon-linux-extras install java-openjdk11 -y
+          yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel gcc-c++ file lsof which procps tar git -y
           
           # python3.9:
-          yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel
           cd /tmp
           wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
           tar -xvf Python-3.9.6.tgz
@@ -75,7 +75,6 @@ commands:
           ./configure --enable-optimizations
           sudo make altinstall
           
-          yum install -y git tar gcc gcc-c++ file lsof which procps
           ln -s /usr/bin/python3.9 /usr/bin/python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,19 @@ commands:
         type: string
     steps:
       - run: |
-          amazon-linux-extras install python3.8 java-openjdk11 -y
+          amazon-linux-extras install java-openjdk11 -y
+          
+          # python3.9:
+          yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel
+          cd /tmp
+          wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
+          tar -xvf Python-3.9.6.tgz
+          cd Python-3.9.6
+          ./configure --enable-optimizations
+          sudo make altinstall
+          
           yum install -y git tar gcc gcc-c++ file lsof which procps
-          ln -s /usr/bin/python3.8 /usr/bin/python3
+          ln -s /usr/bin/python3.9 /usr/bin/python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
@@ -90,7 +100,7 @@ commands:
         type: string
     steps:
       - run: |
-          brew install python@3.8
+          brew install python@3.9
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-<<parameters.bazel-arch>>"
           sudo mv "bazelisk-darwin-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ commands:
           make altinstall
           
           #ln -s /usr/bin/python3.9 /usr/bin/python3
-          which findme
           which python3.9
           which python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -829,32 +829,32 @@ workflows:
       - deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [development, master, "3.0-circleci-python-fix"]
+              only: [development, master, "3.0"]
 
       - deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [development, master, "3.0-circleci-python-fix"]
+              only: [development, master, "3.0"]
 
       - deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [development, master, "3.0-circleci-python-fix"]
+              only: [development, master, "3.0"]
 
       - deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [development, master, "3.0-circleci-python-fix"]
+              only: [development, master, "3.0"]
 
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [development, master, "3.0-circleci-python-fix"]
+              only: [development, master, "3.0"]
 
       - deploy-snapshot-any:
           filters:
             branches:
-              only: [development, master, "3.0-circleci-python-fix"]
+              only: [development, master, "3.0"]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64
@@ -876,7 +876,7 @@ workflows:
       - test-snapshot-linux-arm64:
           filters:
             branches:
-              only: [master, "3.0-circleci-python-fix"]
+              only: [master, "3.0"]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-any
@@ -885,7 +885,7 @@ workflows:
       - test-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [master, "3.0-circleci-python-fix"]
+              only: [master, "3.0"]
           requires:
             - deploy-snapshot-linux-x86_64
             - deploy-snapshot-any
@@ -894,7 +894,7 @@ workflows:
       - test-snapshot-mac-arm64:
           filters:
             branches:
-              only: [master, "3.0-circleci-python-fix"]
+              only: [master, "3.0"]
           requires:
             - deploy-snapshot-mac-arm64
             - deploy-snapshot-any
@@ -903,7 +903,7 @@ workflows:
       - test-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [master, "3.0-circleci-python-fix"]
+              only: [master, "3.0"]
           requires:
             - deploy-snapshot-mac-x86_64
             - deploy-snapshot-any
@@ -913,7 +913,7 @@ workflows:
 #      - test-snapshot-windows-x86_64:
 #          filters:
 #            branches:
-#              only: [master, "3.0-circleci-python-fix"]
+#              only: [master, "3.0"]
 #          requires:
 #            - deploy-snapshot-windows-x86_64
 #            - deploy-snapshot-any
@@ -923,7 +923,7 @@ workflows:
 #      - test-snapshot-any:
 #          filters:
 #            branches:
-#              only: [master, "3.0-circleci-python-fix"]
+#              only: [master, "3.0"]
 #          requires:
 #            - deploy-snapshot-any
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
     steps:
       - run: |
           amazon-linux-extras install java-openjdk11 -y
-          yum install wget gcc openssl-devel bzip2-devel libffi-devel zlib-devel gcc-c++ file lsof which procps tar git -y
+          yum install wget make gcc gcc-c++ openssl-devel bzip2-devel libffi-devel zlib-devel file lsof which procps tar git -y
           
           # python3.9:
           cd /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ commands:
           tar -xvf Python-3.9.6.tgz
           cd Python-3.9.6
           ./configure --enable-optimizations
-          sudo make altinstall
+          make altinstall
           
           ln -s /usr/bin/python3.9 /usr/bin/python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,10 @@ commands:
           ./configure --enable-optimizations
           make altinstall
           
-          ln -s /usr/bin/python3.9 /usr/bin/python3
+          #ln -s /usr/bin/python3.9 /usr/bin/python3
+          which findme
+          which python3.9
+          which python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
@@ -115,8 +118,8 @@ commands:
   install-pip-requirements:
     steps:
       - run: |
-          python3 -m pip install pip==21.3.1
-          python3 -m pip install -r python/requirements_dev.txt
+          python3.9 -m pip install pip==21.3.1
+          python3.9 -m pip install -r python/requirements_dev.txt
 
   deploy-pip-snapshot-unix:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,7 @@ commands:
           ./configure --enable-optimizations
           make altinstall
           
-          #ln -s /usr/bin/python3.9 /usr/bin/python3
-          which python3.9
-          which python3
+          ln -s /usr/local/bin/python3.9 /usr/bin/python3
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
@@ -117,8 +115,8 @@ commands:
   install-pip-requirements:
     steps:
       - run: |
-          python3.9 -m pip install pip==21.3.1
-          python3.9 -m pip install -r python/requirements_dev.txt
+          python3 -m pip install pip==21.3.1
+          python3 -m pip install -r python/requirements_dev.txt
 
   deploy-pip-snapshot-unix:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
     steps:
       - run: |
           amazon-linux-extras install java-openjdk11 -y
-          yum install gcc openssl-devel bzip2-devel libffi-devel zlib-devel gcc-c++ file lsof which procps tar git -y
+          yum install wget gcc openssl-devel bzip2-devel libffi-devel zlib-devel gcc-c++ file lsof which procps tar git -y
           
           # python3.9:
           cd /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,8 @@ commands:
           cd Python-3.9.6
           ./configure --enable-optimizations --enable-shared
           make altinstall
-          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+          sudo echo "/usr/local/lib" >> /etc/ld.so.conf.d/python3.9.conf
+          sudo ldconfig
           ln -s /usr/local/bin/python3.9 /usr/bin/python3
           
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ executors:
 
   mac-arm64:
     macos:
-      xcode: "13.4.1"
+      xcode: "14.3.1"
     resource_class: macos.m1.medium.gen1
     working_directory: ~/typedb-driver
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,10 @@ commands:
           wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz
           tar -xvf Python-3.9.6.tgz
           cd Python-3.9.6
-          ./configure --enable-optimizations
+          ./configure --enable-optimizations --enable-shared
           make altinstall
-          
           ln -s /usr/local/bin/python3.9 /usr/bin/python3
+          
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-linux-<<parameters.bazel-arch>>"
           mv "bazelisk-linux-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel
@@ -134,6 +134,7 @@ commands:
       - install-pip-requirements
       - run: |
           tool/test/start-core-server.sh
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
           python3.9 -m pip install wheel 
           python3.9 -m pip install --extra-index-url https://repo.typedb.com/public/public-snapshot/python/simple typedb-driver==0.0.0+$(git rev-parse HEAD)
           sleep 5

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -22,42 +22,42 @@ config:
     typedb-behaviour: [build]
     typedb-protocol: [build, release]
 
-build:
-  quality:
-    filter:
-      owner: typedb
-      branch: [master, development]
-    dependency-analysis:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
-
-  correctness:
-    build:
-      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-      machine: 16-core-64-gb
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        sudo apt-get update
-        sudo apt install python3-pip -y
-        python3 -m pip install -U pip
-        python3 -m pip install -r python/requirements_dev.txt
-        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        # TODO: Temporarily build only the 3.0-reimplemented drivers:
-        # bazel build //...
-        bazel build //rust/...
-        bazel build //java/...
-        bazel build //python/...
-        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
-        bazel test $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//rust:rustfmt_config
-        # TODO: Return these three steps when npm is reimplemented for 3.0
-        # cd nodejs
-        # npm install
-        # npm run lint
+#build:
+#  quality:
+#    filter:
+#      owner: typedb
+#      branch: [master, development]
+#    dependency-analysis:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
+#
+#  correctness:
+#    build:
+#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+#      machine: 16-core-64-gb
+#      command: |
+#        #export PATH="$HOME/.local/bin:$PATH"
+#        #sudo apt-get update
+#        #sudo apt install python3-pip -y
+#        #python3 -m pip install -U pip
+#        #python3 -m pip install -r python/requirements_dev.txt
+#        #export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+#        #export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+#        #bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        #bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        # TODO: Temporarily build only the 3.0-reimplemented drivers:
+#        # bazel build //...
+#        # bazel build //rust/...
+#        # bazel build //java/...
+#        # bazel build //python/...
+#        # bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
+#        # bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+#        # bazel test $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//rust:rustfmt_config
+#        # TODO: Return these three steps when npm is reimplemented for 3.0
+#        # cd nodejs
+#        # npm install
+#        # npm run lint
 
 #    build-dependency:
 #      image: vaticle-ubuntu-22.04
@@ -189,20 +189,20 @@ build:
 #        tool/test/stop-core-server.sh
 #        exit $TEST_SUCCESS
 
-    test-java-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      command: |
-        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //java/test/integration/... --test_output=errors &&
-          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-        tool/test/stop-core-server.sh
-        exit $TEST_SUCCESS
+#    test-java-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      command: |
+#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //java/test/integration/... --test_output=errors &&
+#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+#        tool/test/stop-core-server.sh
+#        exit $TEST_SUCCESS
 
 #    test-java-behaviour-core:
 #      image: vaticle-ubuntu-22.04
@@ -234,23 +234,23 @@ build:
 #        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
 #        .factory/test-cloud.sh //java/test/behaviour/query/language/... --test_output=errors --jobs=1
 
-    test-python-integration:
-      image: vaticle-ubuntu-22.04
-      dependencies:
-        - build
-      type: foreground
-      command: |
-        export PATH="$HOME/.local/bin:$PATH"
-        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-
-        tool/test/start-core-server.sh &&
-          .factory/test-core.sh //python/tests/integration/... --test_output=errors --jobs=1 &&
-          export CORE_FAILED= || export CORE_FAILED=1
-        tool/test/stop-core-server.sh
-        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
+#    test-python-integration:
+#      image: vaticle-ubuntu-22.04
+#      dependencies:
+#        - build
+#      type: foreground
+#      command: |
+#        export PATH="$HOME/.local/bin:$PATH"
+#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+#
+#        tool/test/start-core-server.sh &&
+#          .factory/test-core.sh //python/tests/integration/... --test_output=errors --jobs=1 &&
+#          export CORE_FAILED= || export CORE_FAILED=1
+#        tool/test/stop-core-server.sh
+#        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
 #        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
 #          bazel test //python/tests/integration:test_cloud_connection --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
@@ -550,26 +550,26 @@ build:
 #        bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 
 # TODO #512: assembly tests for all drivers to run in factory
-
-release:
-  filter:
-    owner: typedb
-    branch: [master, "3.0"]
-  validation:
-    validate-dependencies:
-      image: vaticle-ubuntu-22.04
-      command: |
-        bazel test //:release-validate-deps --test_output=streamed
-    validate-release-notes:
-      image: vaticle-ubuntu-22.04
-      command: |
-        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run @vaticle_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
-
-  deployment:
-    trigger-release-circleci:
-      image: vaticle-ubuntu-22.04
-      command: |
-        git checkout -b release
-        git push -f origin release
-        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."
+#
+#release:
+#  filter:
+#    owner: typedb
+#    branch: [master, "3.0"]
+#  validation:
+#    validate-dependencies:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        bazel test //:release-validate-deps --test_output=streamed
+#    validate-release-notes:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
+#        bazel run @vaticle_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
+#
+#  deployment:
+#    trigger-release-circleci:
+#      image: vaticle-ubuntu-22.04
+#      command: |
+#        git checkout -b release
+#        git push -f origin release
+#        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -22,42 +22,42 @@ config:
     typedb-behaviour: [build]
     typedb-protocol: [build, release]
 
-#build:
-#  quality:
-#    filter:
-#      owner: typedb
-#      branch: [master, development]
-#    dependency-analysis:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
-#
-#  correctness:
-#    build:
-#      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      machine: 16-core-64-gb
-#      command: |
-#        #export PATH="$HOME/.local/bin:$PATH"
-#        #sudo apt-get update
-#        #sudo apt install python3-pip -y
-#        #python3 -m pip install -U pip
-#        #python3 -m pip install -r python/requirements_dev.txt
-#        #export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        #export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        #bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        #bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        # TODO: Temporarily build only the 3.0-reimplemented drivers:
-#        # bazel build //...
-#        # bazel build //rust/...
-#        # bazel build //java/...
-#        # bazel build //python/...
-#        # bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-#        # bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
-#        # bazel test $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//rust:rustfmt_config
-#        # TODO: Return these three steps when npm is reimplemented for 3.0
-#        # cd nodejs
-#        # npm install
-#        # npm run lint
+build:
+  quality:
+    filter:
+      owner: typedb
+      branch: [master, development]
+    dependency-analysis:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel run @vaticle_dependencies//factory/analysis:dependency-analysis
+
+  correctness:
+    build:
+      image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      machine: 16-core-64-gb
+      command: |
+        #export PATH="$HOME/.local/bin:$PATH"
+        #sudo apt-get update
+        #sudo apt install python3-pip -y
+        #python3 -m pip install -U pip
+        #python3 -m pip install -r python/requirements_dev.txt
+        #export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        #export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        #bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        #bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        # TODO: Temporarily build only the 3.0-reimplemented drivers:
+        # bazel build //...
+        # bazel build //rust/...
+        # bazel build //java/...
+        # bazel build //python/...
+        # bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
+        # bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+        # bazel test $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//rust:rustfmt_config
+        # TODO: Return these three steps when npm is reimplemented for 3.0
+        # cd nodejs
+        # npm install
+        # npm run lint
 
 #    build-dependency:
 #      image: vaticle-ubuntu-22.04
@@ -189,20 +189,20 @@ config:
 #        tool/test/stop-core-server.sh
 #        exit $TEST_SUCCESS
 
-#    test-java-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //java/test/integration/... --test_output=errors &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-core-server.sh
-#        exit $TEST_SUCCESS
+    test-java-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //java/test/integration/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
 
 #    test-java-behaviour-core:
 #      image: vaticle-ubuntu-22.04
@@ -234,23 +234,23 @@ config:
 #        .factory/test-cloud.sh //java/test/behaviour/driver/query/... --test_output=errors
 #        .factory/test-cloud.sh //java/test/behaviour/query/language/... --test_output=errors --jobs=1
 
-#    test-python-integration:
-#      image: vaticle-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
-#
-#        tool/test/start-core-server.sh &&
-#          .factory/test-core.sh //python/tests/integration/... --test_output=errors --jobs=1 &&
-#          export CORE_FAILED= || export CORE_FAILED=1
-#        tool/test/stop-core-server.sh
-#        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
+    test-python-integration:
+      image: vaticle-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+
+        tool/test/start-core-server.sh &&
+          .factory/test-core.sh //python/tests/integration/... --test_output=errors --jobs=1 &&
+          export CORE_FAILED= || export CORE_FAILED=1
+        tool/test/stop-core-server.sh
+        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
 #        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
 #          bazel test //python/tests/integration:test_cloud_connection --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
@@ -550,26 +550,26 @@ config:
 #        bazel run @vaticle_dependencies//tool/sync:dependencies -- --source ${FACTORY_REPO}@${FACTORY_COMMIT}
 
 # TODO #512: assembly tests for all drivers to run in factory
-#
-#release:
-#  filter:
-#    owner: typedb
-#    branch: [master, "3.0"]
-#  validation:
-#    validate-dependencies:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        bazel test //:release-validate-deps --test_output=streamed
-#    validate-release-notes:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
-#        bazel run @vaticle_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
-#
-#  deployment:
-#    trigger-release-circleci:
-#      image: vaticle-ubuntu-22.04
-#      command: |
-#        git checkout -b release
-#        git push -f origin release
-#        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."
+
+release:
+  filter:
+    owner: typedb
+    branch: [master, "3.0"]
+  validation:
+    validate-dependencies:
+      image: vaticle-ubuntu-22.04
+      command: |
+        bazel test //:release-validate-deps --test_output=streamed
+    validate-release-notes:
+      image: vaticle-ubuntu-22.04
+      command: |
+        export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
+        bazel run @vaticle_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
+
+  deployment:
+    trigger-release-circleci:
+      image: vaticle-ubuntu-22.04
+      command: |
+        git checkout -b release
+        git push -f origin release
+        echo "Successfully pushed branch 'release', which triggers a release workflow in CircleCI. The progress of the release can be tracked there."

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -37,23 +37,23 @@ build:
       image: vaticle-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
       machine: 16-core-64-gb
       command: |
-        #export PATH="$HOME/.local/bin:$PATH"
-        #sudo apt-get update
-        #sudo apt install python3-pip -y
-        #python3 -m pip install -U pip
-        #python3 -m pip install -r python/requirements_dev.txt
-        #export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-        #export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-        #bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        #bazel run @vaticle_dependencies//distribution/artifact:create-netrc
+        export PATH="$HOME/.local/bin:$PATH"
+        sudo apt-get update
+        sudo apt install python3-pip -y
+        python3 -m pip install -U pip
+        python3 -m pip install -r python/requirements_dev.txt
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run @vaticle_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @vaticle_dependencies//distribution/artifact:create-netrc
         # TODO: Temporarily build only the 3.0-reimplemented drivers:
         # bazel build //...
-        # bazel build //rust/...
-        # bazel build //java/...
-        # bazel build //python/...
-        # bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
-        # bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
-        # bazel test $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//rust:rustfmt_config
+        bazel build //rust/...
+        bazel build //java/...
+        bazel build //python/...
+        bazel run @vaticle_dependencies//tool/checkstyle:test-coverage
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+        bazel test $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//rust:rustfmt_config
         # TODO: Return these three steps when npm is reimplemented for 3.0
         # cd nodejs
         # npm install


### PR DESCRIPTION
## Usage and product changes
We fix two CircleCI issues:
* `brew install maven` [has been failing](https://app.circleci.com/pipelines/github/typedb/typedb-driver/911/workflows/9571978a-e2c7-40cc-afd6-372356f267f7/jobs/7072) for Rosetta configuration;
* python installation for Linux machines required a different process after we updated from `python3.8` to `python3.9` as a minimal version.

## Implementation
* for the first issue, we update `xcode` version to match the first suitable macOS 13 version from [this table](https://circleci.com/docs/using-macos/#supported-xcode-versions), which is [required by brew](https://docs.brew.sh/Installation);
* to install python3.9 on an amazonlinux machine, we build it with `make` as it's absent through `amazon-linux-extras` or `yum`.