### PR TITLE
Move user update and delete API to the User object

### DIFF
--- a/c/src/user.rs
+++ b/c/src/user.rs
@@ -20,11 +20,12 @@
 use std::ffi::c_char;
 
 use typedb_driver::{Database, TypeDBDriver, User, UserManager};
-use crate::memory::{take_arc, take_ownership};
+
 use super::{
     error::unwrap_void,
     memory::{borrow, free, release_string, string_view},
 };
+use crate::memory::{take_arc, take_ownership};
 
 /// Frees the native rust <code>User</code> object.
 #[no_mangle]
@@ -51,13 +52,8 @@ pub extern "C" fn user_get_name(user: *mut User) -> *mut c_char {
 /// @param password_old The current password of this user
 /// @param password_new The new password
 #[no_mangle]
-pub extern "C" fn user_update_password(
-    user: *mut User,
-    password: *const c_char,
-) {
-    unwrap_void(borrow(user).update_password(
-        string_view(password),
-    ));
+pub extern "C" fn user_update_password(user: *mut User, password: *const c_char) {
+    unwrap_void(borrow(user).update_password(string_view(password)));
 }
 
 /// Deletes this database.

--- a/c/src/user.rs
+++ b/c/src/user.rs
@@ -20,7 +20,7 @@
 use std::ffi::c_char;
 
 use typedb_driver::{Database, TypeDBDriver, User, UserManager};
-use crate::memory::take_arc;
+use crate::memory::{take_arc, take_ownership};
 use super::{
     error::unwrap_void,
     memory::{borrow, free, release_string, string_view},
@@ -53,20 +53,15 @@ pub extern "C" fn user_get_name(user: *mut User) -> *mut c_char {
 #[no_mangle]
 pub extern "C" fn user_update_password(
     user: *mut User,
-    driver: *const TypeDBDriver,
     password: *const c_char,
 ) {
-    todo!("User update functions")
-    // unwrap_void(borrow(user).password_update(
-    //     &borrow(driver).connection, // ?
-    //     string_view(password_old),
-    //     string_view(password_new),
-    // ));
+    unwrap_void(borrow(user).update_password(
+        string_view(password),
+    ));
 }
-
 
 /// Deletes this database.
 #[no_mangle]
 pub extern "C" fn user_delete(user: *mut User) {
-    todo!("User delete functions")
+    unwrap_void(take_ownership(user).delete());
 }

--- a/c/src/user.rs
+++ b/c/src/user.rs
@@ -19,8 +19,8 @@
 
 use std::ffi::c_char;
 
-use typedb_driver::{TypeDBDriver, User, UserManager};
-
+use typedb_driver::{Database, TypeDBDriver, User, UserManager};
+use crate::memory::take_arc;
 use super::{
     error::unwrap_void,
     memory::{borrow, free, release_string, string_view},
@@ -54,8 +54,7 @@ pub extern "C" fn user_get_name(user: *mut User) -> *mut c_char {
 pub extern "C" fn user_update_password(
     user: *mut User,
     driver: *const TypeDBDriver,
-    password_old: *const c_char,
-    password_new: *const c_char,
+    password: *const c_char,
 ) {
     todo!("User update functions")
     // unwrap_void(borrow(user).password_update(
@@ -63,4 +62,11 @@ pub extern "C" fn user_update_password(
     //     string_view(password_old),
     //     string_view(password_new),
     // ));
+}
+
+
+/// Deletes this database.
+#[no_mangle]
+pub extern "C" fn user_delete(user: *mut User) {
+    todo!("User delete functions")
 }

--- a/c/src/user_manager.rs
+++ b/c/src/user_manager.rs
@@ -71,7 +71,7 @@ pub extern "C" fn users_create(driver: *const TypeDBDriver, username: *const c_c
 /// Deletes the user with the given username.
 #[no_mangle]
 pub extern "C" fn users_delete(driver: *const TypeDBDriver, username: *const c_char) {
-    unwrap_void(borrow(driver).users().delete(string_view(username)));
+    todo!("User delete functions")
 }
 
 /// Retrieves a user with the given name.
@@ -88,5 +88,5 @@ pub extern "C" fn users_get(driver: *const TypeDBDriver, username: *const c_char
 /// @param password The new password
 #[no_mangle]
 pub extern "C" fn users_set_password(driver: *const TypeDBDriver, username: *const c_char, password: *const c_char) {
-    unwrap_void(borrow(driver).users().update_password(string_view(username), string_view(password)));
+    todo!("User delete functions")
 }

--- a/c/src/user_manager.rs
+++ b/c/src/user_manager.rs
@@ -68,25 +68,8 @@ pub extern "C" fn users_create(driver: *const TypeDBDriver, username: *const c_c
     unwrap_void(borrow(driver).users().create(string_view(username), string_view(password)));
 }
 
-/// Deletes the user with the given username.
-#[no_mangle]
-pub extern "C" fn users_delete(driver: *const TypeDBDriver, username: *const c_char) {
-    todo!("User delete functions")
-}
-
 /// Retrieves a user with the given name.
 #[no_mangle]
 pub extern "C" fn users_get(driver: *const TypeDBDriver, username: *const c_char) -> *mut User {
     try_release_optional(borrow(driver).users().get(string_view(username)).transpose())
-}
-
-/// Sets a new password for a user. This operation can only be performed by administrators.
-///
-/// @param user_manager The </code>UserManager</code> object to be used.
-///                     This must be on a connection opened by an administrator.
-/// @param username The name of the user to set the password of
-/// @param password The new password
-#[no_mangle]
-pub extern "C" fn users_set_password(driver: *const TypeDBDriver, username: *const c_char, password: *const c_char) {
-    todo!("User delete functions")
 }

--- a/c/typedb_driver.i
+++ b/c/typedb_driver.i
@@ -211,5 +211,6 @@ void transaction_on_close_register(const Transaction* transaction, TransactionCa
 %newobject users_get;
 
 %newobject user_get_name;
+%delobject user_delete;
 
 %include "typedb_driver.h"

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "98000d17a135e15fa366da3696be0572e06e69d8"
+        commit = "b733fe85bd0e0199448e3dd14e0c54568911e043"
     )
 
 #def typedb_cloud_artifact():

--- a/java/api/user/User.java
+++ b/java/api/user/User.java
@@ -44,5 +44,5 @@ public interface User {
      * @param passwordOld The current password of this user
      * @param passwordNew The new password
      */
-    void updatePassword(String passwordOld, String passwordNew);
+    void updatePassword(String password);
 }

--- a/java/api/user/User.java
+++ b/java/api/user/User.java
@@ -45,4 +45,15 @@ public interface User {
      * @param passwordNew The new password
      */
     void updatePassword(String password);
+
+    /**
+     * Deletes a user with the given name.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * driver.users().delete(username);
+     * </pre>
+     *
+     */
+    void delete();
 }

--- a/java/api/user/UserManager.java
+++ b/java/api/user/UserManager.java
@@ -53,18 +53,6 @@ public interface UserManager {
     void create(String username, String password);
 
     /**
-     * Deletes a user with the given name.
-     *
-     * <h3>Examples</h3>
-     * <pre>
-     * driver.users().delete(username);
-     * </pre>
-     *
-     * @param username The name of the user to be deleted
-     */
-    void delete(String username);
-
-    /**
      * Retrieves a user with the given name.
      *
      * <h3>Examples</h3>

--- a/java/api/user/UserManager.java
+++ b/java/api/user/UserManager.java
@@ -27,6 +27,17 @@ import java.util.Set;
  */
 public interface UserManager {
     /**
+     * Retrieves the name of the user who opened the current connection.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * driver.users().getCurrentUsername();
+     * </pre>
+     */
+    @CheckReturnValue
+    String getCurrentUsername();
+
+    /**
      * Checks if a user with the given name exists.
      *
      * <h3>Examples</h3>
@@ -38,19 +49,6 @@ public interface UserManager {
      */
     @CheckReturnValue
     boolean contains(String username);
-
-    /**
-     * Creates a user with the given name &amp; password.
-     *
-     * <h3>Examples</h3>
-     * <pre>
-     * driver.users().create(username, password);
-     * </pre>
-     *
-     * @param username The name of the user to be created
-     * @param password The password of the user to be created
-     */
-    void create(String username, String password);
 
     /**
      * Retrieves a user with the given name.
@@ -68,17 +66,6 @@ public interface UserManager {
     // TODO: I don't like this, leaving this way for now. Use driver.users().get(username)
 
     /**
-     * Retrieves the name of the user who opened the current connection.
-     *
-     * <h3>Examples</h3>
-     * <pre>
-     * driver.users().getCurrentUsername();
-     * </pre>
-     */
-    @CheckReturnValue
-    String getCurrentUsername();
-
-    /**
      * Retrieves all users which exist on the TypeDB server.
      *
      * <h3>Examples</h3>
@@ -89,15 +76,15 @@ public interface UserManager {
     Set<User> all();
 
     /**
-     * Sets a new password for a user. This operation can only be performed by administrators.
+     * Creates a user with the given name &amp; password.
      *
      * <h3>Examples</h3>
      * <pre>
-     * driver.users().setPassword(username, password);
+     * driver.users().create(username, password);
      * </pre>
      *
-     * @param username The name of the user to set the password of
-     * @param password The new password
+     * @param username The name of the user to be created
+     * @param password The password of the user to be created
      */
-    void setPassword(String username, String password); // TODO: Why is it not in user?
+    void create(String username, String password);
 }

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -88,7 +88,7 @@ public abstract class ConnectionStepsBase {
         cleanupTransactions();
 
         driver = createDefaultTypeDBDriver();
-        driver.users().all().stream().filter(user -> !user.name().equals(ADMIN_USERNAME)).forEach(user -> driver.users().delete(user.name()));
+        driver.users().all().stream().filter(user -> !user.name().equals(ADMIN_USERNAME)).forEach(user -> driver.users().get(user.name()).delete());
         // TODO: Set admin password to default
         driver.close();
         backgroundDriver.close();

--- a/java/test/behaviour/connection/user/UserSteps.java
+++ b/java/test/behaviour/connection/user/UserSteps.java
@@ -68,7 +68,7 @@ public class UserSteps {
 
     @When("get user\\({non_semicolon}) set password: {non_semicolon}{may_error}")
     public void get_user_set_password(String username, String passwordNew, Parameters.MayError mayError) {
-        mayError.check(() -> driver.users().setPassword(username, passwordNew));
+        mayError.check(() -> driver.users().get(username).updatePassword(passwordNew));
     }
 
     @When("get user\\({non_semicolon}) update password to '{non_semicolon}'{may_error}")
@@ -78,7 +78,7 @@ public class UserSteps {
 
     @When("delete user: {non_semicolon}{may_error}")
     public void delete_user(String username, Parameters.MayError mayError) {
-        mayError.check(() -> driver.users().delete(username));
+        mayError.check(() -> driver.users().get(username).delete());
     }
 
     @Then("get current username: {non_semicolon}")

--- a/java/test/behaviour/connection/user/UserSteps.java
+++ b/java/test/behaviour/connection/user/UserSteps.java
@@ -71,9 +71,9 @@ public class UserSteps {
         mayError.check(() -> driver.users().setPassword(username, passwordNew));
     }
 
-    @When("get user\\({non_semicolon}) update password from '{non_semicolon}' to '{non_semicolon}'{may_error}")
-    public void get_user_update_password(String username, String passwordOld, String passwordNew, Parameters.MayError mayError) {
-        mayError.check(() -> driver.users().get(username).updatePassword(passwordOld, passwordNew));
+    @When("get user\\({non_semicolon}) update password to '{non_semicolon}'{may_error}")
+    public void get_user_update_password(String username, String password, Parameters.MayError mayError) {
+        mayError.check(() -> driver.users().get(username).updatePassword(password));
     }
 
     @When("delete user: {non_semicolon}{may_error}")

--- a/java/user/UserImpl.java
+++ b/java/user/UserImpl.java
@@ -55,4 +55,14 @@ public class UserImpl extends NativeObject<com.typedb.driver.jni.User> implement
             throw new TypeDBDriverException(e);
         }
     }
+
+    @Override
+    public void delete() {
+        try {
+            user_delete(nativeObject.released());
+        } catch (com.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
+    }
+
 }

--- a/java/user/UserImpl.java
+++ b/java/user/UserImpl.java
@@ -48,9 +48,9 @@ public class UserImpl extends NativeObject<com.typedb.driver.jni.User> implement
 //    }
 
     @Override
-    public void updatePassword(String passwordOld, String passwordNew) {
+    public void updatePassword(String password) {
         try {
-            user_update_password(nativeObject, users.nativeDriver, passwordOld, passwordNew);
+            user_update_password(nativeObject, users.nativeDriver, password);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/java/user/UserImpl.java
+++ b/java/user/UserImpl.java
@@ -25,6 +25,7 @@ import com.typedb.driver.common.exception.TypeDBDriverException;
 
 import static com.typedb.driver.jni.typedb_driver.user_get_name;
 import static com.typedb.driver.jni.typedb_driver.user_update_password;
+import static com.typedb.driver.jni.typedb_driver.user_delete;
 
 public class UserImpl extends NativeObject<com.typedb.driver.jni.User> implements User {
     private final UserManagerImpl users;
@@ -50,7 +51,7 @@ public class UserImpl extends NativeObject<com.typedb.driver.jni.User> implement
     @Override
     public void updatePassword(String password) {
         try {
-            user_update_password(nativeObject, users.nativeDriver, password);
+            user_update_password(nativeObject, password);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/java/user/UserManagerImpl.java
+++ b/java/user/UserManagerImpl.java
@@ -39,16 +39,7 @@ public class UserManagerImpl implements UserManager {
     public UserManagerImpl(com.typedb.driver.jni.TypeDBDriver driver) {
         nativeDriver = driver;
     }
-
-    @Override
-    public String getCurrentUsername() {
-        try { // TODO: Make noexcept if we leave it returning just a String
-            return users_current_username(nativeDriver);
-        } catch (com.typedb.driver.jni.Error e) {
-            throw new TypeDBDriverException(e);
-        }
-    }
-
+    
     @Override
     public boolean contains(String username) {
         try {

--- a/java/user/UserManagerImpl.java
+++ b/java/user/UserManagerImpl.java
@@ -61,15 +61,6 @@ public class UserManagerImpl implements UserManager {
     }
 
     @Override
-    public void delete(String username) {
-        try {
-            users_delete(nativeDriver, username);
-        } catch (com.typedb.driver.jni.Error e) {
-            throw new TypeDBDriverException(e);
-        }
-    }
-
-    @Override
     public User get(String username) {
         try {
             com.typedb.driver.jni.User user = users_get(nativeDriver, username);

--- a/java/user/UserManagerImpl.java
+++ b/java/user/UserManagerImpl.java
@@ -43,18 +43,18 @@ public class UserManagerImpl implements UserManager {
     }
 
     @Override
-    public boolean contains(String username) {
-        try {
-            return users_contains(nativeDriver, username);
+    public String getCurrentUsername() {
+        try { // TODO: Make noexcept if we leave it returning just a String
+            return users_current_username(nativeDriver);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }
     }
 
     @Override
-    public void create(String username, String password) {
+    public boolean contains(String username) {
         try {
-            users_create(nativeDriver, username, password);
+            return users_contains(nativeDriver, username);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }
@@ -72,15 +72,6 @@ public class UserManagerImpl implements UserManager {
     }
 
     @Override
-    public String getCurrentUsername() {
-        try { // TODO: Make noexcept if we leave it returning just a String
-            return users_current_username(nativeDriver);
-        } catch (com.typedb.driver.jni.Error e) {
-            throw new TypeDBDriverException(e);
-        }
-    }
-
-    @Override
     public Set<User> all() {
         try {
             return new NativeIterator<>(users_all(nativeDriver)).stream().map(user -> new UserImpl(user, this)).collect(Collectors.toSet());
@@ -90,9 +81,9 @@ public class UserManagerImpl implements UserManager {
     }
 
     @Override
-    public void setPassword(String username, String password) {
+    public void create(String username, String password) {
         try {
-            users_set_password(nativeDriver, username, password);
+            users_create(nativeDriver, username, password);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/java/user/UserManagerImpl.java
+++ b/java/user/UserManagerImpl.java
@@ -31,9 +31,7 @@ import static com.typedb.driver.jni.typedb_driver.users_all;
 import static com.typedb.driver.jni.typedb_driver.users_contains;
 import static com.typedb.driver.jni.typedb_driver.users_create;
 import static com.typedb.driver.jni.typedb_driver.users_current_username;
-import static com.typedb.driver.jni.typedb_driver.users_delete;
 import static com.typedb.driver.jni.typedb_driver.users_get;
-import static com.typedb.driver.jni.typedb_driver.users_set_password;
 
 public class UserManagerImpl implements UserManager {
     com.typedb.driver.jni.TypeDBDriver nativeDriver;

--- a/python/tests/behaviour/background/core/environment.py
+++ b/python/tests/behaviour/background/core/environment.py
@@ -65,7 +65,7 @@ def after_scenario(context: Context, scenario):
     for user in context.driver.users.all():
         if user.name == "admin":
             continue
-        context.driver.users.delete(user.name)
+        context.driver.users.get(user.name).delete()
     context.driver.close()
 
 

--- a/python/tests/behaviour/connection/user/user_steps.py
+++ b/python/tests/behaviour/connection/user/user_steps.py
@@ -56,21 +56,15 @@ def step_impl(context: Context, user: str, name: str):
 def step_impl(context: Context, username: str, password: str, may_error: MayError):
     may_error.check(lambda: context.driver.users.create(username, password))
 
-
-@step("get user({username:NonSemicolon}) set password: {password:NonSemicolon}{may_error:MayError}")
-def step_impl(context: Context, username: str, password: str, may_error: MayError):
-    may_error.check(lambda: context.driver.users.set_password(username, password))
-
-
 @step(
     "get user({username:NonSemicolon}) update password to '{password_new:NonSemicolon}'{may_error:MayError}")
 def step_impl(context: Context, username: str, password_new: str, may_error: MayError):
-    may_error.check(lambda: context.driver.users.set_password(username, password_new))
+    may_error.check(lambda: context.driver.users.get(username).update_password(username, password_new))
 
 
 @step("delete user: {username:NonSemicolon}{may_error:MayError}")
 def step_impl(context: Context, username: str, may_error: MayError):
-    may_error.check(lambda: context.driver.users.delete(username))
+    may_error.check(lambda: context.driver.users.get(username).delete())
 
 
 @step("get current username: {username:NonSemicolon}")

--- a/python/tests/behaviour/connection/user/user_steps.py
+++ b/python/tests/behaviour/connection/user/user_steps.py
@@ -57,9 +57,9 @@ def step_impl(context: Context, username: str, password: str, may_error: MayErro
     may_error.check(lambda: context.driver.users.create(username, password))
 
 @step(
-    "get user({username:NonSemicolon}) update password to '{password_new:NonSemicolon}'{may_error:MayError}")
-def step_impl(context: Context, username: str, password_new: str, may_error: MayError):
-    may_error.check(lambda: context.driver.users.get(username).update_password(username, password_new))
+    "get user({username:NonSemicolon}) update password to '{password:NonSemicolon}'{may_error:MayError}")
+def step_impl(context: Context, username: str, password: str, may_error: MayError):
+    may_error.check(lambda: context.driver.users.get(username).update_password(password))
 
 
 @step("delete user: {username:NonSemicolon}{may_error:MayError}")

--- a/python/typedb/api/user/user.py
+++ b/python/typedb/api/user/user.py
@@ -43,7 +43,7 @@ class User(ABC):
     #     pass
 
     @abstractmethod
-    def update_password(self, password_old: str, password_new: str) -> None:
+    def update_password(self, password: str) -> None:
         """
         Updates the password for this user.
 
@@ -53,6 +53,21 @@ class User(ABC):
         """
         pass
 
+    @abstractmethod
+    def delete(self) -> None:
+        """
+        Deletes a user with the given name.
+
+        :param username: The name of the user to be deleted
+        :return:
+
+        Examples:
+        ---------
+        ::
+
+           driver.users.delete(username)
+        """
+        pass
 
 class UserManager(ABC):
     """
@@ -89,22 +104,6 @@ class UserManager(ABC):
         ::
 
            driver.users.create(username, password)
-        """
-        pass
-
-    @abstractmethod
-    def delete(self, username: str) -> None:
-        """
-        Deletes a user with the given name.
-
-        :param username: The name of the user to be deleted
-        :return:
-
-        Examples:
-        ---------
-        ::
-
-           driver.users.delete(username)
         """
         pass
 
@@ -152,22 +151,5 @@ class UserManager(ABC):
 
            driver.users.all()
 
-        """
-        pass
-
-    @abstractmethod
-    def set_password(self, username: str, password: str) -> None:
-        """
-        Sets a new password for a user. This operation can only be performed by administrators.
-
-        :param username: The name of the user to set the password of
-        :param password: The new password
-        :return:
-
-        Examples:
-        ---------
-        ::
-
-           driver.users.set_password(username, password)
         """
         pass

--- a/python/typedb/user/user.py
+++ b/python/typedb/user/user.py
@@ -57,6 +57,6 @@ class _User(User, NativeWrapper[NativeUser]):
 
     def delete(self) -> None:
         try:
-            user_delete(self.native_driver, username)
+            user_delete(self.native_object)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None

--- a/python/typedb/user/user.py
+++ b/python/typedb/user/user.py
@@ -57,6 +57,6 @@ class _User(User, NativeWrapper[NativeUser]):
 
     def delete(self) -> None:
         try:
-            users_delete(self.native_driver, username)
+            user_delete(self.native_driver, username)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None

--- a/python/typedb/user/user.py
+++ b/python/typedb/user/user.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING
 from typedb.api.user.user import User
 from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE
 from typedb.common.native_wrapper import NativeWrapper
-from typedb.native_driver_wrapper import user_get_name, user_update_password, User as NativeUser, \
+from typedb.native_driver_wrapper import user_get_name, user_update_password, user_delete, User as NativeUser, \
     TypeDBDriverExceptionNative
 
 if TYPE_CHECKING:
@@ -49,8 +49,14 @@ class _User(User, NativeWrapper[NativeUser]):
     #         return res
     #     return None
 
-    def update_password(self, password_old: str, password_new: str) -> None:
+    def update_password(self, password: str) -> None:
         try:
-            user_update_password(self.native_object, self._user_manager.native_object, password_old, password_new)
+            user_update_password(self.native_object, password)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e) from None
+
+    def delete(self) -> None:
+        try:
+            users_delete(self.native_driver, username)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None

--- a/python/typedb/user/user_manager.py
+++ b/python/typedb/user/user_manager.py
@@ -22,8 +22,8 @@ from typing import TYPE_CHECKING, Optional
 from typedb.api.user.user import UserManager
 from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
-from typedb.native_driver_wrapper import users_contains, users_create, users_delete, users_all, users_get, \
-    users_set_password, users_current_username, user_iterator_next, TypeDBDriverExceptionNative
+from typedb.native_driver_wrapper import users_contains, users_create, users_all, users_get, \
+    users_current_username, user_iterator_next, TypeDBDriverExceptionNative
 from typedb.user.user import _User
 
 if TYPE_CHECKING:
@@ -48,12 +48,6 @@ class _UserManager(UserManager):
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 
-    def delete(self, username: str) -> None:
-        try:
-            users_delete(self.native_driver, username)
-        except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e) from None
-
     def all(self) -> list[User]:
         try:
             return [_User(user, self) for user in IteratorWrapper(users_all(self.native_driver), user_iterator_next)]
@@ -65,12 +59,6 @@ class _UserManager(UserManager):
             if user := users_get(self.native_driver, username):
                 return _User(user, self)
             return None
-        except TypeDBDriverExceptionNative as e:
-            raise TypeDBDriverException.of(e) from None
-
-    def set_password(self, username: str, password: str) -> None:
-        try:
-            users_set_password(self.native_driver, username, password)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 

--- a/rust/src/common/info.rs
+++ b/rust/src/common/info.rs
@@ -38,3 +38,9 @@ pub struct ReplicaInfo {
     /// The raft protocol ‘term’ of this replica.
     pub term: i64,
 }
+
+#[derive(Debug)]
+pub(crate) struct UserInfo {
+    pub(crate) name: String,
+    pub(crate) password: Option<String>,
+}

--- a/rust/src/connection/message.rs
+++ b/rust/src/connection/message.rs
@@ -33,10 +33,10 @@ use crate::{
     common::{address::Address, info::DatabaseInfo, RequestID},
     concept::Concept,
     error::ServerError,
+    info::UserInfo,
     user::User,
     Options, TransactionType,
 };
-use crate::info::UserInfo;
 
 #[derive(Debug)]
 pub(super) enum Request {

--- a/rust/src/connection/message.rs
+++ b/rust/src/connection/message.rs
@@ -36,6 +36,7 @@ use crate::{
     user::User,
     Options, TransactionType,
 };
+use crate::info::UserInfo;
 
 #[derive(Debug)]
 pub(super) enum Request {
@@ -57,8 +58,8 @@ pub(super) enum Request {
     UsersAll,
     UsersGet { name: String },
     UsersContains { name: String },
-    UsersCreate { user: User },
-    UsersUpdate { username: String, user: User },
+    UsersCreate { user: UserInfo },
+    UsersUpdate { username: String, user: UserInfo },
     UsersDelete { name: String },
 }
 
@@ -105,7 +106,7 @@ pub(super) enum Response {
     },
 
     UsersAll {
-        users: Vec<User>,
+        users: Vec<UserInfo>,
     },
     UsersContain {
         contains: bool,
@@ -114,7 +115,7 @@ pub(super) enum Response {
     UsersUpdate,
     UsersDelete,
     UsersGet {
-        user: Option<User>,
+        user: Option<UserInfo>,
     },
 }
 

--- a/rust/src/connection/network/proto/message.rs
+++ b/rust/src/connection/network/proto/message.rs
@@ -30,9 +30,9 @@ use crate::{
     common::{info::DatabaseInfo, RequestID, Result},
     connection::message::{QueryRequest, QueryResponse, Request, Response, TransactionRequest, TransactionResponse},
     error::{ConnectionError, InternalError, ServerError},
+    info::UserInfo,
     user::User,
 };
-use crate::info::UserInfo;
 
 impl TryIntoProto<connection::open::Req> for Request {
     fn try_into_proto(self) -> Result<connection::open::Req> {

--- a/rust/src/connection/network/proto/message.rs
+++ b/rust/src/connection/network/proto/message.rs
@@ -32,6 +32,7 @@ use crate::{
     error::{ConnectionError, InternalError, ServerError},
     user::User,
 };
+use crate::info::UserInfo;
 
 impl TryIntoProto<connection::open::Req> for Request {
     fn try_into_proto(self) -> Result<connection::open::Req> {
@@ -380,13 +381,13 @@ impl FromProto<typedb_protocol::Error> for QueryResponse {
 
 impl FromProto<user_manager::all::Res> for Response {
     fn from_proto(proto: user_manager::all::Res) -> Self {
-        Self::UsersAll { users: proto.users.into_iter().map(User::from_proto).collect() }
+        Self::UsersAll { users: proto.users.into_iter().map(UserInfo::from_proto).collect() }
     }
 }
 
 impl FromProto<user_manager::get::Res> for Response {
     fn from_proto(proto: user_manager::get::Res) -> Self {
-        Self::UsersGet { user: proto.user.map(User::from_proto) }
+        Self::UsersGet { user: proto.user.map(UserInfo::from_proto) }
     }
 }
 

--- a/rust/src/connection/network/proto/user.rs
+++ b/rust/src/connection/network/proto/user.rs
@@ -18,11 +18,10 @@
  */
 
 use typedb_protocol::User as UserProto;
-
+use crate::info::UserInfo;
 use super::FromProto;
-use crate::user::User;
 
-impl FromProto<UserProto> for User {
+impl FromProto<UserProto> for UserInfo {
     fn from_proto(proto: UserProto) -> Self {
         let UserProto { name, password } = proto;
         Self { name, password }

--- a/rust/src/connection/network/proto/user.rs
+++ b/rust/src/connection/network/proto/user.rs
@@ -18,8 +18,9 @@
  */
 
 use typedb_protocol::User as UserProto;
-use crate::info::UserInfo;
+
 use super::FromProto;
+use crate::info::UserInfo;
 
 impl FromProto<UserProto> for UserInfo {
     fn from_proto(proto: UserProto) -> Self {

--- a/rust/src/connection/server_connection.rs
+++ b/rust/src/connection/server_connection.rs
@@ -42,6 +42,7 @@ use crate::{
     info::DatabaseInfo,
     ConnectionSettings, Credential, Options, TransactionType, User,
 };
+use crate::info::UserInfo;
 
 #[derive(Clone)]
 pub(crate) struct ServerConnection {
@@ -238,7 +239,7 @@ impl ServerConnection {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub(crate) async fn all_users(&self) -> crate::Result<Vec<User>> {
+    pub(crate) async fn all_users(&self) -> crate::Result<Vec<UserInfo>> {
         match self.request(Request::UsersAll).await? {
             Response::UsersAll { users } => Ok(users),
             other => Err(InternalError::UnexpectedResponseType { response_type: format!("{other:?}") }.into()),
@@ -246,7 +247,7 @@ impl ServerConnection {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub(crate) async fn get_user(&self, name: String) -> crate::Result<Option<User>> {
+    pub(crate) async fn get_user(&self, name: String) -> crate::Result<Option<UserInfo>> {
         match self.request(Request::UsersGet { name }).await? {
             Response::UsersGet { user } => Ok(user),
             other => Err(InternalError::UnexpectedResponseType { response_type: format!("{other:?}") }.into()),
@@ -266,7 +267,7 @@ impl ServerConnection {
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub(crate) async fn create_user(&self, name: String, password: String) -> crate::Result {
-        match self.request(Request::UsersCreate { user: User { name, password: Some(password) } }).await? {
+        match self.request(Request::UsersCreate {user: UserInfo { name, password: Some(password) } }).await? {
             Response::UsersCreate => Ok(()),
             other => Err(InternalError::UnexpectedResponseType { response_type: format!("{other:?}") }.into()),
         }
@@ -277,7 +278,7 @@ impl ServerConnection {
         match self
             .request(Request::UsersUpdate {
                 username: name,
-                user: User { name: "".to_string(), password: Some(password) }, // TODO: make 'name' optional
+                user: UserInfo { name: "".to_string(), password: Some(password) }, // TODO: make 'name' optional
             })
             .await?
         {

--- a/rust/src/connection/server_connection.rs
+++ b/rust/src/connection/server_connection.rs
@@ -39,10 +39,9 @@ use crate::{
         TransactionStream,
     },
     error::{ConnectionError, InternalError},
-    info::DatabaseInfo,
+    info::{DatabaseInfo, UserInfo},
     ConnectionSettings, Credential, Options, TransactionType, User,
 };
-use crate::info::UserInfo;
 
 #[derive(Clone)]
 pub(crate) struct ServerConnection {
@@ -267,7 +266,7 @@ impl ServerConnection {
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub(crate) async fn create_user(&self, name: String, password: String) -> crate::Result {
-        match self.request(Request::UsersCreate {user: UserInfo { name, password: Some(password) } }).await? {
+        match self.request(Request::UsersCreate { user: UserInfo { name, password: Some(password) } }).await? {
             Response::UsersCreate => Ok(()),
             other => Err(InternalError::UnexpectedResponseType { response_type: format!("{other:?}") }.into()),
         }

--- a/rust/src/user/user.rs
+++ b/rust/src/user/user.rs
@@ -16,12 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-use std::collections::HashMap;
-use std::sync::Arc;
-use crate::common::address::Address;
-use crate::connection::server_connection::ServerConnection;
-use crate::common::Result;
-use crate::error::ConnectionError;
+use std::{collections::HashMap, sync::Arc};
+
+use crate::{
+    common::{address::Address, Result},
+    connection::server_connection::ServerConnection,
+    error::ConnectionError,
+};
 
 #[derive(Clone, Debug)]
 pub struct User {
@@ -31,8 +32,6 @@ pub struct User {
 }
 
 impl User {
-
-
     /// Update the user's password.
     ///
     /// # Arguments

--- a/rust/src/user/user.rs
+++ b/rust/src/user/user.rs
@@ -31,6 +31,35 @@ pub struct User {
 }
 
 impl User {
+
+
+    /// Update the user's password.
+    ///
+    /// # Arguments
+    ///
+    /// * `username` — The name of the user
+    /// * `password` — The new password
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    #[cfg_attr(feature = "sync", doc = "user.update_password(username, password);")]
+    #[cfg_attr(not(feature = "sync"), doc = "user.update_password(username, password).await;")]
+    /// user.update_password(username, password).await;
+    /// ```
+    #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
+    pub async fn update_password(self, password: impl Into<String>) -> Result<()> {
+        let password = password.into();
+        let mut error_buffer = Vec::with_capacity(self.server_connections.len());
+        for (server_id, server_connection) in self.server_connections.iter() {
+            match server_connection.update_password(self.name.clone(), password.clone()).await {
+                Ok(res) => return Ok(()),
+                Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
+            }
+        }
+        Err(ConnectionError::ServerConnectionFailedWithError { error: error_buffer.join("\n") })?
+    }
+
     /// Deletes this user
     ///
     /// * `username` — The name of the user to be deleted
@@ -40,7 +69,7 @@ impl User {
     /// ```rust
     #[cfg_attr(feature = "sync", doc = "user.delete();")]
     #[cfg_attr(not(feature = "sync"), doc = "user.delete().await;")]
-    /// driver.users.delete(username).await;
+    /// user.delete(username).await;
     /// ```
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn delete(self) -> Result {

--- a/rust/src/user/user.rs
+++ b/rust/src/user/user.rs
@@ -16,9 +16,41 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+use std::collections::HashMap;
+use std::sync::Arc;
+use crate::common::address::Address;
+use crate::connection::server_connection::ServerConnection;
+use crate::common::Result;
+use crate::error::ConnectionError;
 
 #[derive(Clone, Debug)]
 pub struct User {
     pub name: String,
     pub password: Option<String>,
+    pub server_connections: HashMap<Address, ServerConnection>,
+}
+
+impl User {
+    /// Deletes this user
+    ///
+    /// * `username` — The name of the user to be deleted
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    #[cfg_attr(feature = "sync", doc = "user.delete();")]
+    #[cfg_attr(not(feature = "sync"), doc = "user.delete().await;")]
+    /// driver.users.delete(username).await;
+    /// ```
+    #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
+    pub async fn delete(self) -> Result {
+        let mut error_buffer = Vec::with_capacity(self.server_connections.len());
+        for (server_id, server_connection) in self.server_connections.iter() {
+            match server_connection.delete_user(self.name.clone()).await {
+                Ok(res) => return Ok(res),
+                Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
+            }
+        }
+        Err(ConnectionError::ServerConnectionFailedWithError { error: error_buffer.join("\n") })?
+    }
 }

--- a/rust/src/user/user.rs
+++ b/rust/src/user/user.rs
@@ -48,7 +48,7 @@ impl User {
     /// user.update_password(username, password).await;
     /// ```
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub async fn update_password(self, password: impl Into<String>) -> Result<()> {
+    pub async fn update_password(&self, password: impl Into<String>) -> Result<()> {
         let password = password.into();
         let mut error_buffer = Vec::with_capacity(self.server_connections.len());
         for (server_id, server_connection) in self.server_connections.iter() {

--- a/rust/src/user/user_manager.rs
+++ b/rust/src/user/user_manager.rs
@@ -141,30 +141,4 @@ impl UserManager {
         }
         Err(ConnectionError::ServerConnectionFailedWithError { error: error_buffer.join("\n") })?
     }
-
-    /// Update the user's password.
-    ///
-    /// # Arguments
-    ///
-    /// * `username` — The name of the user
-    /// * `password` — The new password
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// driver.users.update_password(username, password).await;
-    /// ```
-    #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub async fn update_password(&self, username: impl Into<String>, password: impl Into<String>) -> Result {
-        let username = username.into();
-        let password = password.into();
-        let mut error_buffer = Vec::with_capacity(self.server_connections.len());
-        for (server_id, server_connection) in self.server_connections.iter() {
-            match server_connection.update_password(username.clone(), password.clone()).await {
-                Ok(res) => return Ok(res),
-                Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
-            }
-        }
-        Err(ConnectionError::ServerConnectionFailedWithError { error: error_buffer.join("\n") })?
-    }
 }

--- a/rust/src/user/user_manager.rs
+++ b/rust/src/user/user_manager.rs
@@ -86,7 +86,9 @@ impl UserManager {
         let mut error_buffer = Vec::with_capacity(self.server_connections.len());
         for (server_id, server_connection) in self.server_connections.iter() {
             match server_connection.get_user(uname.clone()).await {
-                Ok(res) => return Ok(res),
+                Ok(res) => return Ok(
+                    res.map(|u_info| User { name: u_info.name, password: u_info.password, server_connections: self.server_connections.clone() }))
+                ,
                 Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
             }
         }
@@ -105,7 +107,9 @@ impl UserManager {
         let mut error_buffer = Vec::with_capacity(self.server_connections.len());
         for (server_id, server_connection) in self.server_connections.iter() {
             match server_connection.all_users().await {
-                Ok(res) => return Ok(res),
+                Ok(res) => return Ok(
+                    res.iter().map(|u_info| User { name: u_info.name.clone(), password: u_info.password.clone(), server_connections: self.server_connections.clone() }).collect()
+                ),
                 Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
             }
         }
@@ -157,30 +161,6 @@ impl UserManager {
         let mut error_buffer = Vec::with_capacity(self.server_connections.len());
         for (server_id, server_connection) in self.server_connections.iter() {
             match server_connection.update_password(username.clone(), password.clone()).await {
-                Ok(res) => return Ok(res),
-                Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
-            }
-        }
-        Err(ConnectionError::ServerConnectionFailedWithError { error: error_buffer.join("\n") })?
-    }
-
-    /// Deletes a user with the given name.
-    ///
-    /// # Arguments
-    ///
-    /// * `username` — The name of the user to be deleted
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// driver.users.delete(username).await;
-    /// ```
-    #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub async fn delete(&self, username: impl Into<String>) -> Result {
-        let uname = username.into();
-        let mut error_buffer = Vec::with_capacity(self.server_connections.len());
-        for (server_id, server_connection) in self.server_connections.iter() {
-            match server_connection.delete_user(uname.clone()).await {
                 Ok(res) => return Ok(res),
                 Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
             }

--- a/rust/src/user/user_manager.rs
+++ b/rust/src/user/user_manager.rs
@@ -86,9 +86,13 @@ impl UserManager {
         let mut error_buffer = Vec::with_capacity(self.server_connections.len());
         for (server_id, server_connection) in self.server_connections.iter() {
             match server_connection.get_user(uname.clone()).await {
-                Ok(res) => return Ok(
-                    res.map(|u_info| User { name: u_info.name, password: u_info.password, server_connections: self.server_connections.clone() }))
-                ,
+                Ok(res) => {
+                    return Ok(res.map(|u_info| User {
+                        name: u_info.name,
+                        password: u_info.password,
+                        server_connections: self.server_connections.clone(),
+                    }))
+                }
                 Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
             }
         }
@@ -107,9 +111,16 @@ impl UserManager {
         let mut error_buffer = Vec::with_capacity(self.server_connections.len());
         for (server_id, server_connection) in self.server_connections.iter() {
             match server_connection.all_users().await {
-                Ok(res) => return Ok(
-                    res.iter().map(|u_info| User { name: u_info.name.clone(), password: u_info.password.clone(), server_connections: self.server_connections.clone() }).collect()
-                ),
+                Ok(res) => {
+                    return Ok(res
+                        .iter()
+                        .map(|u_info| User {
+                            name: u_info.name.clone(),
+                            password: u_info.password.clone(),
+                            server_connections: self.server_connections.clone(),
+                        })
+                        .collect())
+                }
                 Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
             }
         }

--- a/rust/tests/behaviour/steps/connection/user.rs
+++ b/rust/tests/behaviour/steps/connection/user.rs
@@ -81,9 +81,9 @@ async fn get_user_update_password(
     let driver = context.driver.as_ref().unwrap();
     let get_user_result = driver.users().get(username);
     let update_password_result = get_user_result
-        .and_then(|user_opt| {
+        .and_then(|user_opt| async move {
             let user = user_opt.unwrap();
-            user.update_password(password)
+            user.update_password(password).await
         }).await;
     may_error.check(update_password_result);
 }

--- a/rust/tests/behaviour/steps/connection/user.rs
+++ b/rust/tests/behaviour/steps/connection/user.rs
@@ -20,10 +20,10 @@
 use std::collections::HashSet;
 
 use cucumber::{gherkin::Step, given, then, when};
+use futures::TryFutureExt;
 use macro_rules_attribute::apply;
 use tokio::time::sleep;
 use typedb_driver::{Database, Result as TypeDBResult, TypeDBDriver, User};
-use futures::TryFutureExt;
 
 use crate::{assert_err, assert_with_timeout, generic_step, params, util::iter_table, Context};
 
@@ -84,7 +84,8 @@ async fn get_user_update_password(
         .and_then(|user_opt| async move {
             let user = user_opt.unwrap();
             user.update_password(password).await
-        }).await;
+        })
+        .await;
     may_error.check(update_password_result);
 }
 
@@ -92,9 +93,7 @@ async fn get_user_update_password(
 #[step(expr = "delete user: {word}{may_error}")]
 async fn delete_user(context: &mut Context, username: String, may_error: params::MayError) {
     may_error.check(
-        context.driver.as_ref().unwrap()
-            .users().get(username)
-            .and_then(|user_opt| user_opt.unwrap().delete()).await
+        context.driver.as_ref().unwrap().users().get(username).and_then(|user_opt| user_opt.unwrap().delete()).await,
     );
 }
 

--- a/rust/tests/behaviour/steps/connection/user.rs
+++ b/rust/tests/behaviour/steps/connection/user.rs
@@ -22,7 +22,8 @@ use std::collections::HashSet;
 use cucumber::{gherkin::Step, given, then, when};
 use macro_rules_attribute::apply;
 use tokio::time::sleep;
-use typedb_driver::Result as TypeDBResult;
+use typedb_driver::{Database, Result as TypeDBResult, TypeDBDriver, User};
+use futures::TryFutureExt;
 
 use crate::{assert_err, assert_with_timeout, generic_step, params, util::iter_table, Context};
 
@@ -83,7 +84,11 @@ async fn get_user_update_password(
 #[apply(generic_step)]
 #[step(expr = "delete user: {word}{may_error}")]
 async fn delete_user(context: &mut Context, username: String, may_error: params::MayError) {
-    may_error.check(context.driver.as_ref().unwrap().users().delete(username).await);
+    may_error.check(
+        context.driver.as_ref().unwrap()
+            .users().get(username)
+            .and_then(|user_opt| user_opt.unwrap().delete()).await
+    );
 }
 
 #[apply(generic_step)]

--- a/rust/tests/behaviour/steps/connection/user.rs
+++ b/rust/tests/behaviour/steps/connection/user.rs
@@ -78,7 +78,14 @@ async fn get_user_update_password(
     password: String,
     may_error: params::MayError,
 ) {
-    may_error.check(context.driver.as_ref().unwrap().users().update_password(username, password).await);
+    let driver = context.driver.as_ref().unwrap();
+    let get_user_result = driver.users().get(username);
+    let update_password_result = get_user_result
+        .and_then(|user_opt| {
+            let user = user_opt.unwrap();
+            user.update_password(password)
+        }).await;
+    may_error.check(update_password_result);
 }
 
 #[apply(generic_step)]

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -222,7 +222,7 @@ impl Context {
                 .unwrap()
                 .into_iter()
                 .filter(|user| user.name != Context::ADMIN_USERNAME)
-                .map(|user| self.driver.as_ref().unwrap().users().delete(user.name)),
+                .map(|user| user.delete()),
         )
         .await
         .expect("Expected users cleanup");


### PR DESCRIPTION
## Usage and product changes
The user update and delete API has been moved from the `UserManager` to the `User` object, removing inconsistency in style between user and database management APIs.

## Implementation
- Make `User` object contains server connections (which makes it "stateful" as a consequence)
- Introduce `UserInfo` object as a "stateless" representation of the user object 
- Move Rust user update API into the user object
- Move Rust user deletion API into the user object
- Update Rust BDD tests accordingly
- Propagate all changes above into Java and Python drivers