### PR TITLE
Revert get current user API

### DIFF
--- a/c/src/user_manager.rs
+++ b/c/src/user_manager.rs
@@ -30,8 +30,8 @@ use crate::{error::try_release_string, memory::release_string};
 
 /// Retrieves the username of the user who opened this connection
 #[no_mangle]
-pub extern "C" fn users_current_username(driver: *const TypeDBDriver) -> *mut c_char {
-    release_string(borrow(driver).users().get_current_user().clone().to_owned())
+pub extern "C" fn users_current_username(driver: *const TypeDBDriver) -> *mut User {
+    try_release_optional(borrow(driver).users().get_current_user().transpose())
 }
 
 /// Iterator over a set of <code>User</code>s

--- a/c/src/user_manager.rs
+++ b/c/src/user_manager.rs
@@ -28,12 +28,6 @@ use super::{
 };
 use crate::{error::try_release_string, memory::release_string};
 
-/// Retrieves the username of the user who opened this connection
-#[no_mangle]
-pub extern "C" fn users_current_username(driver: *const TypeDBDriver) -> *mut User {
-    try_release_optional(borrow(driver).users().get_current_user().transpose())
-}
-
 /// Iterator over a set of <code>User</code>s
 pub struct UserIterator(CIterator<User>);
 
@@ -78,6 +72,12 @@ pub extern "C" fn users_delete(driver: *const TypeDBDriver, username: *const c_c
 #[no_mangle]
 pub extern "C" fn users_get(driver: *const TypeDBDriver, username: *const c_char) -> *mut User {
     try_release_optional(borrow(driver).users().get(string_view(username)).transpose())
+}
+
+/// Retrieves the username of the user who opened this connection
+#[no_mangle]
+pub extern "C" fn users_get_current_user(driver: *const TypeDBDriver) -> *mut User {
+    try_release_optional(borrow(driver).users().get_current_user().transpose())
 }
 
 /// Sets a new password for a user. This operation can only be performed by administrators.

--- a/c/src/user_manager.rs
+++ b/c/src/user_manager.rs
@@ -31,7 +31,7 @@ use crate::{error::try_release_string, memory::release_string};
 /// Retrieves the username of the user who opened this connection
 #[no_mangle]
 pub extern "C" fn users_current_username(driver: *const TypeDBDriver) -> *mut c_char {
-    release_string(borrow(driver).users().current_username().clone().to_owned())
+    release_string(borrow(driver).users().get_current_user().clone().to_owned())
 }
 
 /// Iterator over a set of <code>User</code>s

--- a/c/typedb_driver.i
+++ b/c/typedb_driver.i
@@ -207,7 +207,7 @@ void transaction_on_close_register(const Transaction* transaction, TransactionCa
 %newobject transaction_query;
 
 %newobject users_all;
-%newobject users_current_username;
+%newobject users_get_current_user;
 %newobject users_get;
 
 %newobject user_get_name;

--- a/docs/modules/ROOT/partials/python/connection/UserManager.adoc
+++ b/docs/modules/ROOT/partials/python/connection/UserManager.adoc
@@ -146,12 +146,12 @@ a| `username` a| The name of the user to retrieve a| `str` a|
 driver.users.get(username)
 ----
 
-[#_UserManager_get_current_username_]
-==== get_current_username
+[#_UserManager_get_current_user_]
+==== get_current_user
 
 [source,python]
 ----
-get_current_username() -> str
+get_current_user() -> Optional[User]
 ----
 
 Retrieve the name of the user who opened the current connection.
@@ -164,7 +164,7 @@ Retrieve the name of the user who opened the current connection.
 .Code examples
 [source,python]
 ----
-driver.users.get_current_username()
+driver.users.get_current_user()
 ----
 
 [#_UserManager_set_password_username_str_password_str]

--- a/java/api/user/UserManager.java
+++ b/java/api/user/UserManager.java
@@ -88,7 +88,7 @@ public interface UserManager {
      * </pre>
      */
     @CheckReturnValue
-    String getCurrentUsername();
+    User getCurrentUser();
 
     /**
      * Retrieves all users which exist on the TypeDB server.

--- a/java/test/behaviour/connection/user/UserSteps.java
+++ b/java/test/behaviour/connection/user/UserSteps.java
@@ -83,6 +83,6 @@ public class UserSteps {
 
     @Then("get current username: {non_semicolon}")
     public void get_current_username(String username) {
-        assertEquals(username, driver.users().getCurrentUsername());
+        assertEquals(username, driver.users().getCurrentUser().name());
     }
 }

--- a/java/user/UserManagerImpl.java
+++ b/java/user/UserManagerImpl.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import static com.typedb.driver.jni.typedb_driver.users_all;
 import static com.typedb.driver.jni.typedb_driver.users_contains;
 import static com.typedb.driver.jni.typedb_driver.users_create;
-import static com.typedb.driver.jni.typedb_driver.users_current_username;
+import static com.typedb.driver.jni.typedb_driver.users_get_current_user;
 import static com.typedb.driver.jni.typedb_driver.users_delete;
 import static com.typedb.driver.jni.typedb_driver.users_get;
 import static com.typedb.driver.jni.typedb_driver.users_set_password;
@@ -81,9 +81,11 @@ public class UserManagerImpl implements UserManager {
     }
 
     @Override
-    public String getCurrentUsername() {
+    public User getCurrentUser() {
         try { // TODO: Make noexcept if we leave it returning just a String
-            return users_current_username(nativeDriver);
+            com.typedb.driver.jni.User user = users_get_current_user(nativeDriver);
+            if (user != null) return new UserImpl(user, this);
+            else return null;
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/python/tests/behaviour/connection/user/user_steps.py
+++ b/python/tests/behaviour/connection/user/user_steps.py
@@ -75,4 +75,4 @@ def step_impl(context: Context, username: str, may_error: MayError):
 
 @step("get current username: {username:NonSemicolon}")
 def step_impl(context: Context, username: str):
-    assert_that(context.driver.users.get_current_username(), is_(equal_to(username)))
+    assert_that(context.driver.users.get_current_user().name(), is_(equal_to(username)))

--- a/python/tests/behaviour/connection/user/user_steps.py
+++ b/python/tests/behaviour/connection/user/user_steps.py
@@ -75,4 +75,4 @@ def step_impl(context: Context, username: str, may_error: MayError):
 
 @step("get current username: {username:NonSemicolon}")
 def step_impl(context: Context, username: str):
-    assert_that(context.driver.users.get_current_user().name(), is_(equal_to(username)))
+    assert_that(context.driver.users.get_current_user().name, is_(equal_to(username)))

--- a/python/typedb/api/user/user.py
+++ b/python/typedb/api/user/user.py
@@ -125,7 +125,7 @@ class UserManager(ABC):
         pass
 
     @abstractmethod
-    def get_current_username(self) -> str:
+    def get_current_user(self) -> Optional[User]:
         """
         Retrieve the name of the user who opened the current connection.
 
@@ -135,7 +135,7 @@ class UserManager(ABC):
         ---------
         ::
 
-           driver.users.get_current_username()
+           driver.users.get_current_user()
         """
         pass
 

--- a/python/typedb/user/user_manager.py
+++ b/python/typedb/user/user_manager.py
@@ -76,7 +76,7 @@ class _UserManager(UserManager):
 
     def get_current_user(self) -> Optional[User]:
         try:  # TODO: remove try if we leave it as str
-            # return users_current_username(self.native_driver)
+            # return users_get_current_user(self.native_driver)
             if user := users_get_current_user(self.native_driver):
                 return _User(user, self)
             return None

--- a/python/typedb/user/user_manager.py
+++ b/python/typedb/user/user_manager.py
@@ -23,7 +23,7 @@ from typedb.api.user.user import UserManager
 from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.native_driver_wrapper import users_contains, users_create, users_delete, users_all, users_get, \
-    users_set_password, users_current_username, user_iterator_next, TypeDBDriverExceptionNative
+    users_set_password, users_get_current_user, user_iterator_next, TypeDBDriverExceptionNative
 from typedb.user.user import _User
 
 if TYPE_CHECKING:
@@ -74,8 +74,11 @@ class _UserManager(UserManager):
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 
-    def get_current_username(self) -> str:
+    def get_current_user(self) -> Optional[User]:
         try:  # TODO: remove try if we leave it as str
-            return users_current_username(self.native_driver)
-        except TypeDBDriverExceptionNative as e:
+            # return users_current_username(self.native_driver)
+            if user := users_get_current_user(self.native_driver):
+                return _User(user, self)
+            return None
+    except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None

--- a/python/typedb/user/user_manager.py
+++ b/python/typedb/user/user_manager.py
@@ -80,5 +80,5 @@ class _UserManager(UserManager):
             if user := users_get_current_user(self.native_driver):
                 return _User(user, self)
             return None
-    except TypeDBDriverExceptionNative as e:
+        except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None

--- a/rust/src/user/user_manager.rs
+++ b/rust/src/user/user_manager.rs
@@ -36,13 +36,14 @@ impl UserManager {
         Self { server_connections }
     }
 
-    pub fn current_username(&self) -> &str {
+    #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
+    pub async fn get_current_user(&self) -> Result<Option<User>> {
         let (_, connection) = self
             .server_connections
             .iter()
             .next()
             .expect("Unexpected condition: the server connection collection is empty");
-        connection.username()
+        self.get(connection.username()).await
     }
 
     /// Checks if a user with the given name exists.

--- a/rust/tests/behaviour/steps/connection/user.rs
+++ b/rust/tests/behaviour/steps/connection/user.rs
@@ -89,5 +89,5 @@ async fn delete_user(context: &mut Context, username: String, may_error: params:
 #[apply(generic_step)]
 #[step(expr = "get current username: {word}")]
 async fn get_current_username(context: &mut Context, username: String) {
-    assert_eq!(context.driver.as_ref().unwrap().users().current_username(), &username);
+    assert_eq!(context.driver.as_ref().unwrap().users().get_current_user().await.unwrap().unwrap().name, username);
 }


### PR DESCRIPTION
## Usage and product changes
Revert the `get_current_username` which returns the username as a string, back to `get_current_user` which returns the user object.

## Implementation
- Revert the `get_current_username` method in Rust, C, Java, and Python
- Update the BDD tests accordingly