### PR TITLE
Unify transaction cleanup in driver BDDs when opening new transactions

### DIFF
--- a/dependencies/vaticle/artifacts.bzl
+++ b/dependencies/vaticle/artifacts.bzl
@@ -25,7 +25,7 @@ def vaticle_typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "2c110dc1dce03270842b3a92f859f0b4a7a18cb4"
+        tag = "3.0.0-alpha-8"
     )
 
 #def vaticle_typedb_cloud_artifact():

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -36,5 +36,5 @@ def vaticle_typedb_behaviour():
     git_repository(
         name = "vaticle_typedb_behaviour",
         remote = "https://github.com/farost/typedb-behaviour",
-        commit = "ed0471c8a22698e161e087866a80807c15383111",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        commit = "1af26664cffe316b40636c897733704543447f3b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,9 +32,8 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
-    # TODO: Return typedb after merge
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/farost/typedb-behaviour",
-        commit = "1af26664cffe316b40636c897733704543447f3b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "0f24dc7a841de46697297a1eac9993df8eca3acd",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/dependencies/vaticle/repositories.bzl
+++ b/dependencies/vaticle/repositories.bzl
@@ -32,8 +32,9 @@ def vaticle_typedb_protocol():
     )
 
 def vaticle_typedb_behaviour():
+    # TODO: Return typedb after merge
     git_repository(
         name = "vaticle_typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "4ec10ad5a5f9a7fd19b327240a33bcb77e502f57",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
+        remote = "https://github.com/farost/typedb-behaviour",
+        commit = "ed0471c8a22698e161e087866a80807c15383111",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @vaticle_typedb_behaviour
     )

--- a/java/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/java/test/behaviour/connection/transaction/TransactionSteps.java
@@ -55,6 +55,7 @@ public class TransactionSteps {
 
     @When("connection open {transaction_type} transaction for database: {non_semicolon}{may_error}")
     public void connection_open_transaction_for_database(Transaction.Type type, String databaseName, Parameters.MayError mayError) {
+        transactions.clear();
         mayError.check(() -> {
             Transaction transaction = driver.transaction(databaseName, type);
             transactions.add(transaction);

--- a/rust/tests/behaviour/steps/connection/transaction.rs
+++ b/rust/tests/behaviour/steps/connection/transaction.rs
@@ -42,6 +42,7 @@ pub async fn connection_open_transaction_for_database(
     database_name: String,
     may_error: params::MayError,
 ) {
+    context.cleanup_transactions().await;
     may_error.check(context.push_transaction(
         open_transaction_for_database(&context.driver, &database_name, type_.transaction_type).await,
     ));


### PR DESCRIPTION
# Usage and product changes
We add unconditional transactions cleanup when opening new transactions in driver BDDs to allow writing BDD descriptions in a [direct usage fashion](https://github.com/typedb/typedb-behaviour/pull/310).