### PR TITLE
Speed up transaction opening and fix parallel 

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -32,9 +32,8 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
-    # TODO: Return typedb after the BDD pr merge
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/farost/typedb-behaviour",
-        commit = "22de030b82f2e9da421c210140860c99b9980ab8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "3418b20f2cef7ebcb2f573a42d8cbbce507d0ac3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -32,8 +32,9 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
+    # TODO: Return typedb after the BDD pr merge
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "ce1d517f2444cddbb37b7290a8003d336ac14b98",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/farost/typedb-behaviour",
+        commit = "22de030b82f2e9da421c210140860c99b9980ab8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
@@ -16,7 +16,7 @@ a| `CloudReplicaNotPrimary`
 a| `CloudSSLCertificateNotValidated`
 a| `CloudTokenCredentialInvalid`
 a| `ConnectionFailed`
-a| `DatabaseDoesNotExist`
+a| `DatabaseNotFound`
 a| `InvalidResponseField`
 a| `ListsNotImplemented`
 a| `MissingPort`

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -41,6 +41,7 @@ public abstract class ConnectionStepsBase {
     public static int THREAD_POOL_SIZE = 32;
     public static ExecutorService threadPool = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
     public static Driver driver;
+    public static Driver backgroundDriver;
     public static List<Transaction> transactions = new ArrayList<>();
     public static List<CompletableFuture<Transaction>> transactionsParallel = new ArrayList<>();
 
@@ -73,6 +74,8 @@ public abstract class ConnectionStepsBase {
                 isBeforeAllRan = true;
             }
         }
+
+        backgroundDriver = createDefaultTypeDBDriver();
     }
 
     void after() {
@@ -81,6 +84,7 @@ public abstract class ConnectionStepsBase {
         driver = createTypeDBDriver(TypeDB.DEFAULT_ADDRESS);
         driver.databases().all().forEach(Database::delete);
         driver.close();
+        backgroundDriver.close();
     }
 
     void cleanupTransactions() {
@@ -97,6 +101,8 @@ public abstract class ConnectionStepsBase {
     }
 
     abstract Driver createTypeDBDriver(String address);
+
+    abstract Driver createDefaultTypeDBDriver();
 
 //    abstract Options createOptions();
 

--- a/java/test/behaviour/connection/ConnectionStepsCore.java
+++ b/java/test/behaviour/connection/ConnectionStepsCore.java
@@ -48,6 +48,11 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
         return TypeDB.coreDriver(address);
     }
 
+    @Override
+    Driver createDefaultTypeDBDriver() {
+        return createTypeDBDriver(TypeDB.DEFAULT_ADDRESS);
+    }
+
 //    @Override
 //    Options createOptions() {
 //        return new Options();
@@ -60,7 +65,7 @@ public class ConnectionStepsCore extends ConnectionStepsBase {
     @Override
     @When("connection opens with default authentication")
     public void connection_opens_with_default_authentication() {
-        driver = createTypeDBDriver(TypeDB.DEFAULT_ADDRESS);
+        driver = createDefaultTypeDBDriver();
     }
 
     @When("connection opens with a wrong host{may_error}")

--- a/java/test/behaviour/connection/database/DatabaseSteps.java
+++ b/java/test/behaviour/connection/database/DatabaseSteps.java
@@ -39,7 +39,6 @@ import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.th
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class DatabaseSteps {
     public void createDatabases(Driver driver, List<String> names) {

--- a/java/test/behaviour/connection/database/DatabaseSteps.java
+++ b/java/test/behaviour/connection/database/DatabaseSteps.java
@@ -19,6 +19,7 @@
 
 package com.typedb.driver.test.behaviour.connection.database;
 
+import com.typedb.driver.api.Driver;
 import com.typedb.driver.api.database.Database;
 import com.typedb.driver.test.behaviour.config.Parameters;
 import io.cucumber.java.en.Then;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 import static com.typedb.driver.common.collection.Collections.list;
 import static com.typedb.driver.common.collection.Collections.set;
 import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.THREAD_POOL_SIZE;
+import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.backgroundDriver;
 import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.driver;
 import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.threadPool;
 import static org.junit.Assert.assertEquals;
@@ -40,21 +42,31 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DatabaseSteps {
+    public void createDatabases(Driver driver, List<String> names) {
+        for (String name : names) {
+            driver.databases().create(name);
+        }
+    }
+
+    public void deleteDatabases(Driver driver, List<String> names) {
+        for (String databaseName : names) {
+            driver.databases().get(databaseName).delete();
+        }
+    }
+
     @When("connection create database: {non_semicolon}{may_error}")
     public void connection_create_database(String name, Parameters.MayError mayError) {
-        mayError.check(() -> connection_create_databases(list(name)));
+        mayError.check(() -> createDatabases(driver, list(name)));
     }
 
     @When("connection create database with empty name{may_error}")
     public void connection_create_database_with_empty_name(Parameters.MayError mayError) {
-        mayError.check(() -> connection_create_databases(list("")));
+        mayError.check(() -> createDatabases(driver, list("")));
     }
 
     @When("connection create database(s):")
     public void connection_create_databases(List<String> names) {
-        for (String name : names) {
-            driver.databases().create(name);
-        }
+        createDatabases(driver, names);
     }
 
     @When("connection create databases in parallel:")
@@ -68,33 +80,19 @@ public class DatabaseSteps {
         CompletableFuture.allOf(creations).join();
     }
 
+    @When("in background, connection create database: {non_semicolon}{may_error}")
+    public void in_background_connection_create_database(String name, Parameters.MayError mayError) {
+        mayError.check(() -> createDatabases(backgroundDriver, list(name)));
+    }
+
     @When("connection delete database: {word}{may_error}")
     public void connection_delete_database(String name, Parameters.MayError mayError) {
-        mayError.check(() -> connection_delete_databases(list(name)));
+        mayError.check(() -> deleteDatabases(driver, list(name)));
     }
 
     @When("connection delete database(s):")
     public void connection_delete_databases(List<String> names) {
-        for (String databaseName : names) {
-            driver.databases().get(databaseName).delete();
-        }
-    }
-
-    @Then("connection delete database; throws exception: {word}")
-    public void connection_delete_database_throws_exception(String name) {
-        connection_delete_databases_throws_exception(list(name));
-    }
-
-    @Then("connection delete database(s); throws exception")
-    public void connection_delete_databases_throws_exception(List<String> names) {
-        for (String databaseName : names) {
-            try {
-                driver.databases().get(databaseName).delete();
-                fail();
-            } catch (Exception e) {
-                // successfully failed
-            }
-        }
+        deleteDatabases(driver, names);
     }
 
     @When("connection delete databases in parallel:")
@@ -108,6 +106,12 @@ public class DatabaseSteps {
         CompletableFuture.allOf(deletions).join();
     }
 
+    @When("in background, connection delete database: {non_semicolon}{may_error}")
+    public void in_background_connection_delete_database(String name, Parameters.MayError mayError) {
+        mayError.check(() -> deleteDatabases(backgroundDriver, list(name)));
+    }
+
+    // TODO: Use "contains" instead. Cover "all" interfaces explicitly
     @When("connection has database: {word}")
     public void connection_has_database(String name) {
         connection_has_databases(list(name));
@@ -122,7 +126,6 @@ public class DatabaseSteps {
     public void connection_does_not_have_database(String name) {
         connection_does_not_have_databases(list(name));
     }
-
 
     @Then("connection does not have database(s):")
     public void connection_does_not_have_databases(List<String> names) {

--- a/python/tests/behaviour/background/core/environment.py
+++ b/python/tests/behaviour/background/core/environment.py
@@ -24,6 +24,8 @@ IGNORE_TAGS = ["ignore", "ignore-typedb-driver", "ignore-typedb-driver-python"]
 
 def before_all(context: Context):
     environment_base.before_all(context)
+    context.create_driver_fn = lambda host="localhost", port=None, user=None, password=None: \
+        create_driver(context, host, port, user, password)
     context.setup_context_driver_fn = lambda host="localhost", port=None, user=None, password=None: \
         setup_context_driver(context, host, port, user, password)
     context.setup_context_driver_fn()
@@ -41,12 +43,16 @@ def before_scenario(context: Context, scenario):
 
 
 def setup_context_driver(context, host="localhost", port=None, username=None, password=None):
+    context.driver = create_driver(context, host, port, username, password)
+    # context.transaction_options = Options(infer=True)
+
+
+def create_driver(context, host="localhost", port=None, username=None, password=None) -> Driver:
     if username is not None or password is not None:
         raise Exception("Core driver does not support authentication")
     if port is None:
         port = int(context.config.userdata["port"])
-    context.driver = TypeDB.core_driver(address=f"{host}:{port}")
-    # context.transaction_options = Options(infer=True)
+    return TypeDB.core_driver(address=f"{host}:{port}")
 
 
 def after_scenario(context: Context, scenario):

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -133,8 +133,8 @@ error_messages! { ConnectionError
         6: "The transaction is closed and no further operation is allowed.",
     TransactionIsClosedWithErrors { errors: String } =
         7: "The transaction is closed because of the error(s):\n{errors}",
-    DatabaseDoesNotExist { name: String } =
-        8: "The database '{name}' does not exist.",
+    DatabaseNotFound { name: String } =
+        8: "Database '{name}' not found.",
     MissingResponseField { field: &'static str } =
         9: "Missing field in message received from server: '{field}'. This is either a version compatibility issue or a bug.",
     UnknownRequestId { request_id: RequestID } =
@@ -271,7 +271,7 @@ impl Error {
             // TODO: CLS and ENT are synonyms which we can simplify on protocol change
             Some("[CLS08]") => Self::Connection(ConnectionError::CloudTokenCredentialInvalid),
             Some("[ENT08]") => Self::Connection(ConnectionError::CloudTokenCredentialInvalid),
-            Some("[DBS06]") => Self::Connection(ConnectionError::DatabaseDoesNotExist {
+            Some("[DBS06]") => Self::Connection(ConnectionError::DatabaseNotFound {
                 name: message.split('\'').nth(1).unwrap_or("{unknown}").to_owned(),
             }),
             _ => Self::Other(message.to_owned()),

--- a/rust/src/connection/network/transmitter/rpc.rs
+++ b/rust/src/connection/network/transmitter/rpc.rs
@@ -157,7 +157,9 @@ impl RPCTransmitter {
                 match response_source.next().await {
                     Some(Ok(transaction::Server { server: Some(Server::Res(res)) })) => {
                         match TransactionResponse::try_from_proto(res) {
-                            Ok(TransactionResponse::Open { server_duration_millis }) => {
+                            Ok(TransactionResponse::Open { server_duration_millis: _ }) => {
+                                // TODO: Return as a part of Response::TransactionStream and use
+                                // the code below outside:
                                 // let open_latency =
                                 //     Instant::now().duration_since(open_request_start).as_millis() as u64 - server_duration_millis;
                                 // tracker.update_latency(open_latency)
@@ -171,9 +173,9 @@ impl RPCTransmitter {
                             }
                         }
                     }
-                    Some(Ok(unexpected_message)) => panic!("Unexpected message {unexpected_message:?}"),
+                    Some(Ok(unexpected_message)) => panic!("Unexpected message {unexpected_message:?}"), // TODO: return Err()
                     Some(Err(status)) => return Err(status.into()),
-                    None => panic!("Unexpected close"),
+                    None => panic!("Unexpected close"), // TODO: return Err()
                 }
                 Ok(Response::TransactionStream { open_request_id: req_id, request_sink, response_source })
             }

--- a/rust/src/connection/network/transmitter/rpc.rs
+++ b/rust/src/connection/network/transmitter/rpc.rs
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+use futures::StreamExt;
 use tokio::{
     select,
     sync::{
@@ -24,12 +25,13 @@ use tokio::{
         oneshot::channel as oneshot_async,
     },
 };
+use typedb_protocol::{transaction, transaction::server::Server};
 
 use super::{oneshot_blocking, response_sink::ResponseSink};
 use crate::{
     common::{address::Address, RequestID, Result},
     connection::{
-        message::{Request, Response},
+        message::{Request, Response, TransactionResponse},
         network::{
             channel::{open_callcred_channel, open_plaintext_channel, GRPCChannel},
             proto::{FromProto, IntoProto, TryFromProto, TryIntoProto},
@@ -151,7 +153,28 @@ impl RPCTransmitter {
             Request::Transaction(transaction_request) => {
                 let req = transaction_request.into_proto();
                 let req_id = RequestID::from(req.req_id.clone());
-                let (request_sink, response_source) = rpc.transaction(req).await?;
+                let (request_sink, mut response_source) = rpc.transaction(req).await?;
+                match response_source.next().await {
+                    Some(Ok(transaction::Server { server: Some(Server::Res(res)) })) => {
+                        match TransactionResponse::try_from_proto(res) {
+                            Ok(TransactionResponse::Open { server_duration_millis }) => {
+                                // let open_latency =
+                                //     Instant::now().duration_since(open_request_start).as_millis() as u64 - server_duration_millis;
+                                // tracker.update_latency(open_latency)
+                            }
+                            Err(error) => return Err(error),
+                            Ok(TransactionResponse::Commit)
+                            | Ok(TransactionResponse::Rollback)
+                            | Ok(TransactionResponse::Query(_))
+                            | Ok(TransactionResponse::Close) => {
+                                panic!("Unexpected - transaction open response was not TransactionOpen.")
+                            }
+                        }
+                    }
+                    Some(Ok(unexpected_message)) => panic!("Unexpected message {unexpected_message:?}"),
+                    Some(Err(status)) => return Err(status.into()),
+                    None => panic!("Unexpected close"),
+                }
                 Ok(Response::TransactionStream { open_request_id: req_id, request_sink, response_source })
             }
 

--- a/rust/tests/behaviour/steps/connection/mod.rs
+++ b/rust/tests/behaviour/steps/connection/mod.rs
@@ -35,13 +35,13 @@ async fn typedb_starts(_: &mut Context) {}
 #[apply(generic_step)]
 #[step("connection opens with default authentication")]
 async fn connection_opens_with_default_authentication(context: &mut Context) {
-    context.create_default_driver(None, None).await.unwrap();
+    context.set_driver(context.create_default_driver(None, None).await.unwrap());
 }
 
 #[apply(generic_step)]
 #[step(expr = "connection opens with authentication: {word}, {word}")]
 async fn connection_opens_with_authentication(context: &mut Context, username: String, password: String) {
-    context.create_default_driver(Some(&username), Some(&password)).await.unwrap()
+    context.set_driver(context.create_default_driver(Some(&username), Some(&password)).await.unwrap())
 }
 
 fn change_host(address: &str, new_host: &str) -> String {


### PR DESCRIPTION
## Usage and product changes
* We fix transaction opening for all the supported drivers, speeding up the operation by 2x.
* We eliminate database-related errors happening during concurrent database management (create and delete operations) by multiple drivers due to cache mismatches. 
* We make transaction opening requests immediately return errors instead of waiting for additional transaction operations to be performed (e.g. commit or query).

## Implementation
Details in PR comments to specific lines.