### PR TITLE
Remove system database workaround

### DIFF
--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "4237d1429d7f97e709a3b1ddc2c30ce3c3b792a0"
+        commit = "e9b255fa3eb05610c18899d1cac76dbac0f69492"
     )
 
 #def typedb_cloud_artifact():

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "e9b255fa3eb05610c18899d1cac76dbac0f69492"
+        commit = "464db06d733b6aaf29dc5b087f5c38b448039a68"
     )
 
 #def typedb_cloud_artifact():

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -88,8 +88,6 @@ public abstract class ConnectionStepsBase {
         cleanupTransactions();
 
         driver = createDefaultTypeDBDriver();
-        // TODO: A temporary filter hack before we hide the system db
-        driver.databases().all().stream().filter(db -> !db.name().equals("system")).forEach(Database::delete);
         driver.users().all().stream().filter(user -> !user.name().equals(ADMIN_USERNAME)).forEach(user -> driver.users().delete(user.name()));
         // TODO: Set admin password to default
         driver.close();

--- a/python/tests/behaviour/background/core/environment.py
+++ b/python/tests/behaviour/background/core/environment.py
@@ -61,8 +61,6 @@ def after_scenario(context: Context, scenario):
     # TODO: reset the database through the TypeDB runner once it exists
     context.setup_context_driver_fn()
     for database in context.driver.databases.all():
-        if database.name == "system":  # Temporary hack for system database
-            continue
         database.delete()
     for user in context.driver.users.all():
         if user.name == "admin":

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -197,19 +197,9 @@ impl Context {
     }
 
     pub async fn cleanup_databases(&mut self) {
-        try_join_all(
-            self.driver
-                .as_ref()
-                .unwrap()
-                .databases()
-                .all()
-                .await
-                .unwrap()
-                .into_iter()
-                .map(|db| db.delete()),
-        )
-        .await
-        .unwrap();
+        try_join_all(self.driver.as_ref().unwrap().databases().all().await.unwrap().into_iter().map(|db| db.delete()))
+            .await
+            .unwrap();
     }
 
     pub async fn cleanup_transactions(&mut self) {

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -206,7 +206,6 @@ impl Context {
                 .await
                 .unwrap()
                 .into_iter()
-                .filter(|db| db.name() != "system") // TODO: A temporary hack before we hide the system db
                 .map(|db| db.delete()),
         )
         .await


### PR DESCRIPTION
## Usage and product changes

Remove workaround logic in Rust, Java, and Python tests following an update in TypeDB Core server, in which the `_system` database is now properly hidden

## Implementation
