### PR TITLE
Native library names now include platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -821,32 +821,32 @@ workflows:
       - deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [development, master]
+              only: [development, master, native-library-names-include-platform]
 
       - deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [development, master]
+              only: [development, master, native-library-names-include-platform]
 
       - deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [development, master]
+              only: [development, master, native-library-names-include-platform]
 
       - deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [development, master]
+              only: [development, master, native-library-names-include-platform]
 
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [development, master]
+              only: [development, master, native-library-names-include-platform]
 
       - deploy-snapshot-any:
           filters:
             branches:
-              only: [development, master]
+              only: [development, master, native-library-names-include-platform]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64
@@ -857,7 +857,7 @@ workflows:
       - deploy-snapshot-dotnet-any:
           filters:
             branches:
-              only: [development, master]
+              only: [development, master, native-library-names-include-platform]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -821,32 +821,32 @@ workflows:
       - deploy-snapshot-linux-arm64:
           filters:
             branches:
-              only: [development, master, native-library-names-include-platform]
+              only: [development, master]
 
       - deploy-snapshot-linux-x86_64:
           filters:
             branches:
-              only: [development, master, native-library-names-include-platform]
+              only: [development, master]
 
       - deploy-snapshot-mac-arm64:
           filters:
             branches:
-              only: [development, master, native-library-names-include-platform]
+              only: [development, master]
 
       - deploy-snapshot-mac-x86_64:
           filters:
             branches:
-              only: [development, master, native-library-names-include-platform]
+              only: [development, master]
 
       - deploy-snapshot-windows-x86_64:
           filters:
             branches:
-              only: [development, master, native-library-names-include-platform]
+              only: [development, master]
 
       - deploy-snapshot-any:
           filters:
             branches:
-              only: [development, master, native-library-names-include-platform]
+              only: [development, master]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64
@@ -857,7 +857,7 @@ workflows:
       - deploy-snapshot-dotnet-any:
           filters:
             branches:
-              only: [development, master, native-library-names-include-platform]
+              only: [development, master]
           requires:
             - deploy-snapshot-linux-arm64
             - deploy-snapshot-linux-x86_64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ commands:
         type: string
     steps:
       - run: |
-          brew install python@3.8
+          brew install python@3.9
           curl -OL "https://github.com/bazelbuild/bazelisk/releases/download/v1.17.0/bazelisk-darwin-<<parameters.bazel-arch>>"
           sudo mv "bazelisk-darwin-<<parameters.bazel-arch>>" /usr/local/bin/bazel
           chmod a+x /usr/local/bin/bazel

--- a/java/BUILD
+++ b/java/BUILD
@@ -72,6 +72,7 @@ deploy_maven(
 
 swig_native_java_library(
     name = "typedb_driver_jni",
+    library_name_with_platform = "typedb_driver_jni-{platform}",
     lib = "//c:typedb_driver_clib_headers",
     package = "com.vaticle.typedb.driver.jni",
     interface = "//c:typedb_driver.i",

--- a/java/common/Loader.java
+++ b/java/common/Loader.java
@@ -38,16 +38,15 @@ import static com.vaticle.typedb.driver.common.exception.ErrorMessage.Driver.UNR
 public class Loader {
 
     private static final String DRIVER_JNI_LIB_RESOURCE = "typedb_driver_jni";
+    private static final Map<Pair<OS, Arch>, String> DRIVER_JNI_JAR_NAME = Map.of(new Pair<>(OS.WINDOWS, Arch.x86_64), "windows-x86_64",
+            new Pair<>(OS.MAC, Arch.x86_64), "macosx-x86_64", new Pair<>(OS.MAC, Arch.ARM64), "macosx-arm64", new Pair<>(OS.LINUX, Arch.x86_64),
+            "linux-x86_64", new Pair<>(OS.LINUX, Arch.ARM64), "linux-arm64");
     private static final String DRIVER_JNI_LIBRARY_NAME = Loader.mapLibraryName();
 
     private static String mapLibraryName() {
         String fullName = DRIVER_JNI_LIB_RESOURCE + "-" + DRIVER_JNI_JAR_NAME.get(new Pair<>(OS.detect(), Arch.detect()));
-        return System.mapLibraryName(fullName );
+        return System.mapLibraryName(fullName);
     }
-
-    private static final Map<Pair<OS, Arch>, String> DRIVER_JNI_JAR_NAME = Map.of(new Pair<>(OS.WINDOWS, Arch.x86_64), "windows-x86_64",
-            new Pair<>(OS.MAC, Arch.x86_64), "macosx-x86_64", new Pair<>(OS.MAC, Arch.ARM64), "macosx-arm64", new Pair<>(OS.LINUX, Arch.x86_64),
-            "linux-x86_64", new Pair<>(OS.LINUX, Arch.ARM64), "linux-arm64");
 
     private static boolean loaded = false;
 

--- a/java/common/Loader.java
+++ b/java/common/Loader.java
@@ -38,7 +38,12 @@ import static com.vaticle.typedb.driver.common.exception.ErrorMessage.Driver.UNR
 public class Loader {
 
     private static final String DRIVER_JNI_LIB_RESOURCE = "typedb_driver_jni";
-    private static final String DRIVER_JNI_LIBRARY_NAME = System.mapLibraryName(DRIVER_JNI_LIB_RESOURCE);
+    private static final String DRIVER_JNI_LIBRARY_NAME = Loader.mapLibraryName();
+
+    private static String mapLibraryName() {
+        String fullName = DRIVER_JNI_LIB_RESOURCE + "-" + DRIVER_JNI_JAR_NAME.get(new Pair<>(OS.detect(), Arch.detect()));
+        return System.mapLibraryName(fullName );
+    }
 
     private static final Map<Pair<OS, Arch>, String> DRIVER_JNI_JAR_NAME = Map.of(new Pair<>(OS.WINDOWS, Arch.x86_64), "windows-x86_64",
             new Pair<>(OS.MAC, Arch.x86_64), "macosx-x86_64", new Pair<>(OS.MAC, Arch.ARM64), "macosx-arm64", new Pair<>(OS.LINUX, Arch.x86_64),

--- a/java/rules.bzl
+++ b/java/rules.bzl
@@ -17,27 +17,28 @@
 
 load("@vaticle_dependencies//builder/swig:java.bzl", "swig_java")
 
-def swig_native_java_library(name, platforms, maven_coordinates, tags=[], **kwargs):
-    swig_java(
-        name = "__" + name,
-        shared_lib_name = name,
-        tags = tags,
-        **kwargs,
-    )
-
+def swig_native_java_library(name, library_name_with_platform, platforms, maven_coordinates, tags=[], **kwargs):
     # generate identical libraries with different maven coordinate tags, since we can't 'select' tags
     for platform in platforms.values():
+        platform_specific_name = library_name_with_platform.replace("{platform}", platform)
+        swig_java(
+            name = "__" + platform_specific_name,
+            shared_lib_name = platform_specific_name,
+            tags = tags,
+            **kwargs,
+        )
+
         native.java_library(
-            name = name + "__native-as__" + platform + "__do_not_reference",
-            srcs = ["__" + name + "__swig"],
-            resources = ["lib" + name],
+            name = platform_specific_name + "__native-as__do_not_reference",
+            srcs = ["__" + platform_specific_name + "__swig"],
+            resources = ["lib" + platform_specific_name],
             tags = tags + ["maven_coordinates=" + maven_coordinates.replace("{platform}", platform)],
         )
 
     native.alias(
         name = name,
         actual = select({
-            config: name + "__native-as__" + platform + "__do_not_reference"
+            config: library_name_with_platform.replace("{platform}", platform) + "__native-as__do_not_reference"
             for config, platform in platforms.items()
         })
     )


### PR DESCRIPTION
## Usage and product changes
Native library names now include platform. This avoids the case where flattening a java project causes libraries for from one architecture for a given os clobbers the other.

## Implementation
Update library names to `[lib]typedb_driver_jni-{platform}.<ext>` e.g. `libtypedb_driver_jni-linux-x86_64.so`

