### PR TITLE
Rename 'Credential' and 'ConnectionSettings'

### DIFF
--- a/c/src/connection.rs
+++ b/c/src/connection.rs
@@ -20,7 +20,7 @@
 use std::{ffi::c_char, path::Path};
 
 use itertools::Itertools;
-use typedb_driver::{ConnectionSettings, Credential, TypeDBDriver};
+use typedb_driver::{ConnectionSettings, Credentials, TypeDBDriver};
 
 use super::{
     error::{try_release, unwrap_void},
@@ -37,7 +37,7 @@ use crate::memory::{release, string_array_view};
 #[no_mangle]
 pub extern "C" fn driver_open_core(
     address: *const c_char,
-    credential: *const Credential,
+    credential: *const Credentials,
     connection_settings: *const ConnectionSettings,
     driver_lang: *const c_char,
 ) -> *mut TypeDBDriver {
@@ -59,7 +59,7 @@ pub extern "C" fn driver_open_core(
 #[no_mangle]
 pub extern "C" fn driver_open_cloud(
     addresses: *const *const c_char,
-    credential: *const Credential,
+    credential: *const Credentials,
     connection_settings: *const ConnectionSettings,
     driver_lang: *const c_char,
 ) -> *mut TypeDBDriver {
@@ -86,7 +86,7 @@ pub extern "C" fn driver_open_cloud(
 pub extern "C" fn driver_open_cloud_translated(
     public_addresses: *const *const c_char,
     private_addresses: *const *const c_char,
-    credential: *const Credential,
+    credential: *const Credentials,
     connection_settings: *const ConnectionSettings,
     driver_lang: *const c_char,
 ) -> *mut TypeDBDriver {
@@ -124,13 +124,13 @@ pub extern "C" fn driver_force_close(driver: *mut TypeDBDriver) {
 // @param username The name of the user to connect as
 // @param password The password for the user
 #[no_mangle]
-pub extern "C" fn credential_new(username: *const c_char, password: *const c_char) -> *mut Credential {
-    release(Credential::new(string_view(username), string_view(password)))
+pub extern "C" fn credential_new(username: *const c_char, password: *const c_char) -> *mut Credentials {
+    release(Credentials::new(string_view(username), string_view(password)))
 }
 
 // Frees the native rust <code>Credential</code> object
 #[no_mangle]
-pub extern "C" fn credential_drop(credential: *mut Credential) {
+pub extern "C" fn credential_drop(credential: *mut Credentials) {
     free(credential);
 }
 

--- a/c/src/connection.rs
+++ b/c/src/connection.rs
@@ -20,7 +20,7 @@
 use std::{ffi::c_char, path::Path};
 
 use itertools::Itertools;
-use typedb_driver::{ConnectionSettings, Credentials, TypeDBDriver};
+use typedb_driver::{DriverOptions, Credentials, TypeDBDriver};
 
 use super::{
     error::{try_release, unwrap_void},
@@ -38,7 +38,7 @@ use crate::memory::{release, string_array_view};
 pub extern "C" fn driver_open_core(
     address: *const c_char,
     credential: *const Credentials,
-    connection_settings: *const ConnectionSettings,
+    connection_settings: *const DriverOptions,
     driver_lang: *const c_char,
 ) -> *mut TypeDBDriver {
     // TODO: Add a separate entry point for C with a provided "c" driver_lang!
@@ -60,7 +60,7 @@ pub extern "C" fn driver_open_core(
 pub extern "C" fn driver_open_cloud(
     addresses: *const *const c_char,
     credential: *const Credentials,
-    connection_settings: *const ConnectionSettings,
+    connection_settings: *const DriverOptions,
     driver_lang: *const c_char,
 ) -> *mut TypeDBDriver {
     // TODO: Add a separate entry point for C with a provided "c" driver_lang!
@@ -87,7 +87,7 @@ pub extern "C" fn driver_open_cloud_translated(
     public_addresses: *const *const c_char,
     private_addresses: *const *const c_char,
     credential: *const Credentials,
-    connection_settings: *const ConnectionSettings,
+    connection_settings: *const DriverOptions,
     driver_lang: *const c_char,
 ) -> *mut TypeDBDriver {
     // TODO: Add a separate entry point for C with a provided "c" driver_lang!
@@ -139,13 +139,13 @@ pub extern "C" fn credential_drop(credential: *mut Credentials) {
 // @param tls_root_ca Path to the CA certificate to use for authenticating server certificates.
 // @param with_tls Specify whether the connection to TypeDB Cloud must be done over TLS
 #[no_mangle]
-pub extern "C" fn connection_settings_new(is_tls_enabled: bool, tls_root_ca: *const c_char) -> *mut ConnectionSettings {
+pub extern "C" fn connection_settings_new(is_tls_enabled: bool, tls_root_ca: *const c_char) -> *mut DriverOptions {
     let tls_root_ca_path = unsafe { tls_root_ca.as_ref().map(|str| Path::new(string_view(str))) };
-    try_release(ConnectionSettings::new(is_tls_enabled, tls_root_ca_path))
+    try_release(DriverOptions::new(is_tls_enabled, tls_root_ca_path))
 }
 
 // Frees the native rust <code>ConnectionSettings</code> object
 #[no_mangle]
-pub extern "C" fn connection_settings_drop(connection_settings: *mut ConnectionSettings) {
+pub extern "C" fn connection_settings_drop(connection_settings: *mut DriverOptions) {
     free(connection_settings);
 }

--- a/rust/src/connection/connection_settings.rs
+++ b/rust/src/connection/connection_settings.rs
@@ -23,12 +23,12 @@ use tonic::transport::{Certificate, ClientTlsConfig};
 
 /// User connection settings for connecting to TypeDB.
 #[derive(Debug, Clone)]
-pub struct ConnectionSettings {
+pub struct DriverOptions {
     is_tls_enabled: bool,
     tls_config: Option<ClientTlsConfig>,
 }
 
-impl ConnectionSettings {
+impl DriverOptions {
     /// Creates a credential with username and password. Specifies the connection must use TLS
     ///
     /// # Arguments

--- a/rust/src/connection/credential.rs
+++ b/rust/src/connection/credential.rs
@@ -21,13 +21,13 @@ use std::fmt;
 
 /// User credentials for connecting to TypeDB
 #[derive(Clone)]
-pub struct Credential {
+pub struct Credentials {
     username: String,
     password: String,
 }
 
 /// User credentials for connecting to TypeDB
-impl Credential {
+impl Credentials {
     /// Creates a credential with username and password.
     ///
     /// # Arguments
@@ -55,7 +55,7 @@ impl Credential {
     }
 }
 
-impl fmt::Debug for Credential {
+impl fmt::Debug for Credentials {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Credential").field("username", &self.username).finish()
     }

--- a/rust/src/connection/mod.rs
+++ b/rust/src/connection/mod.rs
@@ -18,7 +18,7 @@
  */
 
 pub(crate) use self::transaction_stream::TransactionStream;
-pub use self::{connection_settings::ConnectionSettings, credential::Credentials};
+pub use self::{connection_settings::DriverOptions, credential::Credentials};
 
 mod connection_settings;
 mod credential;

--- a/rust/src/connection/mod.rs
+++ b/rust/src/connection/mod.rs
@@ -18,7 +18,7 @@
  */
 
 pub(crate) use self::transaction_stream::TransactionStream;
-pub use self::{connection_settings::ConnectionSettings, credential::Credential};
+pub use self::{connection_settings::ConnectionSettings, credential::Credentials};
 
 mod connection_settings;
 mod credential;

--- a/rust/src/connection/network/channel.rs
+++ b/rust/src/connection/network/channel.rs
@@ -32,7 +32,7 @@ use tonic::{
 
 use crate::{
     common::{address::Address, Result, StdResult},
-    ConnectionSettings, Credentials,
+    DriverOptions, Credentials,
 };
 
 type ResponseFuture = InterceptorResponseFuture<ChannelResponseFuture>;
@@ -49,7 +49,7 @@ impl GRPCChannel for CallCredChannel {}
 pub(super) fn open_callcred_channel(
     address: Address,
     credential: Credentials,
-    connection_settings: ConnectionSettings,
+    connection_settings: DriverOptions,
 ) -> Result<(CallCredChannel, Arc<CallCredentials>)> {
     let mut builder = Channel::builder(address.into_uri());
     if connection_settings.is_tls_enabled() {

--- a/rust/src/connection/network/channel.rs
+++ b/rust/src/connection/network/channel.rs
@@ -32,7 +32,7 @@ use tonic::{
 
 use crate::{
     common::{address::Address, Result, StdResult},
-    ConnectionSettings, Credential,
+    ConnectionSettings, Credentials,
 };
 
 type ResponseFuture = InterceptorResponseFuture<ChannelResponseFuture>;
@@ -48,7 +48,7 @@ impl GRPCChannel for CallCredChannel {}
 
 pub(super) fn open_callcred_channel(
     address: Address,
-    credential: Credential,
+    credential: Credentials,
     connection_settings: ConnectionSettings,
 ) -> Result<(CallCredChannel, Arc<CallCredentials>)> {
     let mut builder = Channel::builder(address.into_uri());
@@ -64,11 +64,11 @@ pub(super) fn open_callcred_channel(
 
 #[derive(Debug)]
 pub(super) struct CallCredentials {
-    credential: Credential,
+    credential: Credentials,
 }
 
 impl CallCredentials {
-    pub(super) fn new(credential: Credential) -> Self {
+    pub(super) fn new(credential: Credentials) -> Self {
         Self { credential }
     }
 

--- a/rust/src/connection/network/transmitter/rpc.rs
+++ b/rust/src/connection/network/transmitter/rpc.rs
@@ -39,7 +39,7 @@ use crate::{
         },
         runtime::BackgroundRuntime,
     },
-    ConnectionSettings, Credential, Error,
+    ConnectionSettings, Credentials, Error,
 };
 
 pub(in crate::connection) struct RPCTransmitter {
@@ -50,7 +50,7 @@ pub(in crate::connection) struct RPCTransmitter {
 impl RPCTransmitter {
     pub(in crate::connection) fn start(
         address: Address,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
         runtime: &BackgroundRuntime,
     ) -> Result<Self> {

--- a/rust/src/connection/network/transmitter/rpc.rs
+++ b/rust/src/connection/network/transmitter/rpc.rs
@@ -39,7 +39,7 @@ use crate::{
         },
         runtime::BackgroundRuntime,
     },
-    ConnectionSettings, Credentials, Error,
+    DriverOptions, Credentials, Error,
 };
 
 pub(in crate::connection) struct RPCTransmitter {
@@ -51,7 +51,7 @@ impl RPCTransmitter {
     pub(in crate::connection) fn start(
         address: Address,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
         runtime: &BackgroundRuntime,
     ) -> Result<Self> {
         let (request_sink, request_source) = unbounded_async();

--- a/rust/src/connection/server_connection.rs
+++ b/rust/src/connection/server_connection.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     error::{ConnectionError, InternalError},
     info::DatabaseInfo,
-    ConnectionSettings, Credentials, Options, TransactionType, User,
+    DriverOptions, Credentials, Options, TransactionType, User,
 };
 
 #[derive(Clone)]
@@ -59,7 +59,7 @@ impl ServerConnection {
         background_runtime: Arc<BackgroundRuntime>,
         address: Address,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
         driver_lang: &str,
         driver_version: &str,
     ) -> crate::Result<(Self, Vec<DatabaseInfo>)> {

--- a/rust/src/connection/server_connection.rs
+++ b/rust/src/connection/server_connection.rs
@@ -40,7 +40,7 @@ use crate::{
     },
     error::{ConnectionError, InternalError},
     info::DatabaseInfo,
-    ConnectionSettings, Credential, Options, TransactionType, User,
+    ConnectionSettings, Credentials, Options, TransactionType, User,
 };
 
 #[derive(Clone)]
@@ -58,7 +58,7 @@ impl ServerConnection {
     pub(crate) async fn new_core(
         background_runtime: Arc<BackgroundRuntime>,
         address: Address,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
         driver_lang: &str,
         driver_version: &str,
@@ -83,7 +83,7 @@ impl ServerConnection {
     pub(crate) fn new_cloud(
         background_runtime: Arc<BackgroundRuntime>,
         address: Address,
-        credential: Credential,
+        credential: Credentials,
     ) -> crate::Result<Self> {
         todo!()
         // let request_transmitter = Arc::new(RPCTransmitter::start(address, credential, &background_runtime)?);

--- a/rust/src/driver.rs
+++ b/rust/src/driver.rs
@@ -32,7 +32,7 @@ use crate::{
         Result,
     },
     connection::{runtime::BackgroundRuntime, server_connection::ServerConnection},
-    ConnectionSettings, Credential, DatabaseManager, Options, Transaction, TransactionType, UserManager,
+    ConnectionSettings, Credentials, DatabaseManager, Options, Transaction, TransactionType, UserManager,
 };
 
 /// A connection to a TypeDB server which serves as the starting point for all interaction.
@@ -71,7 +71,7 @@ impl TypeDBDriver {
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn new_core(
         address: impl AsRef<str>,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
     ) -> Result<Self> {
         Self::new_core_with_description(address, credential, connection_settings, Self::DRIVER_LANG).await
@@ -95,7 +95,7 @@ impl TypeDBDriver {
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn new_core_with_description(
         address: impl AsRef<str>,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
         driver_lang: impl AsRef<str>,
     ) -> Result<Self> {
@@ -148,7 +148,7 @@ impl TypeDBDriver {
     pub async fn new_cloud<T: AsRef<str> + Sync>(
         // init_addresses: &[T], // TODO: return the slice version when we don't need to check the size
         init_addresses: &Vec<T>,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
     ) -> Result<Self> {
         Self::new_cloud_with_description(init_addresses, credential, connection_settings, Self::DRIVER_LANG).await
@@ -168,7 +168,7 @@ impl TypeDBDriver {
     pub async fn new_cloud_with_description<T: AsRef<str> + Sync>(
         // init_addresses: &[T], // TODO: return the slice version when we don't need to check the size
         init_addresses: &Vec<T>,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
         driver_lang: impl AsRef<str>,
     ) -> Result<Self> {
@@ -197,7 +197,7 @@ impl TypeDBDriver {
     pub async fn new_cloud_with_translation<T, U>(
         // TODO: Find a better name
         address_translation: HashMap<T, U>,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
     ) -> Result<Self>
     where
@@ -227,7 +227,7 @@ impl TypeDBDriver {
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn new_cloud_with_translation_with_description<T, U>(
         address_translation: HashMap<T, U>,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
         driver_lang: impl AsRef<str>,
     ) -> Result<Self>
@@ -261,7 +261,7 @@ impl TypeDBDriver {
     fn new_cloud_impl(
         address_to_server: HashMap<Address, Address>,
         background_runtime: Arc<BackgroundRuntime>,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
     ) -> Result<TypeDBDriver> {
         // let server_connections: HashMap<Address, ServerConnection> = address_to_server
@@ -291,7 +291,7 @@ impl TypeDBDriver {
     fn fetch_server_list(
         background_runtime: Arc<BackgroundRuntime>,
         addresses: impl IntoIterator<Item = impl AsRef<str>> + Clone,
-        credential: Credential,
+        credential: Credentials,
         connection_settings: ConnectionSettings,
     ) -> Result<HashSet<Address>> {
         let addresses: Vec<Address> = addresses.into_iter().map(|addr| addr.as_ref().parse()).try_collect()?;

--- a/rust/src/driver.rs
+++ b/rust/src/driver.rs
@@ -32,7 +32,7 @@ use crate::{
         Result,
     },
     connection::{runtime::BackgroundRuntime, server_connection::ServerConnection},
-    ConnectionSettings, Credentials, DatabaseManager, Options, Transaction, TransactionType, UserManager,
+    DriverOptions, Credentials, DatabaseManager, Options, Transaction, TransactionType, UserManager,
 };
 
 /// A connection to a TypeDB server which serves as the starting point for all interaction.
@@ -72,7 +72,7 @@ impl TypeDBDriver {
     pub async fn new_core(
         address: impl AsRef<str>,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
     ) -> Result<Self> {
         Self::new_core_with_description(address, credential, connection_settings, Self::DRIVER_LANG).await
     }
@@ -96,7 +96,7 @@ impl TypeDBDriver {
     pub async fn new_core_with_description(
         address: impl AsRef<str>,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
         driver_lang: impl AsRef<str>,
     ) -> Result<Self> {
         let id = address.as_ref().to_string();
@@ -149,7 +149,7 @@ impl TypeDBDriver {
         // init_addresses: &[T], // TODO: return the slice version when we don't need to check the size
         init_addresses: &Vec<T>,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
     ) -> Result<Self> {
         Self::new_cloud_with_description(init_addresses, credential, connection_settings, Self::DRIVER_LANG).await
     }
@@ -169,7 +169,7 @@ impl TypeDBDriver {
         // init_addresses: &[T], // TODO: return the slice version when we don't need to check the size
         init_addresses: &Vec<T>,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
         driver_lang: impl AsRef<str>,
     ) -> Result<Self> {
         if let Some(single_address) = init_addresses.iter().next() {
@@ -198,7 +198,7 @@ impl TypeDBDriver {
         // TODO: Find a better name
         address_translation: HashMap<T, U>,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
     ) -> Result<Self>
     where
         T: AsRef<str> + Sync,
@@ -228,7 +228,7 @@ impl TypeDBDriver {
     pub async fn new_cloud_with_translation_with_description<T, U>(
         address_translation: HashMap<T, U>,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
         driver_lang: impl AsRef<str>,
     ) -> Result<Self>
     where
@@ -262,7 +262,7 @@ impl TypeDBDriver {
         address_to_server: HashMap<Address, Address>,
         background_runtime: Arc<BackgroundRuntime>,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
     ) -> Result<TypeDBDriver> {
         // let server_connections: HashMap<Address, ServerConnection> = address_to_server
         //     .into_iter()
@@ -292,7 +292,7 @@ impl TypeDBDriver {
         background_runtime: Arc<BackgroundRuntime>,
         addresses: impl IntoIterator<Item = impl AsRef<str>> + Clone,
         credential: Credentials,
-        connection_settings: ConnectionSettings,
+        connection_settings: DriverOptions,
     ) -> Result<HashSet<Address>> {
         let addresses: Vec<Address> = addresses.into_iter().map(|addr| addr.as_ref().parse()).try_collect()?;
         for address in &addresses {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,7 +22,7 @@
 
 pub use self::{
     common::{box_stream, error, info, BoxPromise, BoxStream, Error, Options, Promise, Result, TransactionType, IID},
-    connection::{ConnectionSettings, Credential},
+    connection::{ConnectionSettings, Credentials},
     database::{Database, DatabaseManager},
     driver::TypeDBDriver,
     transaction::Transaction,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,7 +22,7 @@
 
 pub use self::{
     common::{box_stream, error, info, BoxPromise, BoxStream, Error, Options, Promise, Result, TransactionType, IID},
-    connection::{ConnectionSettings, Credentials},
+    connection::{DriverOptions, Credentials},
     database::{Database, DatabaseManager},
     driver::TypeDBDriver,
     transaction::Transaction,

--- a/rust/tests/behaviour/steps/connection/mod.rs
+++ b/rust/tests/behaviour/steps/connection/mod.rs
@@ -20,7 +20,7 @@
 use cucumber::{given, then, when};
 use macro_rules_attribute::apply;
 use tokio::time::sleep;
-use typedb_driver::{Credential, TypeDBDriver};
+use typedb_driver::{Credentials, TypeDBDriver};
 
 use crate::{assert_with_timeout, generic_step, params, params::check_boolean, Context};
 

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -38,7 +38,7 @@ use itertools::Itertools;
 use tokio::time::{sleep, Duration};
 use typedb_driver::{
     answer::{ConceptDocument, ConceptRow, QueryAnswer, QueryType},
-    BoxStream, ConnectionSettings, Credential, Options, Result as TypeDBResult, Transaction, TypeDBDriver,
+    BoxStream, ConnectionSettings, Credentials, Options, Result as TypeDBResult, Transaction, TypeDBDriver,
 };
 
 use crate::params::QueryAnswerType;
@@ -386,7 +386,7 @@ impl Context {
 
     async fn create_core_driver(&self, address: &str, username: &str, password: &str) -> TypeDBResult<TypeDBDriver> {
         assert!(!self.is_cloud);
-        let credential = Credential::new(username, password);
+        let credential = Credentials::new(username, password);
         let conn_settings = ConnectionSettings::new(false, None)?;
         TypeDBDriver::new_core(address, credential, conn_settings).await
     }
@@ -399,7 +399,7 @@ impl Context {
     ) -> TypeDBResult<TypeDBDriver> {
         assert!(self.is_cloud); // TODO: Probably requires connection settings with tls enabled by default for cloud
         let addresses = addresses.iter().collect_vec(); // TODO: Remove when new_cloud accepts a slice
-        TypeDBDriver::new_cloud(&addresses, Credential::new(username, password), ConnectionSettings::new(false, None)?)
+        TypeDBDriver::new_cloud(&addresses, Credentials::new(username, password), ConnectionSettings::new(false, None)?)
             .await
     }
 

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -38,7 +38,7 @@ use itertools::Itertools;
 use tokio::time::{sleep, Duration};
 use typedb_driver::{
     answer::{ConceptDocument, ConceptRow, QueryAnswer, QueryType},
-    BoxStream, ConnectionSettings, Credentials, Options, Result as TypeDBResult, Transaction, TypeDBDriver,
+    BoxStream, DriverOptions, Credentials, Options, Result as TypeDBResult, Transaction, TypeDBDriver,
 };
 
 use crate::params::QueryAnswerType;
@@ -387,7 +387,7 @@ impl Context {
     async fn create_core_driver(&self, address: &str, username: &str, password: &str) -> TypeDBResult<TypeDBDriver> {
         assert!(!self.is_cloud);
         let credential = Credentials::new(username, password);
-        let conn_settings = ConnectionSettings::new(false, None)?;
+        let conn_settings = DriverOptions::new(false, None)?;
         TypeDBDriver::new_core(address, credential, conn_settings).await
     }
 
@@ -399,7 +399,7 @@ impl Context {
     ) -> TypeDBResult<TypeDBDriver> {
         assert!(self.is_cloud); // TODO: Probably requires connection settings with tls enabled by default for cloud
         let addresses = addresses.iter().collect_vec(); // TODO: Remove when new_cloud accepts a slice
-        TypeDBDriver::new_cloud(&addresses, Credentials::new(username, password), ConnectionSettings::new(false, None)?)
+        TypeDBDriver::new_cloud(&addresses, Credentials::new(username, password), DriverOptions::new(false, None)?)
             .await
     }
 

--- a/rust/tests/integration/core/example.rs
+++ b/rust/tests/integration/core/example.rs
@@ -28,7 +28,7 @@ use typedb_driver::{
         ConceptRow, QueryAnswer,
     },
     concept::{Concept, ValueType},
-    ConnectionSettings, Credentials, Error, TransactionType, TypeDBDriver,
+    DriverOptions, Credentials, Error, TransactionType, TypeDBDriver,
 };
 
 // EXAMPLE END MARKER
@@ -37,7 +37,7 @@ async fn cleanup() {
     let driver = TypeDBDriver::new_core(
         TypeDBDriver::DEFAULT_ADDRESS,
         Credentials::new("admin", "password"),
-        ConnectionSettings::new(false, None).unwrap(),
+        DriverOptions::new(false, None).unwrap(),
     )
     .await
     .unwrap();
@@ -58,7 +58,7 @@ fn example() {
         let driver = TypeDBDriver::new_core(
             TypeDBDriver::DEFAULT_ADDRESS,
             Credentials::new("admin", "password"),
-            ConnectionSettings::new(false, None).unwrap(),
+            DriverOptions::new(false, None).unwrap(),
         )
         .await
         .unwrap();

--- a/rust/tests/integration/core/example.rs
+++ b/rust/tests/integration/core/example.rs
@@ -28,7 +28,7 @@ use typedb_driver::{
         ConceptRow, QueryAnswer,
     },
     concept::{Concept, ValueType},
-    ConnectionSettings, Credential, Error, TransactionType, TypeDBDriver,
+    ConnectionSettings, Credentials, Error, TransactionType, TypeDBDriver,
 };
 
 // EXAMPLE END MARKER
@@ -36,7 +36,7 @@ use typedb_driver::{
 async fn cleanup() {
     let driver = TypeDBDriver::new_core(
         TypeDBDriver::DEFAULT_ADDRESS,
-        Credential::new("admin", "password"),
+        Credentials::new("admin", "password"),
         ConnectionSettings::new(false, None).unwrap(),
     )
     .await
@@ -57,7 +57,7 @@ fn example() {
         // Open a driver connection
         let driver = TypeDBDriver::new_core(
             TypeDBDriver::DEFAULT_ADDRESS,
-            Credential::new("admin", "password"),
+            Credentials::new("admin", "password"),
             ConnectionSettings::new(false, None).unwrap(),
         )
         .await


### PR DESCRIPTION
## Usage and product changes
- Rename `ConnectionSettings` to `DriverOptions`
- Rename `Credential` to `Credentials`

## Implementation
