### PR TITLE
Remove promises resolves in destructors to eliminate redundant exceptions. Cleanup Python exceptions formatting

### DIFF
--- a/c/src/answer.rs
+++ b/c/src/answer.rs
@@ -51,6 +51,12 @@ pub extern "C" fn query_answer_promise_resolve(promise: *mut QueryAnswerPromise)
     try_release(take_ownership(promise).0.resolve())
 }
 
+/// Frees the native rust <code>QueryAnswerPromise</code> object.
+#[no_mangle]
+pub extern "C" fn query_answer_promise_drop(promise: *mut QueryAnswerPromise) {
+    drop(take_ownership(promise))
+}
+
 /// Retrieve the executed query's type of the <code>QueryAnswer</code>.
 #[no_mangle]
 pub extern "C" fn query_answer_get_query_type(query_answer: *const QueryAnswer) -> QueryType {

--- a/c/src/concept/mod.rs
+++ b/c/src/concept/mod.rs
@@ -45,6 +45,12 @@ pub extern "C" fn concept_promise_resolve(promise: *mut ConceptPromise) -> *mut 
     try_release_optional(take_ownership(promise).0.resolve().transpose())
 }
 
+/// Frees the native rust <code>ConceptPromise</code> object.
+#[no_mangle]
+pub extern "C" fn concept_promise_drop(promise: *mut ConceptPromise) {
+    drop(take_ownership(promise))
+}
+
 /// Iterator over the <code>ConceptRow</code>s returned by an API method or query.
 pub struct ConceptRowIterator(pub CIterator<Result<ConceptRow>>);
 

--- a/c/src/promise.rs
+++ b/c/src/promise.rs
@@ -39,6 +39,12 @@ pub extern "C" fn void_promise_resolve(promise: *mut VoidPromise) {
     unwrap_void(take_ownership(promise).0.resolve());
 }
 
+/// Frees the native rust <code>VoidPromise</code> object.
+#[no_mangle]
+pub extern "C" fn void_promise_drop(promise: *mut VoidPromise) {
+    drop(take_ownership(promise))
+}
+
 /// Promise object representing the result of an asynchronous operation.
 /// Use \ref bool_promise_resolve(BoolPromise*) to wait for and retrieve the resulting boolean value.
 pub struct BoolPromise(pub BoxPromise<'static, Result<bool>>);
@@ -51,6 +57,12 @@ pub extern "C" fn bool_promise_resolve(promise: *mut BoolPromise) -> bool {
     unwrap_or_default(take_ownership(promise).0.resolve())
 }
 
+/// Frees the native rust <code>BoolPromise</code> object.
+#[no_mangle]
+pub extern "C" fn bool_promise_drop(promise: *mut BoolPromise) {
+    drop(take_ownership(promise))
+}
+
 /// Promise object representing the result of an asynchronous operation.
 /// Use \ref string_promise_resolve(StringPromise*) to wait for and retrieve the resulting string.
 pub struct StringPromise(pub BoxPromise<'static, Result<Option<String>>>);
@@ -61,4 +73,10 @@ pub struct StringPromise(pub BoxPromise<'static, Result<Option<String>>>);
 #[no_mangle]
 pub extern "C" fn string_promise_resolve(promise: *mut StringPromise) -> *mut c_char {
     try_release_optional_string(take_ownership(promise).0.resolve().transpose())
+}
+
+/// Frees the native rust <code>StringPromise</code> object.
+#[no_mangle]
+pub extern "C" fn string_promise_drop(promise: *mut StringPromise) {
+    drop(take_ownership(promise))
 }

--- a/c/typedb_driver.i
+++ b/c/typedb_driver.i
@@ -95,7 +95,7 @@ struct Type {};
 struct Type {};
 %newobject function_prefix ## _resolve;
 %delobject function_prefix ## _resolve;
-%extend Type { ~Type() { function_prefix ## _resolve(self); } }
+%extend Type { ~Type() { function_prefix ## _drop(self); } }
 %delobject function_prefix ## _drop;
 %enddef
 

--- a/c/typedb_driver.i
+++ b/c/typedb_driver.i
@@ -93,9 +93,10 @@ struct Type {};
 
 %define %promiseproxy(Type, function_prefix)
 struct Type {};
-%extend Type { ~Type() { function_prefix ## _resolve(self); } }
 %newobject function_prefix ## _resolve;
 %delobject function_prefix ## _resolve;
+%extend Type { ~Type() { function_prefix ## _resolve(self); } }
+%delobject function_prefix ## _drop;
 %enddef
 
 %promiseproxy(BoolPromise, bool_promise)

--- a/java/BUILD
+++ b/java/BUILD
@@ -135,7 +135,7 @@ test_to_example(
     name = "example_core",
     input = "//java/test/integration/core:ExampleTest.java",
     output = "java/core_example",
-    removed_lines = ["assert", "todo"],
+    removed_lines = ["assert", "fail(", "todo"],
     changed_words = {
         "ExampleTest": "TypeDBExample",
     },

--- a/java/core_example
+++ b/java/core_example
@@ -13,6 +13,7 @@ import com.typedb.driver.api.concept.type.EntityType;
 import com.typedb.driver.api.database.Database;
 import com.typedb.driver.common.Promise;
 import com.typedb.driver.common.exception.TypeDBDriverException;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -137,6 +138,33 @@ public class TypeDBExample {
 
                 // Do not forget to commit if the changes should be persisted
                 transaction.commit();
+            }
+
+            // Open another write transaction to try inserting even more data
+            try (Transaction transaction = driver.transaction(database.name(), Transaction.Type.WRITE)) {
+                // When loading a large dataset, it's often better not to resolve every query's promise immediately.
+                // Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+                // just call `commit`, which will wait for all ongoing operations to finish before executing.
+                List<String> queries = List.of("insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";");
+                for (String query : queries) {
+                    transaction.query(query);
+                }
+                transaction.commit();
+            }
+
+            try (Transaction transaction = driver.transaction(database.name(), Transaction.Type.WRITE)) {
+                // Commit will still fail if at least one of the queries produce an error.
+                List<String> queries = List.of("insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";");
+                List<Promise<? extends QueryAnswer>> promises = new ArrayList<>();
+                for (String query : queries) {
+                    promises.add(transaction.query(query));
+                }
+
+                try {
+                    transaction.commit();
+                } catch (TypeDBDriverException expectedException) {
+                    System.out.println("Commit result will contain the unresolved query's error: " + expectedException);
+                }
             }
 
             // Open a read transaction to verify that the inserted data is saved

--- a/python/README.md
+++ b/python/README.md
@@ -149,7 +149,29 @@ from typedb.driver import *
                 # Do not forget to commit if the changes should be persisted
                 tx.commit()
 
-            # Open a read transaction to verify that the inserted data is saved
+            # Open another write transaction to try inserting even more data
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                # When loading a large dataset, it's often better not to resolve every query's promise immediately.
+                # Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+                # just call `commit`, which will wait for all ongoing operations to finish before executing.
+                queries = ["insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";"]
+                for query in queries:
+                    tx.query(query)
+                tx.commit()
+
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                # Commit will still fail if at least one of the queries produce an error.
+                queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"]
+                for query in queries:
+                    tx.query(query)
+
+                try:
+                    tx.commit()
+                    assert False, "TypeDBDriverException is expected"
+                except TypeDBDriverException as expected_exception:
+                    print(f"Commit will contain the unresolved query's error: {expected_exception}")
+
+            # Open a read transaction to verify that the previously inserted data is saved
             with driver.transaction(database.name, TransactionType.READ) as tx:
                 # A match query can be used for concept row outputs
                 var = "x"

--- a/python/README.md
+++ b/python/README.md
@@ -162,14 +162,15 @@ from typedb.driver import *
             with driver.transaction(database.name, TransactionType.WRITE) as tx:
                 # Commit will still fail if at least one of the queries produce an error.
                 queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"]
+                promises = []
                 for query in queries:
-                    tx.query(query)
+                    promises.append(tx.query(query))
 
                 try:
                     tx.commit()
                     assert False, "TypeDBDriverException is expected"
                 except TypeDBDriverException as expected_exception:
-                    print(f"Commit will contain the unresolved query's error: {expected_exception}")
+                    print(f"Commit result will contain the unresolved query's error: {expected_exception}")
 
             # Open a read transaction to verify that the previously inserted data is saved
             with driver.transaction(database.name, TransactionType.READ) as tx:
@@ -190,7 +191,7 @@ from typedb.driver import *
                 fetch_query = """
                 match
                   $x isa! person, has $a;
-                  $a isa! $t; 
+                  $a isa! $t;
                 fetch {
                   "single attribute type": $t,
                   "single attribute": $a,

--- a/python/core_example
+++ b/python/core_example
@@ -115,7 +115,29 @@ from typedb.driver import *
                 # Do not forget to commit if the changes should be persisted
                 tx.commit()
 
-            # Open a read transaction to verify that the inserted data is saved
+            # Open another write transaction to try inserting even more data
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                # When loading a large dataset, it's often better not to resolve every query's promise immediately.
+                # Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+                # just call `commit`, which will wait for all ongoing operations to finish before executing.
+                queries = ["insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";"]
+                for query in queries:
+                    tx.query(query)
+                tx.commit()
+
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                # Commit will still fail if at least one of the queries produce an error.
+                queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"]
+                for query in queries:
+                    tx.query(query)
+
+                try:
+                    tx.commit()
+                    assert False, "TypeDBDriverException is expected"
+                except TypeDBDriverException as expected_exception:
+                    print(f"Commit will contain the unresolved query's error: {expected_exception}")
+
+            # Open a read transaction to verify that the previously inserted data is saved
             with driver.transaction(database.name, TransactionType.READ) as tx:
                 # A match query can be used for concept row outputs
                 var = "x"

--- a/python/core_example
+++ b/python/core_example
@@ -128,14 +128,15 @@ from typedb.driver import *
             with driver.transaction(database.name, TransactionType.WRITE) as tx:
                 # Commit will still fail if at least one of the queries produce an error.
                 queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"]
+                promises = []
                 for query in queries:
-                    tx.query(query)
+                    promises.append(tx.query(query))
 
                 try:
                     tx.commit()
                     assert False, "TypeDBDriverException is expected"
                 except TypeDBDriverException as expected_exception:
-                    print(f"Commit will contain the unresolved query's error: {expected_exception}")
+                    print(f"Commit result will contain the unresolved query's error: {expected_exception}")
 
             # Open a read transaction to verify that the previously inserted data is saved
             with driver.transaction(database.name, TransactionType.READ) as tx:
@@ -156,7 +157,7 @@ from typedb.driver import *
                 fetch_query = """
                 match
                   $x isa! person, has $a;
-                  $a isa! $t; 
+                  $a isa! $t;
                 fetch {
                   "single attribute type": $t,
                   "single attribute": $a,

--- a/python/tests/integration/core/BUILD
+++ b/python/tests/integration/core/BUILD
@@ -17,7 +17,7 @@
 
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@typedb_driver_pip//:requirements.bzl", "requirement")
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_test", "py_binary")
 
 exports_files(
     ["test_example.py"],

--- a/python/tests/integration/core/test_example.py
+++ b/python/tests/integration/core/test_example.py
@@ -191,14 +191,15 @@ class TestExample(TestCase):
             with driver.transaction(database.name, TransactionType.WRITE) as tx:
                 # Commit will still fail if at least one of the queries produce an error.
                 queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"]
+                promises = []
                 for query in queries:
-                    tx.query(query)
+                    promises.append(tx.query(query))
 
                 try:
                     tx.commit()
                     assert False, "TypeDBDriverException is expected"
                 except TypeDBDriverException as expected_exception:
-                    print(f"Commit will contain the unresolved query's error: {expected_exception}")
+                    print(f"Commit result will contain the unresolved query's error: {expected_exception}")
 
             # Open a read transaction to verify that the previously inserted data is saved
             with driver.transaction(database.name, TransactionType.READ) as tx:
@@ -229,7 +230,7 @@ class TestExample(TestCase):
                 fetch_query = """
                 match
                   $x isa! person, has $a;
-                  $a isa! $t; 
+                  $a isa! $t;
                 fetch {
                   "single attribute type": $t,
                   "single attribute": $a,

--- a/python/tests/integration/core/test_example.py
+++ b/python/tests/integration/core/test_example.py
@@ -178,7 +178,29 @@ class TestExample(TestCase):
                 # Do not forget to commit if the changes should be persisted
                 tx.commit()
 
-            # Open a read transaction to verify that the inserted data is saved
+            # Open another write transaction to try inserting even more data
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                # When loading a large dataset, it's often better not to resolve every query's promise immediately.
+                # Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+                # just call `commit`, which will wait for all ongoing operations to finish before executing.
+                queries = ["insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";"]
+                for query in queries:
+                    tx.query(query)
+                tx.commit()
+
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                # Commit will still fail if at least one of the queries produce an error.
+                queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"]
+                for query in queries:
+                    tx.query(query)
+
+                try:
+                    tx.commit()
+                    assert False, "TypeDBDriverException is expected"
+                except TypeDBDriverException as expected_exception:
+                    print(f"Commit will contain the unresolved query's error: {expected_exception}")
+
+            # Open a read transaction to verify that the previously inserted data is saved
             with driver.transaction(database.name, TransactionType.READ) as tx:
                 # A match query can be used for concept row outputs
                 var = "x"
@@ -200,7 +222,7 @@ class TestExample(TestCase):
                     assert_that(x_type.get_label(), is_not("not person"))
                     count += 1
                     print(f"Found a person {x} of type {x_type}")
-                assert_that(count, is_(2))
+                assert_that(count, is_(4))
                 print(f"Total persons found: {count}")
 
                 # A fetch query can be used for concept document outputs with flexible structure
@@ -224,7 +246,7 @@ class TestExample(TestCase):
                     count += 1
                     print(f"Fetched a document: {document}.")
                     print(f"This document contains an attribute of type: {document['single attribute type']['label']}")
-                assert_that(count, is_(3))
+                assert_that(count, is_(5))
                 print(f"Total documents fetched: {count}")
 
         print("More examples can be found in the API reference and the documentation.\nWelcome to TypeDB!")

--- a/python/typedb/common/iterator_wrapper.py
+++ b/python/typedb/common/iterator_wrapper.py
@@ -36,4 +36,4 @@ class IteratorWrapper:
                 return next_item
             raise StopIteration
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None

--- a/python/typedb/common/promise.py
+++ b/python/typedb/common/promise.py
@@ -60,4 +60,4 @@ class Promise(Generic[T]):
         try:
             return self.inner()
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None

--- a/python/typedb/connection/database.py
+++ b/python/typedb/connection/database.py
@@ -47,27 +47,27 @@ class _Database(Database, NativeWrapper[NativeDatabase]):
         try:
             return database_schema(self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     def type_schema(self) -> str:
         try:
             return database_type_schema(self.native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     def delete(self) -> None:
         try:
             self._native_object.thisown = 0
             database_delete(self._native_object)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     # def replicas(self) -> set[Replica]:
     #     try:
     #         repl_iter = IteratorWrapper(database_get_replicas_info(self.native_object), replica_info_iterator_next)
     #         return set(_Database.Replica(replica_info) for replica_info in repl_iter)
     #     except TypeDBDriverExceptionNative as e:
-    #         raise TypeDBDriverException.of(e)
+    #         raise TypeDBDriverException.of(e) from None
     #
     # def primary_replica(self) -> Optional[Replica]:
     #     if res := database_get_primary_replica_info(self.native_object):

--- a/python/typedb/connection/database_manager.py
+++ b/python/typedb/connection/database_manager.py
@@ -44,22 +44,22 @@ class _DatabaseManager(DatabaseManager, NativeWrapper[NativeDriver]):
         try:
             return _Database(databases_get(self.native_object, name))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     def contains(self, name: str) -> bool:
         try:
             return databases_contains(self.native_object, name)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     def create(self, name: str) -> None:
         try:
             databases_create(self.native_object, name)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     def all(self) -> list[_Database]:
         try:
             return list(map(_Database, IteratorWrapper(databases_all(self.native_object), database_iterator_next)))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None

--- a/python/typedb/connection/driver.py
+++ b/python/typedb/connection/driver.py
@@ -49,12 +49,12 @@ class _Driver(Driver, NativeWrapper[NativeDriver]):
         #             native_connection = driver_open_cloud_translated(
         #                     public_addresses, private_addresses, credential.native_object)
         #     except TypeDBDriverExceptionNative as e:
-        #         raise TypeDBDriverException.of(e)
+        #         raise TypeDBDriverException.of(e) from None
         # else:
         try:
             native_driver = driver_open_core(addresses[0], Driver.LANGUAGE)
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
         super().__init__(native_driver)
         # self._user_manager = _UserManager(native_connection)
 

--- a/python/typedb/connection/transaction.py
+++ b/python/typedb/connection/transaction.py
@@ -48,7 +48,7 @@ class _Transaction(Transaction, NativeWrapper[NativeTransaction]):
             super().__init__(
                 transaction_new(driver.native_object, database_name, transaction_type.value))  # , options.native_object
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     @property
     def _native_object_not_owned_exception(self) -> TypeDBDriverException:
@@ -91,13 +91,13 @@ class _Transaction(Transaction, NativeWrapper[NativeTransaction]):
             self._native_object.thisown = 0
             void_promise_resolve(transaction_commit(self._native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     def rollback(self):
         try:
             void_promise_resolve(transaction_rollback(self.native_object))
         except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e)
+            raise TypeDBDriverException.of(e) from None
 
     def close(self):
         if self._native_object.thisown:

--- a/python/typedb/user/user.py
+++ b/python/typedb/user/user.py
@@ -52,4 +52,4 @@
 #         try:
 #             user_password_update(self.native_object, self._user_manager.native_object, password_old, password_new)
 #         except TypeDBDriverExceptionNative as e:
-#             raise TypeDBDriverException.of(e)
+#             raise TypeDBDriverException.of(e) from None

--- a/python/typedb/user/user_manager.py
+++ b/python/typedb/user/user_manager.py
@@ -47,25 +47,25 @@
 #         try:
 #             return users_contains(self.native_object, username)
 #         except TypeDBDriverExceptionNative as e:
-#             raise TypeDBDriverException.of(e)
+#             raise TypeDBDriverException.of(e) from None
 #
 #     def create(self, username: str, password: str) -> None:
 #         try:
 #             users_create(self.native_object, username, password)
 #         except TypeDBDriverExceptionNative as e:
-#             raise TypeDBDriverException.of(e)
+#             raise TypeDBDriverException.of(e) from None
 #
 #     def delete(self, username: str) -> None:
 #         try:
 #             users_delete(self.native_object, username)
 #         except TypeDBDriverExceptionNative as e:
-#             raise TypeDBDriverException.of(e)
+#             raise TypeDBDriverException.of(e) from None
 #
 #     def all(self) -> list[User]:
 #         try:
 #             return [_User(user, self) for user in IteratorWrapper(users_all(self.native_object), user_iterator_next)]
 #         except TypeDBDriverExceptionNative as e:
-#             raise TypeDBDriverException.of(e)
+#             raise TypeDBDriverException.of(e) from None
 #
 #     def get(self, username: str) -> Optional[User]:
 #         try:
@@ -73,16 +73,16 @@
 #                 return _User(user, self)
 #             return None
 #         except TypeDBDriverExceptionNative as e:
-#             raise TypeDBDriverException.of(e)
+#             raise TypeDBDriverException.of(e) from None
 #
 #     def password_set(self, username: str, password: str) -> None:
 #         try:
 #             users_set_password(self.native_object, username, password)
 #         except TypeDBDriverExceptionNative as e:
-#             raise TypeDBDriverException.of(e)
+#             raise TypeDBDriverException.of(e) from None
 #
 #     def get_current_user(self) -> User:
 #         try:
 #             return _User(users_current_user(self.native_object), self)
 #         except TypeDBDriverExceptionNative as e:
-#             raise TypeDBDriverException.of(e)
+#             raise TypeDBDriverException.of(e) from None

--- a/rust/README.md
+++ b/rust/README.md
@@ -175,7 +175,9 @@ fn typedb_example() {
 
         // Open a write transaction to insert data
         let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
-        let answer = transaction.query("insert $z isa person, has age 10; $x isa person, has age 20;").await.unwrap();
+        let answer = transaction.query(
+            "insert $z isa person, has age 10; $x isa person, has age 20, has name \"John\";"
+        ).await.unwrap();
 
         // Insert queries also return concept rows
         let mut rows = Vec::new();
@@ -203,6 +205,31 @@ fn typedb_example() {
 
         // Do not forget to commit if the changes should be persisted
         transaction.commit().await.unwrap();
+
+        // Open another write transaction to try inserting even more data
+        let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+        // When loading a large dataset, it's often better not to resolve every query's promise immediately.
+        // Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+        // just call `commit`, which will wait for all ongoing operations to finish before executing.
+        let queries = ["insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";"];
+        for query in queries {
+            transaction.query(query);
+        }
+        transaction.commit().await.unwrap();
+
+        {
+            let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+
+            // Commit will still fail if at least one of the queries produce an error.
+            let queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"];
+            let mut promises = vec![];
+            for query in queries {
+                promises.push(transaction.query(query));
+            }
+
+            let result = transaction.commit().await;
+            println!("Commit result will contain the unresolved query's error: {}", result.unwrap_err());
+        }
 
         // Open a read transaction to verify that the inserted data is saved
         let transaction = driver.transaction(database.name(), TransactionType::Read).await.unwrap();

--- a/rust/core_example
+++ b/rust/core_example
@@ -110,7 +110,9 @@ fn typedb_example() {
 
         // Open a write transaction to insert data
         let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
-        let answer = transaction.query("insert $z isa person, has age 10; $x isa person, has age 20;").await.unwrap();
+        let answer = transaction.query(
+            "insert $z isa person, has age 10; $x isa person, has age 20, has name \"John\";"
+        ).await.unwrap();
 
         // Insert queries also return concept rows
         let mut rows = Vec::new();
@@ -138,6 +140,31 @@ fn typedb_example() {
 
         // Do not forget to commit if the changes should be persisted
         transaction.commit().await.unwrap();
+
+        // Open another write transaction to try inserting even more data
+        let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+        // When loading a large dataset, it's often better not to resolve every query's promise immediately.
+        // Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+        // just call `commit`, which will wait for all ongoing operations to finish before executing.
+        let queries = ["insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";"];
+        for query in queries {
+            transaction.query(query);
+        }
+        transaction.commit().await.unwrap();
+
+        {
+            let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+
+            // Commit will still fail if at least one of the queries produce an error.
+            let queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"];
+            let mut promises = vec![];
+            for query in queries {
+                promises.push(transaction.query(query));
+            }
+
+            let result = transaction.commit().await;
+            println!("Commit result will contain the unresolved query's error: {}", result.unwrap_err());
+        }
 
         // Open a read transaction to verify that the inserted data is saved
         let transaction = driver.transaction(database.name(), TransactionType::Read).await.unwrap();

--- a/rust/tests/integration/core/example.rs
+++ b/rust/tests/integration/core/example.rs
@@ -167,7 +167,9 @@ fn example() {
 
         // Open a write transaction to insert data
         let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
-        let answer = transaction.query("insert $z isa person, has age 10; $x isa person, has age 20;").await.unwrap();
+        let answer = transaction.query(
+            "insert $z isa person, has age 10; $x isa person, has age 20, has name \"John\";"
+        ).await.unwrap();
         assert!(answer.is_row_stream());
 
         // Insert queries also return concept rows
@@ -201,6 +203,31 @@ fn example() {
         // Do not forget to commit if the changes should be persisted
         transaction.commit().await.unwrap();
 
+        // Open another write transaction to try inserting even more data
+        let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+        // When loading a large dataset, it's often better not to resolve every query's promise immediately.
+        // Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+        // just call `commit`, which will wait for all ongoing operations to finish before executing.
+        let queries = ["insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";"];
+        for query in queries {
+            transaction.query(query);
+        }
+        transaction.commit().await.unwrap();
+
+        {
+            let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+
+            // Commit will still fail if at least one of the queries produce an error.
+            let queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"];
+            let mut promises = vec![];
+            for query in queries {
+                promises.push(transaction.query(query));
+            }
+
+            let result = transaction.commit().await;
+            println!("Commit result will contain the unresolved query's error: {}", result.unwrap_err());
+        }
+
         // Open a read transaction to verify that the inserted data is saved
         let transaction = driver.transaction(database.name(), TransactionType::Read).await.unwrap();
 
@@ -231,7 +258,7 @@ fn example() {
                 _ => unreachable!("An entity is expected"),
             }
         }
-        assert_eq!(count, 2);
+        assert_eq!(count, 4);
         println!("Total persons found: {}", count);
 
         // A fetch query can be used for concept document outputs with flexible structure
@@ -281,7 +308,7 @@ fn example() {
             count += 1;
             println!("JSON representation of the fetched document:\n{}", document.into_json().to_string());
         }
-        assert_eq!(count, 2);
+        assert_eq!(count, 5);
         println!("Total documents fetched: {}", count);
         // EXAMPLE END MARKER
     });


### PR DESCRIPTION
## Usage and product changes
We remove the feature of `Promise`s to call `resolve` in destructors in languages like Java and Python. Now, if a promise is destroyed, it's not resolved, and, thus, not awaited.

If you just run queries and close the transaction, nothing will be awaited and persisted. However, if you commit your transaction, all the ongoing operations on the server side will finish before the actual commit. This lets you speed up the query execution (in case these queries don't collide with each other): 
```py
for query in queries:
    tx.query(query)
tx.commit()
```
If one of the `queries` contains an error and it's not `resolve`d, it will be returned from the `commit` call.

Detailed examples for each language supported are presented in `README`s.

Additionally, Python Driver's `TypeDBDriverError` exceptions no longer show the excessive traceback of its implementation, and only the short informative version for your executed code is presented.

## Implementation
