### PR TITLE
Support CPython 3.13

### DIFF
--- a/python/python_versions.bzl
+++ b/python/python_versions.bzl
@@ -48,6 +48,13 @@ python_versions = [
         "libpython": "@python312//:libpython",
         "suffix": "312",
     },
+    {
+        "name": "python313",
+        "python_version": "3.13",
+        "python_headers": "@python313//:python_headers",
+        "libpython": "@python313//:libpython",
+        "suffix": "313",
+    },
 ]
 
 def register_all_toolchains():


### PR DESCRIPTION
## Usage and product changes

Support [CPython 3.13](https://docs.python.org/3/whatsnew/3.13.html), which has been released on 7 October.

## Implementation

- Change the Bazel file.
- ...?