### PR TITLE
Rename long to integer

### DIFF
--- a/c/src/concept/concept.rs
+++ b/c/src/concept/concept.rs
@@ -209,11 +209,11 @@ pub extern "C" fn concept_is_boolean(concept: *const Concept) -> bool {
     borrow(concept).is_boolean()
 }
 
-/// Returns <code>true</code> if the value which this <code>Concept</code> holds is of type <code>long</code>.
+/// Returns <code>true</code> if the value which this <code>Concept</code> holds is of type <code>integer</code>.
 /// Otherwise, returns <code>false</code>.
 #[no_mangle]
-pub extern "C" fn concept_is_long(concept: *const Concept) -> bool {
-    borrow(concept).is_long()
+pub extern "C" fn concept_is_integer(concept: *const Concept) -> bool {
+    borrow(concept).is_integer()
 }
 
 /// Returns <code>true</code> if the value which this <code>Concept</code> holds is of type <code>double</code>.
@@ -282,13 +282,13 @@ pub extern "C" fn concept_get_boolean(concept: *const Concept) -> bool {
     }
 }
 
-/// Returns the <code>long</code> value of this value concept.
+/// Returns the <code>integer</code> value of this value concept.
 /// If the value has another type, the error is set.
 #[no_mangle]
-pub extern "C" fn concept_get_long(concept: *const Concept) -> i64 {
-    match borrow(concept).try_get_long() {
+pub extern "C" fn concept_get_integer(concept: *const Concept) -> i64 {
+    match borrow(concept).try_get_integer() {
         Some(value) => value,
-        None => unreachable!("Attempting to unwrap a non-long {:?} as long", borrow(concept)),
+        None => unreachable!("Attempting to unwrap a non-integer {:?} as integer", borrow(concept)),
     }
 }
 

--- a/c/swig/typedb_driver_csharp.swg
+++ b/c/swig/typedb_driver_csharp.swg
@@ -242,17 +242,17 @@
 %noexception value_get_boolean;
 %noexception value_get_date_time_as_millis;
 %noexception value_get_double;
-%noexception value_get_long;
+%noexception value_get_integer;
 %noexception value_get_string;
 %noexception value_is_boolean;
 %noexception value_is_date_time;
 %noexception value_is_double;
-%noexception value_is_long;
+%noexception value_is_integer;
 %noexception value_is_string;
 %noexception value_new_boolean;
 %noexception value_new_date_time_from_millis;
 %noexception value_new_double;
-%noexception value_new_long;
+%noexception value_new_integer;
 %noexception value_new_string;
 
 %noexception role_player_get_role_type;

--- a/c/swig/typedb_driver_java.swg
+++ b/c/swig/typedb_driver_java.swg
@@ -167,7 +167,7 @@
 %nojavaexception concept_is_decimal;
 %nojavaexception concept_is_double;
 %nojavaexception concept_is_duration;
-%nojavaexception concept_is_long;
+%nojavaexception concept_is_integer;
 %nojavaexception concept_is_string;
 %nojavaexception concept_is_struct;
 
@@ -179,7 +179,7 @@
 %nojavaexception concept_get_decimal;
 %nojavaexception concept_get_double;
 %nojavaexception concept_get_duration;
-%nojavaexception concept_get_long;
+%nojavaexception concept_get_integer;
 %nojavaexception concept_get_string;
 %nojavaexception concept_get_struct;
 

--- a/cpp/test/integration/test_core.cpp
+++ b/cpp/test/integration/test_core.cpp
@@ -80,7 +80,7 @@ TEST(TestExplanations, TestExplainableOwnership) {
         auto sess = driver.session(dbName, TypeDB::SessionType::DATA, options);
         auto tx = sess.transaction(TypeDB::TransactionType::WRITE, options);
 
-        auto res = tx.query.insert("insert $o " + std::to_string(attrValue) + " isa attr;", options);
+        auto res = tx.query.insert("insert $o isa attr " + std::to_string(attrValue) + ";", options);
         for (auto& it : res)
             ;
         tx.commit();

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "b61fefb61ca8904825fd35a2753b3e2ffc1f14f5"
+        commit = "0d99e6eb8985b9e06f159bc7a4f14bfeae8522e5"
     )
 
 #def typedb_cloud_artifact():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -34,6 +34,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "d805d6198be34859bbc9170ed01b22a093cb2377",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "80e07b383c13686ae67be233f6304fd3fbdac138",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -27,13 +27,13 @@ def typedb_dependencies():
 def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
-        remote = "https://github.com/krishnangovindraj/typedb-protocol",
-        commit = "62c478634f7458761f4fc38cb6113d8e05fea8a2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        remote = "https://github.com/typedb/typedb-protocol",
+        commit = "3ead863d3a4b15a35178ea9212bc70d0a489bbea",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "60542b1e00cfdc8456c569c18a2366715bdd020a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "e681093ed2a2281fc7cd24ceb21d147f98ab7a84",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -27,8 +27,8 @@ def typedb_dependencies():
 def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
-        remote = "https://github.com/typedb/typedb-protocol",
-        commit = "b891ffbd3fe6d8a2f3824b71d050fecc4ed798b5",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        remote = "https://github.com/krishnangovindraj/typedb-protocol",
+        commit = "62c478634f7458761f4fc38cb6113d8e05fea8a2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,5 +35,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-        commit = "80e07b383c13686ae67be233f6304fd3fbdac138",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "60542b1e00cfdc8456c569c18a2366715bdd020a",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/docs/modules/ROOT/partials/java/concept/Concept.adoc
+++ b/docs/modules/ROOT/partials/java/concept/Concept.adoc
@@ -534,16 +534,16 @@ Checks if the concept is an ``Instance``.
 concept.isInstance();
 ----
 
-[#_Concept_isLong_]
-==== isLong
+[#_Concept_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -554,7 +554,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_Concept_isRelation_]
@@ -895,6 +895,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_Concept_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_Concept_tryGetLabel_]
 ==== tryGetLabel
 
@@ -916,28 +938,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_Concept_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_Concept_tryGetString_]

--- a/docs/modules/ROOT/partials/java/data/Attribute.adoc
+++ b/docs/modules/ROOT/partials/java/data/Attribute.adoc
@@ -368,6 +368,28 @@ Returns a ``duration`` value of the value concept that this attribute holds. If 
 attribute.getDuration();
 ----
 
+[#_Attribute_getInteger_]
+==== getInteger
+
+[source,java]
+----
+long getInteger()
+----
+
+Returns a ``integer`` value of the value concept that this attribute holds. If the value has another type, raises an exception. 
+
+
+[caption=""]
+.Returns
+`long`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+attribute.getInteger();
+----
+
 [#_Attribute_getLabel_]
 ==== getLabel
 
@@ -389,28 +411,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.getLabel();
-----
-
-[#_Attribute_getLong_]
-==== getLong
-
-[source,java]
-----
-long getLong()
-----
-
-Returns a ``long`` value of the value concept that this attribute holds. If the value has another type, raises an exception. 
-
-
-[caption=""]
-.Returns
-`long`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-attribute.getLong();
 ----
 
 [#_Attribute_getString_]
@@ -779,16 +779,16 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Attribute_isLong_]
-==== isLong
+[#_Attribute_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -799,7 +799,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_Attribute_isRelation_]
@@ -1140,6 +1140,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_Attribute_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_Attribute_tryGetLabel_]
 ==== tryGetLabel
 
@@ -1161,28 +1183,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_Attribute_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_Attribute_tryGetString_]

--- a/docs/modules/ROOT/partials/java/data/Entity.adoc
+++ b/docs/modules/ROOT/partials/java/data/Entity.adoc
@@ -532,16 +532,16 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Entity_isLong_]
-==== isLong
+[#_Entity_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -552,7 +552,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_Entity_isRelation_]
@@ -893,6 +893,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_Entity_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_Entity_tryGetLabel_]
 ==== tryGetLabel
 
@@ -914,28 +936,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_Entity_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_Entity_tryGetString_]

--- a/docs/modules/ROOT/partials/java/data/Instance.adoc
+++ b/docs/modules/ROOT/partials/java/data/Instance.adoc
@@ -551,16 +551,16 @@ Checks if the concept is a ``Instance``.
 instance.isInstance();
 ----
 
-[#_Instance_isLong_]
-==== isLong
+[#_Instance_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -571,7 +571,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_Instance_isRelation_]
@@ -912,6 +912,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_Instance_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_Instance_tryGetLabel_]
 ==== tryGetLabel
 
@@ -933,28 +955,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_Instance_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_Instance_tryGetString_]

--- a/docs/modules/ROOT/partials/java/data/Relation.adoc
+++ b/docs/modules/ROOT/partials/java/data/Relation.adoc
@@ -532,16 +532,16 @@ Checks if the concept is an ``EntityType``.
 concept.isEntityType();
 ----
 
-[#_Relation_isLong_]
-==== isLong
+[#_Relation_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -552,7 +552,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_Relation_isRelation_]
@@ -893,6 +893,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_Relation_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_Relation_tryGetLabel_]
 ==== tryGetLabel
 
@@ -914,28 +936,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_Relation_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_Relation_tryGetString_]

--- a/docs/modules/ROOT/partials/java/data/Value.adoc
+++ b/docs/modules/ROOT/partials/java/data/Value.adoc
@@ -404,6 +404,28 @@ Returns a ``duration`` value of this value concept. If the value has another typ
 value.getDuration();
 ----
 
+[#_Value_getInteger_]
+==== getInteger
+
+[source,java]
+----
+long getInteger()
+----
+
+Returns a ``integer`` value of this value concept. If the value has another type, raises an exception. 
+
+
+[caption=""]
+.Returns
+`long`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+value.getInteger();
+----
+
 [#_Value_getLabel_]
 ==== getLabel
 
@@ -425,28 +447,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.getLabel();
-----
-
-[#_Value_getLong_]
-==== getLong
-
-[source,java]
-----
-long getLong()
-----
-
-Returns a ``long`` value of this value concept. If the value has another type, raises an exception. 
-
-
-[caption=""]
-.Returns
-`long`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-value.getLong();
 ----
 
 [#_Value_getString_]
@@ -791,16 +791,16 @@ Checks if the concept is an ``Instance``.
 concept.isInstance();
 ----
 
-[#_Value_isLong_]
-==== isLong
+[#_Value_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -811,7 +811,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_Value_isRelation_]
@@ -1151,6 +1151,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_Value_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_Value_tryGetLabel_]
 ==== tryGetLabel
 
@@ -1172,28 +1194,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_Value_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_Value_tryGetString_]

--- a/docs/modules/ROOT/partials/java/schema/AttributeType.adoc
+++ b/docs/modules/ROOT/partials/java/schema/AttributeType.adoc
@@ -515,16 +515,16 @@ Checks if the concept is an ``Instance``.
 concept.isInstance();
 ----
 
-[#_AttributeType_isLong_]
-==== isLong
+[#_AttributeType_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -535,7 +535,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_AttributeType_isRelation_]
@@ -853,6 +853,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_AttributeType_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_AttributeType_tryGetLabel_]
 ==== tryGetLabel
 
@@ -874,28 +896,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_AttributeType_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_AttributeType_tryGetString_]

--- a/docs/modules/ROOT/partials/java/schema/EntityType.adoc
+++ b/docs/modules/ROOT/partials/java/schema/EntityType.adoc
@@ -509,16 +509,16 @@ Checks if the concept is an ``Instance``.
 concept.isInstance();
 ----
 
-[#_EntityType_isLong_]
-==== isLong
+[#_EntityType_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -529,7 +529,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_EntityType_isRelation_]
@@ -847,6 +847,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_EntityType_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_EntityType_tryGetLabel_]
 ==== tryGetLabel
 
@@ -868,28 +890,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_EntityType_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_EntityType_tryGetString_]

--- a/docs/modules/ROOT/partials/java/schema/RelationType.adoc
+++ b/docs/modules/ROOT/partials/java/schema/RelationType.adoc
@@ -509,16 +509,16 @@ Checks if the concept is an ``Instance``.
 concept.isInstance();
 ----
 
-[#_RelationType_isLong_]
-==== isLong
+[#_RelationType_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -529,7 +529,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_RelationType_isRelation_]
@@ -847,6 +847,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_RelationType_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_RelationType_tryGetLabel_]
 ==== tryGetLabel
 
@@ -868,28 +890,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_RelationType_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_RelationType_tryGetString_]

--- a/docs/modules/ROOT/partials/java/schema/RoleType.adoc
+++ b/docs/modules/ROOT/partials/java/schema/RoleType.adoc
@@ -509,16 +509,16 @@ Checks if the concept is an ``Instance``.
 concept.isInstance();
 ----
 
-[#_RoleType_isLong_]
-==== isLong
+[#_RoleType_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -529,7 +529,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_RoleType_isRelation_]
@@ -847,6 +847,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_RoleType_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_RoleType_tryGetLabel_]
 ==== tryGetLabel
 
@@ -868,28 +890,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_RoleType_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_RoleType_tryGetString_]

--- a/docs/modules/ROOT/partials/java/schema/Type.adoc
+++ b/docs/modules/ROOT/partials/java/schema/Type.adoc
@@ -528,16 +528,16 @@ Checks if the concept is an ``Instance``.
 concept.isInstance();
 ----
 
-[#_Type_isLong_]
-==== isLong
+[#_Type_isInteger_]
+==== isInteger
 
 [source,java]
 ----
 @CheckReturnValue
-boolean isLong()
+boolean isInteger()
 ----
 
-Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``false``. 
+Returns ``true`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``false``. 
 
 
 [caption=""]
@@ -548,7 +548,7 @@ Returns ``true`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,java]
 ----
-concept.isLong();
+concept.isInteger();
 ----
 
 [#_Type_isRelation_]
@@ -889,6 +889,28 @@ Retrieves the unique id of the ``Concept``. Returns ``null`` if absent.
 concept.tryGetIID();
 ----
 
+[#_Type_tryGetInteger_]
+==== tryGetInteger
+
+[source,java]
+----
+java.util.Optional<java.lang.Long> tryGetInteger()
+----
+
+Returns a ``integer`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
+
+
+[caption=""]
+.Returns
+`java.util.Optional<java.lang.Long>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+concept.tryGetInteger();
+----
+
 [#_Type_tryGetLabel_]
 ==== tryGetLabel
 
@@ -910,28 +932,6 @@ Retrieves the unique label of the concept. If this is an ``Instance``, return th
 [source,java]
 ----
 concept.tryGetLabel();
-----
-
-[#_Type_tryGetLong_]
-==== tryGetLong
-
-[source,java]
-----
-java.util.Optional<java.lang.Long> tryGetLong()
-----
-
-Returns a ``long`` value of this ``Concept``. If it's not a ``Value`` or it has another type, returns ``null``. 
-
-
-[caption=""]
-.Returns
-`java.util.Optional<java.lang.Long>`
-
-[caption=""]
-.Code examples
-[source,java]
-----
-concept.tryGetLong();
 ----
 
 [#_Type_tryGetString_]

--- a/docs/modules/ROOT/partials/python/concept/Concept.adoc
+++ b/docs/modules/ROOT/partials/python/concept/Concept.adoc
@@ -485,15 +485,15 @@ Checks if the concept is a ``Instance``.
 concept.is_instance()
 ----
 
-[#_Concept_is_long_]
-==== is_long
+[#_Concept_is_integer_]
+==== is_integer
 
 [source,python]
 ----
-is_long() -> bool
+is_integer() -> bool
 ----
 
-Returns ``True`` if the value which this ``Concept`` holds is of type ``long`` or if this ``Concept`` is an ``AttributeType`` of type ``long``. Otherwise, returns ``False``.
+Returns ``True`` if the value which this ``Concept`` holds is of type ``integer`` or if this ``Concept`` is an ``AttributeType`` of type ``integer``. Otherwise, returns ``False``.
 
 [caption=""]
 .Returns
@@ -503,7 +503,7 @@ Returns ``True`` if the value which this ``Concept`` holds is of type ``long`` o
 .Code examples
 [source,python]
 ----
-concept.is_long()
+concept.is_integer()
 ----
 
 [#_Concept_is_relation_]
@@ -821,6 +821,27 @@ Retrieves the unique id of the ``Concept``. Returns ``None`` if absent.
 concept.try_get_iid()
 ----
 
+[#_Concept_try_get_integer_]
+==== try_get_integer
+
+[source,python]
+----
+try_get_integer() -> int | None
+----
+
+Returns a ``integer`` value of this ``Concept``. If it’s not a ``Value`` or it has another type, raises an exception.
+
+[caption=""]
+.Returns
+`int | None`
+
+[caption=""]
+.Code examples
+[source,python]
+----
+value.try_get_integer()
+----
+
 [#_Concept_try_get_label_]
 ==== try_get_label
 
@@ -840,27 +861,6 @@ Get the label of the concept. If this is an ``Instance``, return the label of th
 [source,python]
 ----
 concept.try_get_label()
-----
-
-[#_Concept_try_get_long_]
-==== try_get_long
-
-[source,python]
-----
-try_get_long() -> int | None
-----
-
-Returns a ``long`` value of this ``Concept``. If it’s not a ``Value`` or it has another type, raises an exception.
-
-[caption=""]
-.Returns
-`int | None`
-
-[caption=""]
-.Code examples
-[source,python]
-----
-value.try_get_long()
 ----
 
 [#_Concept_try_get_string_]

--- a/docs/modules/ROOT/partials/python/data/Attribute.adoc
+++ b/docs/modules/ROOT/partials/python/data/Attribute.adoc
@@ -178,15 +178,15 @@ Returns a timezone naive ``duration`` value of the value concept that this attri
 attribute.get_duration()
 ----
 
-[#_Attribute_get_long_]
-==== get_long
+[#_Attribute_get_integer_]
+==== get_integer
 
 [source,python]
 ----
-get_long() -> int
+get_integer() -> int
 ----
 
-Returns a ``long`` value of the value concept that this attribute holds. If the value has another type, raises an exception.
+Returns a ``integer`` value of the value concept that this attribute holds. If the value has another type, raises an exception.
 
 [caption=""]
 .Returns
@@ -196,7 +196,7 @@ Returns a ``long`` value of the value concept that this attribute holds. If the 
 .Code examples
 [source,python]
 ----
-attribute.get_long()
+attribute.get_integer()
 ----
 
 [#_Attribute_get_string_]

--- a/docs/modules/ROOT/partials/python/data/Value.adoc
+++ b/docs/modules/ROOT/partials/python/data/Value.adoc
@@ -195,15 +195,15 @@ Returns a timezone naive ``duration`` value of this value concept. If the value 
 value.get_duration()
 ----
 
-[#_Value_get_long_]
-==== get_long
+[#_Value_get_integer_]
+==== get_integer
 
 [source,python]
 ----
-get_long() -> int
+get_integer() -> int
 ----
 
-Returns a ``long`` value of this value concept. If the value has another type, raises an exception.
+Returns a ``integer`` value of this value concept. If the value has another type, raises an exception.
 
 [caption=""]
 .Returns
@@ -213,7 +213,7 @@ Returns a ``long`` value of this value concept. If the value has another type, r
 .Code examples
 [source,python]
 ----
-value.get_long()
+value.get_integer()
 ----
 
 [#_Value_get_string_]

--- a/docs/modules/ROOT/partials/rust/concept/Concept.adoc
+++ b/docs/modules/ROOT/partials/rust/concept/Concept.adoc
@@ -269,15 +269,15 @@ bool
 concept.is_entity() || concept.is_relation() ||  concept.is_attribute()
 ----
 
-[#_enum_Concept_is_long_]
-==== is_long
+[#_enum_Concept_is_integer_]
+==== is_integer
 
 [source,rust]
 ----
-pub fn is_long(&self) -> bool
+pub fn is_integer(&self) -> bool
 ----
 
-Check if this Concept holds a long as an AttributeType, an Attribute, or a Value
+Check if this Concept holds an integer as an AttributeType, an Attribute, or a Value
 
 [caption=""]
 .Returns
@@ -550,6 +550,23 @@ Retrieves the unique id (IID) of this Concept. If this is an Entity or Relation 
 Option<&IID>
 ----
 
+[#_enum_Concept_try_get_integer_]
+==== try_get_integer
+
+[source,rust]
+----
+pub fn try_get_integer(&self) -> Option<i64>
+----
+
+Retrieves the integer value of this Concept, if it exists. If this is an integer-valued Attribute Instance, returns the integer value of this instance. If this an integer-valued Value, returns the integer value. Otherwise, returns None.
+
+[caption=""]
+.Returns
+[source,rust]
+----
+Option<i64>
+----
+
 [#_enum_Concept_try_get_label_]
 ==== try_get_label
 
@@ -565,23 +582,6 @@ Retrieves the optional label of the concept. If this is an Instance, returns the
 [source,rust]
 ----
 Option<&str>
-----
-
-[#_enum_Concept_try_get_long_]
-==== try_get_long
-
-[source,rust]
-----
-pub fn try_get_long(&self) -> Option<i64>
-----
-
-Retrieves the long value of this Concept, if it exists. If this is a long-valued Attribute Instance, returns the long value of this instance. If this a long-valued Value, returns the long value. Otherwise, returns None.
-
-[caption=""]
-.Returns
-[source,rust]
-----
-Option<i64>
 ----
 
 [#_enum_Concept_try_get_string_]

--- a/docs/modules/ROOT/partials/rust/data/Value.adoc
+++ b/docs/modules/ROOT/partials/rust/data/Value.adoc
@@ -15,7 +15,7 @@ a| `DatetimeTZ(DateTime<TimeZone>)`
 a| `Decimal(Decimal)`
 a| `Double(f64)`
 a| `Duration(Duration)`
-a| `Long(i64)`
+a| `Integer(i64)`
 a| `String(String)`
 a| `Struct(Struct, String)`
 |===

--- a/docs/modules/ROOT/partials/rust/schema/ValueType.adoc
+++ b/docs/modules/ROOT/partials/rust/schema/ValueType.adoc
@@ -17,7 +17,7 @@ a| `DatetimeTZ`
 a| `Decimal`
 a| `Double`
 a| `Duration`
-a| `Long`
+a| `Integer`
 a| `String`
 a| `Struct(String)`
 |===

--- a/java/README.md
+++ b/java/README.md
@@ -113,7 +113,7 @@ public class TypeDBExample {
                 String defineQuery = "define " +
                         "entity person, owns name, owns age; " +
                         "attribute name, value string;\n" +
-                        "attribute age, value long;";
+                        "attribute age, value integer;";
 
                 QueryAnswer answer = transaction.query(defineQuery).resolve();
 

--- a/java/api/concept/Concept.java
+++ b/java/api/concept/Concept.java
@@ -311,17 +311,17 @@ public interface Concept {
     boolean isBoolean();
 
     /**
-     * Returns <code>true</code> if the value which this <code>Concept</code> holds is of type <code>long</code>
-     * or if this <code>Concept</code> is an <code>AttributeType</code> of type <code>long</code>.
+     * Returns <code>true</code> if the value which this <code>Concept</code> holds is of type <code>integer</code>
+     * or if this <code>Concept</code> is an <code>AttributeType</code> of type <code>integer</code>.
      * Otherwise, returns <code>false</code>.
      *
      * <h3>Examples</h3>
      * <pre>
-     * concept.isLong();
+     * concept.isInteger();
      * </pre>
      */
     @CheckReturnValue
-    boolean isLong();
+    boolean isInteger();
 
     /**
      * Returns <code>true</code> if the value which this <code>Concept</code> holds is of type <code>double</code>
@@ -441,15 +441,15 @@ public interface Concept {
     Optional<Boolean> tryGetBoolean();
 
     /**
-     * Returns a <code>long</code> value of this <code>Concept</code>.
+     * Returns a <code>integer</code> value of this <code>Concept</code>.
      * If it's not a <code>Value</code> or it has another type, returns <code>null</code>.
      *
      * <h3>Examples</h3>
      * <pre>
-     * concept.tryGetLong();
+     * concept.tryGetInteger();
      * </pre>
      */
-    Optional<Long> tryGetLong();
+    Optional<Long> tryGetInteger();
 
     /**
      * Returns a <code>double</code> value of this <code>Concept</code>.

--- a/java/api/concept/instance/Attribute.java
+++ b/java/api/concept/instance/Attribute.java
@@ -100,15 +100,15 @@ public interface Attribute extends Instance {
     boolean getBoolean();
 
     /**
-     * Returns a <code>long</code> value of the value concept that this attribute holds.
+     * Returns a <code>integer</code> value of the value concept that this attribute holds.
      * If the value has another type, raises an exception.
      *
      * <h3>Examples</h3>
      * <pre>
-     * attribute.getLong();
+     * attribute.getInteger();
      * </pre>
      */
-    long getLong();
+    long getInteger();
 
     /**
      * Returns a <code>double</code> value of the value concept that this attribute holds.

--- a/java/api/concept/value/Value.java
+++ b/java/api/concept/value/Value.java
@@ -79,14 +79,14 @@ public interface Value extends Concept {
     boolean getBoolean();
 
     /**
-     * Returns a <code>long</code> value of this value concept. If the value has another type, raises an exception.
+     * Returns a <code>integer</code> value of this value concept. If the value has another type, raises an exception.
      *
      * <h3>Examples</h3>
      * <pre>
-     * value.getLong();
+     * value.getInteger();
      * </pre>
      */
-    long getLong();
+    long getInteger();
 
     /**
      * Returns a <code>double</code> value of this value concept.

--- a/java/concept/ConceptImpl.java
+++ b/java/concept/ConceptImpl.java
@@ -59,7 +59,7 @@ import static com.typedb.driver.jni.typedb_driver.concept_get_decimal;
 import static com.typedb.driver.jni.typedb_driver.concept_get_double;
 import static com.typedb.driver.jni.typedb_driver.concept_get_duration;
 import static com.typedb.driver.jni.typedb_driver.concept_get_label;
-import static com.typedb.driver.jni.typedb_driver.concept_get_long;
+import static com.typedb.driver.jni.typedb_driver.concept_get_integer;
 import static com.typedb.driver.jni.typedb_driver.concept_get_string;
 import static com.typedb.driver.jni.typedb_driver.concept_get_struct;
 import static com.typedb.driver.jni.typedb_driver.concept_is_attribute;
@@ -73,7 +73,7 @@ import static com.typedb.driver.jni.typedb_driver.concept_is_double;
 import static com.typedb.driver.jni.typedb_driver.concept_is_duration;
 import static com.typedb.driver.jni.typedb_driver.concept_is_entity;
 import static com.typedb.driver.jni.typedb_driver.concept_is_entity_type;
-import static com.typedb.driver.jni.typedb_driver.concept_is_long;
+import static com.typedb.driver.jni.typedb_driver.concept_is_integer;
 import static com.typedb.driver.jni.typedb_driver.concept_is_relation;
 import static com.typedb.driver.jni.typedb_driver.concept_is_relation_type;
 import static com.typedb.driver.jni.typedb_driver.concept_is_role_type;
@@ -135,8 +135,8 @@ public abstract class ConceptImpl extends NativeObject<com.typedb.driver.jni.Con
     }
 
     @Override
-    public boolean isLong() {
-        return concept_is_long(nativeObject);
+    public boolean isInteger() {
+        return concept_is_integer(nativeObject);
     }
 
     @Override
@@ -186,9 +186,9 @@ public abstract class ConceptImpl extends NativeObject<com.typedb.driver.jni.Con
     }
 
     @Override
-    public Optional<Long> tryGetLong() {
-        if (isType() || !isLong()) return Optional.empty();
-        return Optional.of(concept_get_long(nativeObject));
+    public Optional<Long> tryGetInteger() {
+        if (isType() || !isInteger()) return Optional.empty();
+        return Optional.of(concept_get_integer(nativeObject));
     }
 
     @Override

--- a/java/concept/instance/AttributeImpl.java
+++ b/java/concept/instance/AttributeImpl.java
@@ -61,8 +61,8 @@ public class AttributeImpl extends InstanceImpl implements Attribute {
     }
 
     @Override
-    public long getLong() {
-        return getValue().getLong();
+    public long getInteger() {
+        return getValue().getInteger();
     }
 
     @Override

--- a/java/concept/value/ValueImpl.java
+++ b/java/concept/value/ValueImpl.java
@@ -51,7 +51,7 @@ public class ValueImpl extends ConceptImpl implements Value {
     @Override
     public Object get() {
         if (isBoolean()) return getBoolean();
-        else if (isLong()) return getLong();
+        else if (isInteger()) return getInteger();
         else if (isDouble()) return getDouble();
         else if (isDecimal()) return getDecimal();
         else if (isString()) return getString();
@@ -69,8 +69,8 @@ public class ValueImpl extends ConceptImpl implements Value {
     }
 
     @Override
-    public long getLong() {
-        return tryGetLong().orElseThrow(() -> new TypeDBDriverException(INVALID_VALUE_RETRIEVAL, "long"));
+    public long getInteger() {
+        return tryGetInteger().orElseThrow(() -> new TypeDBDriverException(INVALID_VALUE_RETRIEVAL, "long"));
     }
 
     @Override
@@ -116,7 +116,7 @@ public class ValueImpl extends ConceptImpl implements Value {
     @Override
     public String toString() {
         if (isBoolean()) return Boolean.toString(getBoolean());
-        else if (isLong()) return Long.toString(getLong());
+        else if (isInteger()) return Long.toString(getInteger());
         else if (isDouble()) return Double.toString(getDouble());
         else if (isDecimal()) return getDecimal().toString();
         else if (isString()) return getString();

--- a/java/concept/value/ValueImpl.java
+++ b/java/concept/value/ValueImpl.java
@@ -70,7 +70,7 @@ public class ValueImpl extends ConceptImpl implements Value {
 
     @Override
     public long getInteger() {
-        return tryGetInteger().orElseThrow(() -> new TypeDBDriverException(INVALID_VALUE_RETRIEVAL, "long"));
+        return tryGetInteger().orElseThrow(() -> new TypeDBDriverException(INVALID_VALUE_RETRIEVAL, "integer"));
     }
 
     @Override

--- a/java/core_example
+++ b/java/core_example
@@ -54,7 +54,7 @@ public class TypeDBExample {
                 String defineQuery = "define " +
                         "entity person, owns name, owns age; " +
                         "attribute name, value string;\n" +
-                        "attribute age, value long;";
+                        "attribute age, value integer;";
 
                 QueryAnswer answer = transaction.query(defineQuery).resolve();
 

--- a/java/test/behaviour/config/Parameters.java
+++ b/java/test/behaviour/config/Parameters.java
@@ -115,7 +115,7 @@ public class Parameters {
     }
 
 
-    @ParameterType("boolean|long|double|decimal|string|date|datetime|datetime-tz|duration|struct")
+    @ParameterType("boolean|integer|double|decimal|string|date|datetime|datetime-tz|duration|struct")
     public ValueType value_type(String value) {
         return ValueType.of(value);
     }
@@ -226,7 +226,7 @@ public class Parameters {
 
     public enum ValueType {
         BOOLEAN("boolean"),
-        LONG("long"),
+        INTEGER("integer"),
         DOUBLE("double"),
         DECIMAL("decimal"),
         STRING("string"),

--- a/java/test/behaviour/query/QuerySteps.java
+++ b/java/test/behaviour/query/QuerySteps.java
@@ -683,7 +683,7 @@ public class QuerySteps {
             case BOOLEAN:
                 return concept.isBoolean();
             case LONG:
-                return concept.isLong();
+                return concept.isInteger();
             case DOUBLE:
                 return concept.isDouble();
             case DECIMAL:
@@ -747,7 +747,7 @@ public class QuerySteps {
             case BOOLEAN:
                 return value.getBoolean();
             case LONG:
-                return value.getLong();
+                return value.getInteger();
             case DOUBLE:
                 return value.getDouble();
             case DECIMAL:
@@ -814,7 +814,7 @@ public class QuerySteps {
             case BOOLEAN:
                 return castedConcept.tryGetBoolean();
             case LONG:
-                return castedConcept.tryGetLong();
+                return castedConcept.tryGetInteger();
             case DOUBLE:
                 return castedConcept.tryGetDouble();
             case DECIMAL:

--- a/java/test/behaviour/query/QuerySteps.java
+++ b/java/test/behaviour/query/QuerySteps.java
@@ -682,7 +682,7 @@ public class QuerySteps {
         switch (valueType) {
             case BOOLEAN:
                 return concept.isBoolean();
-            case LONG:
+            case INTEGER:
                 return concept.isInteger();
             case DOUBLE:
                 return concept.isDouble();
@@ -712,7 +712,7 @@ public class QuerySteps {
         switch (valueType) {
             case BOOLEAN:
                 return Boolean.parseBoolean(value);
-            case LONG:
+            case INTEGER:
                 return Long.parseLong(value);
             case DOUBLE:
                 return Double.parseDouble(value);
@@ -746,7 +746,7 @@ public class QuerySteps {
         switch (valueType) {
             case BOOLEAN:
                 return value.getBoolean();
-            case LONG:
+            case INTEGER:
                 return value.getInteger();
             case DOUBLE:
                 return value.getDouble();
@@ -813,7 +813,7 @@ public class QuerySteps {
         switch (valueType) {
             case BOOLEAN:
                 return castedConcept.tryGetBoolean();
-            case LONG:
+            case INTEGER:
                 return castedConcept.tryGetInteger();
             case DOUBLE:
                 return castedConcept.tryGetDouble();

--- a/java/test/integration/core/ExampleTest.java
+++ b/java/test/integration/core/ExampleTest.java
@@ -103,7 +103,7 @@ public class ExampleTest {
                 String defineQuery = "define " +
                         "entity person, owns name, owns age; " +
                         "attribute name, value string;\n" +
-                        "attribute age, value long;";
+                        "attribute age, value integer;";
 
                 QueryAnswer answer = transaction.query(defineQuery).resolve();
                 assertTrue(answer.isOk());
@@ -178,8 +178,8 @@ public class ExampleTest {
                     if (conceptByName.isAttributeType()) {
                         AttributeType attributeType = conceptByName.asAttributeType();
                         System.out.printf("Defined attribute type's label: '%s', value type: '%s'%n", attributeType.getLabel(), attributeType.tryGetValueType().get());
-                        assertTrue(attributeType.isLong() || attributeType.isString());
-                        assertTrue(Objects.equals(attributeType.tryGetValueType().get(), "long") || Objects.equals(attributeType.tryGetValueType().get(), "string"));
+                        assertTrue(attributeType.isInteger() || attributeType.isString());
+                        assertTrue(Objects.equals(attributeType.tryGetValueType().get(), "integer") || Objects.equals(attributeType.tryGetValueType().get(), "string"));
                         assertTrue(Objects.equals(attributeType.getLabel(), "age") || Objects.equals(attributeType.getLabel(), "name"));
                         assertNotEquals(attributeType.getLabel(), "person");
                         assertNotEquals(attributeType.getLabel(), "person:age");

--- a/java/test/integration/core/ValueTest.java
+++ b/java/test/integration/core/ValueTest.java
@@ -217,7 +217,7 @@ public class ValueTest {
         }, Transaction.Type.SCHEMA);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P1Y isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P1Y;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P12M PT0S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(12, typedbDuration.getMonths());
@@ -230,7 +230,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P1M isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P1M;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P1M PT0S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(1, typedbDuration.getMonths());
@@ -245,7 +245,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P1D isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P1D;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P1D PT0S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(0, typedbDuration.getMonths());
@@ -256,7 +256,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P0DT1H isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P0DT1H;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P0D PT1H", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(0, typedbDuration.getMonths());
@@ -267,7 +267,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P0DT1S isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P0DT1S;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P0D PT1S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(0, typedbDuration.getMonths());
@@ -278,7 +278,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P0DT0.000000001S isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P0DT0.000000001S;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P0D PT0.000000001S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(0, typedbDuration.getMonths());
@@ -289,7 +289,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P0DT0.0000001S isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P0DT0.0000001S;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P0D PT0.0000001S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(0, typedbDuration.getMonths());
@@ -300,7 +300,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P0DT0S isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P0DT0S;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P0D PT0S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(0, typedbDuration.getMonths());
@@ -312,7 +312,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P7W isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P7W;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P49D PT0S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(0, typedbDuration.getMonths());
@@ -324,7 +324,7 @@ public class ValueTest {
         }, Transaction.Type.WRITE);
 
         localhostTypeDBTX(tx -> {
-            QueryAnswer answer = tx.query("insert $d P999Y12M31DT24H59M59.999999999S isa d;").resolve();
+            QueryAnswer answer = tx.query("insert $d isa d P999Y12M31DT24H59M59.999999999S;").resolve();
             Duration typedbDuration = answer.asConceptRows().next().get("d").asAttribute().getDuration();
             assertEquals("P12000M31D PT24H59M59.999999999S", typedbDuration.toString()); // we just reuse the java's classes
             assertEquals(12000, typedbDuration.getMonths());

--- a/java/test/integration/core/ValueTest.java
+++ b/java/test/integration/core/ValueTest.java
@@ -161,8 +161,8 @@ public class ValueTest {
                     String attributeName = attribute.getType().getLabel();
                     Value value = attribute.getValue();
                     assertEquals(value.getType(), attributeValueTypes.get(attributeName));
-                    if (value.isLong()) {
-                        assertEquals(Long.parseLong(attributeValues.get(attributeName)), value.getLong());
+                    if (value.isInteger()) {
+                        assertEquals(Long.parseLong(attributeValues.get(attributeName)), value.getInteger());
                         checked.incrementAndGet();
                     } else if (value.isString()) {
                         assertEquals(attributeValues.get(attributeName).substring(1, attributeValues.get(attributeName).length() - 1), value.getString());

--- a/java/test/integration/core/ValueTest.java
+++ b/java/test/integration/core/ValueTest.java
@@ -81,7 +81,7 @@ public class ValueTest {
 
         Map<String, String> attributeValueTypes = Map.ofEntries(
                 Map.entry("root", "none"),
-                Map.entry("age", "long"),
+                Map.entry("age", "integer"),
                 Map.entry("name", "string"),
                 Map.entry("is-new", "boolean"),
                 Map.entry("success", "double"),

--- a/python/README.md
+++ b/python/README.md
@@ -67,7 +67,7 @@ from typedb.driver import *
                 define 
                   entity person, owns name, owns age; 
                   attribute name, value string;
-                  attribute age, value long;
+                  attribute age, value integer;
                 """
                 answer = tx.query(define_query).resolve()
                 if answer.is_ok():

--- a/python/core_example
+++ b/python/core_example
@@ -33,7 +33,7 @@ from typedb.driver import *
                 define 
                   entity person, owns name, owns age; 
                   attribute name, value string;
-                  attribute age, value long;
+                  attribute age, value integer;
                 """
                 answer = tx.query(define_query).resolve()
                 if answer.is_ok():

--- a/python/tests/behaviour/config/parameters.py
+++ b/python/tests/behaviour/config/parameters.py
@@ -115,7 +115,7 @@ register_type(ConceptKind=parse_concept_kind)
 
 class ValueType(Enum):
     BOOLEAN = 0,
-    LONG = 1,
+    INTEGER = 1,
     DOUBLE = 2,
     DECIMAL = 3,
     STRING = 4,
@@ -126,7 +126,7 @@ class ValueType(Enum):
     STRUCT = 9,
 
 
-@parse.with_pattern(r"boolean|long|double|decimal|string|date|datetime|datetime-tz|duration|struct")
+@parse.with_pattern(r"boolean|integer|double|decimal|string|date|datetime|datetime-tz|duration|struct")
 def parse_value_type(text: str) -> ValueType:
     value_type_opt = try_parse_value_type(text)
     if value_type_opt is None:
@@ -137,8 +137,8 @@ def parse_value_type(text: str) -> ValueType:
 def try_parse_value_type(text: str) -> Optional[ValueType]:
     if text == "boolean":
         return ValueType.BOOLEAN
-    elif text == "long":
-        return ValueType.LONG
+    elif text == "integer":
+        return ValueType.INTEGER
     elif text == "double":
         return ValueType.DOUBLE
     elif text == "decimal":

--- a/python/tests/behaviour/query/query_steps.py
+++ b/python/tests/behaviour/query/query_steps.py
@@ -504,10 +504,10 @@ def step_impl(context: Context, row_index: int, kind: ConceptKind, is_by_var_ind
 
 
 @step(
-    "answer get row({row_index:Int}) get {kind:ConceptKind}{is_by_var_index:IsByVarIndex}({var:Var}) is long: {is_long:Bool}")
-def step_impl(context: Context, row_index: int, kind: ConceptKind, is_by_var_index: bool, var: str, is_long: bool):
-    result = get_row_get_concept_of_kind(context, row_index, var, is_by_var_index, kind).is_long()
-    assert_that(result, is_(is_long))
+    "answer get row({row_index:Int}) get {kind:ConceptKind}{is_by_var_index:IsByVarIndex}({var:Var}) is integer: {is_integer:Bool}")
+def step_impl(context: Context, row_index: int, kind: ConceptKind, is_by_var_index: bool, var: str, is_integer: bool):
+    result = get_row_get_concept_of_kind(context, row_index, var, is_by_var_index, kind).is_integer()
+    assert_that(result, is_(is_integer))
 
 
 @step(
@@ -593,7 +593,7 @@ def parse_expected_value(value: str, value_type: Optional[ValueType]):
 
     if value_type == ValueType.BOOLEAN:
         return parse_bool(value)
-    elif value_type == ValueType.LONG:
+    elif value_type == ValueType.INTEGER:
         return int(value)
     elif value_type == ValueType.DOUBLE:
         return float(value)
@@ -629,8 +629,8 @@ def parse_expected_value(value: str, value_type: Optional[ValueType]):
 def get_by_value_type(concept, value_type: ValueType) -> Concept.VALUE:
     if value_type == ValueType.BOOLEAN:
         return concept.get_boolean()
-    elif value_type == ValueType.LONG:
-        return concept.get_long()
+    elif value_type == ValueType.INTEGER:
+        return concept.get_integer()
     elif value_type == ValueType.DOUBLE:
         return concept.get_double()
     elif value_type == ValueType.DECIMAL:
@@ -654,8 +654,8 @@ def get_by_value_type(concept, value_type: ValueType) -> Concept.VALUE:
 def try_get_by_value_type(concept, value_type: ValueType) -> Optional[Concept.VALUE]:
     if value_type == ValueType.BOOLEAN:
         return concept.try_get_boolean()
-    elif value_type == ValueType.LONG:
-        return concept.try_get_long()
+    elif value_type == ValueType.INTEGER:
+        return concept.try_get_integer()
     elif value_type == ValueType.DOUBLE:
         return concept.try_get_double()
     elif value_type == ValueType.DECIMAL:

--- a/python/tests/integration/core/test_example.py
+++ b/python/tests/integration/core/test_example.py
@@ -65,7 +65,7 @@ class TestExample(TestCase):
                 define 
                   entity person, owns name, owns age; 
                   attribute name, value string;
-                  attribute age, value long;
+                  attribute age, value integer;
                 """
                 answer = tx.query(define_query).resolve()
                 if answer.is_ok():
@@ -140,8 +140,8 @@ class TestExample(TestCase):
                         print(f"Defined attribute type's label: '{attribute_type.get_label()}', "
                               f"value type: '{attribute_type.try_get_value_type()}'")
 
-                        assert_that(attribute_type.is_long() or attribute_type.is_string(), is_(True))
-                        assert_that(attribute_type.try_get_value_type(), is_in(["long", "string"]))
+                        assert_that(attribute_type.is_integer() or attribute_type.is_string(), is_(True))
+                        assert_that(attribute_type.try_get_value_type(), is_in(["integer", "string"]))
                         assert_that(attribute_type.get_label(), is_in(["age", "name"]))
                         assert_that(attribute_type.get_label(), is_not("person"))
                         assert_that(attribute_type.get_label(), is_not("person:age"))

--- a/python/tests/integration/core/test_values.py
+++ b/python/tests/integration/core/test_values.py
@@ -42,7 +42,7 @@ class TestValues(TestCase):
     def test_values(self):
         attribute_value_types = {
             "root": "none",
-            "age": "long",
+            "age": "integer",
             "name": "string",
             "is-new": "boolean",
             "success": "double",
@@ -121,7 +121,7 @@ class TestValues(TestCase):
                     value = attribute.get_value()
                     expected = attribute_values[attribute_name]
 
-                    if attribute.is_long():
+                    if attribute.is_integer():
                         assert_that(value, is_(int(expected)))
                         checked += 1
                     elif attribute.is_string():

--- a/python/tests/integration/core/test_values.py
+++ b/python/tests/integration/core/test_values.py
@@ -256,7 +256,7 @@ class TestValues(TestCase):
                             is_not(typedb_datetime))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $dt 0001-01-01T00:00:00.000000001 isa dt;").resolve()
+                answer = tx.query("insert $dt isa dt 0001-01-01T00:00:00.000000001;").resolve()
                 typedb_datetime = list(answer.as_concept_rows())[0].get("dt").as_attribute().get_datetime()
 
                 assert_that(f"{typedb_datetime}", is_("0001-01-01T00:00:00.000000001"))
@@ -277,7 +277,7 @@ class TestValues(TestCase):
                 assert_that(Datetime.utcfromstring("0001-01-01T00:00:00.000000001"), is_(typedb_datetime))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $dt 1970-01-01T00:00:00 isa dt;").resolve()
+                answer = tx.query("insert $dt isa dt 1970-01-01T00:00:00;").resolve()
                 typedb_datetime = list(answer.as_concept_rows())[0].get("dt").as_attribute().get_datetime()
 
                 assert_that(f"{typedb_datetime}", is_("1970-01-01T00:00:00.000000000"))
@@ -300,7 +300,7 @@ class TestValues(TestCase):
                 assert_that(Datetime.utcfromtimestamp(timestamp_seconds=0, subsec_nanos=0), is_(typedb_datetime))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $dt 9999-12-31T23:59:59.999999999 isa dt;").resolve()
+                answer = tx.query("insert $dt isa dt 9999-12-31T23:59:59.999999999;").resolve()
                 typedb_datetime = list(answer.as_concept_rows())[0].get("dt").as_attribute().get_datetime()
 
                 assert_that(f"{typedb_datetime}", is_("9999-12-31T23:59:59.999999999"))
@@ -322,7 +322,7 @@ class TestValues(TestCase):
                 assert_that(Datetime.utcfromstring("9999-12-31T23:59:59.999999999"), is_(typedb_datetime))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $dtz 2024-10-09T13:07:38.123456789 Asia/Calcutta isa dtz;").resolve()
+                answer = tx.query("insert $dtz isa dtz 2024-10-09T13:07:38.123456789 Asia/Calcutta;").resolve()
                 typedb_datetime = list(answer.as_concept_rows())[0].get("dtz").as_attribute().get_datetime_tz()
 
                 assert_that(f"{typedb_datetime}", is_("2024-10-09T13:07:38.123456789+05:30"))

--- a/python/tests/integration/core/test_values.py
+++ b/python/tests/integration/core/test_values.py
@@ -192,7 +192,7 @@ class TestValues(TestCase):
                 tx.commit()
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $dt 2024-10-09T13:07:38.123456789 isa dt;").resolve()
+                answer = tx.query("insert $dt isa dt  2024-10-09T13:07:38.123456789;").resolve()
                 # answer = tx.query("match $dt isa dt;").resolve() # TODO: Looks like it doesn't work...
                 typedb_datetime = list(answer.as_concept_rows())[0].get("dt").as_attribute().get_datetime()
 

--- a/python/tests/integration/core/test_values.py
+++ b/python/tests/integration/core/test_values.py
@@ -382,7 +382,7 @@ class TestValues(TestCase):
                 tx.commit()
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P1Y isa d;").resolve()
+                answer = tx.query("insert $d isa d P1Y;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 12, days: 0, nanos: 0"))
@@ -394,7 +394,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0Y1M0DT0H0M0S"), is_not(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P1M isa d;").resolve()
+                answer = tx.query("insert $d isa d P1M;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 1, days: 0, nanos: 0"))
@@ -408,7 +408,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0Y0M28DT0H0M0S"), is_not(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P1D isa d;").resolve()
+                answer = tx.query("insert $d isa d P1D;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 0, days: 1, nanos: 0"))
@@ -418,7 +418,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0Y0M1DT0H0M0S"), is_(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P0DT1H isa d;").resolve()
+                answer = tx.query("insert $d isa d P0DT1H;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 0, days: 0, nanos: 3600000000000"))
@@ -428,7 +428,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0Y0M0DT1H0M0S"), is_(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P0DT1S isa d;").resolve()
+                answer = tx.query("insert $d isa d P0DT1S;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 0, days: 0, nanos: 1000000000"))
@@ -438,7 +438,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0Y0M0DT0H0M1S"), is_(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P0DT0.000000001S isa d;").resolve()
+                answer = tx.query("insert $d isa d P0DT0.000000001S;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 0, days: 0, nanos: 1"))
@@ -448,7 +448,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0Y0M0DT0H0M0.000000001S"), is_(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P0DT0.0000001S isa d;").resolve()
+                answer = tx.query("insert $d isa d P0DT0.0000001S;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 0, days: 0, nanos: 100"))
@@ -458,7 +458,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0Y0M0DT0H0M0.0000001S"), is_(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P0DT0S isa d;").resolve()
+                answer = tx.query("insert $d isa d P0DT0S;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 0, days: 0, nanos: 0"))
@@ -469,7 +469,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0W"), is_(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P7W isa d;").resolve()
+                answer = tx.query("insert $d isa d P7W;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 0, days: 49, nanos: 0"))
@@ -480,7 +480,7 @@ class TestValues(TestCase):
                 assert_that(Duration.fromstring("P0Y0M49DT0H0M0S"), is_(typedb_duration))
 
             with driver.transaction(database.name, WRITE) as tx:
-                answer = tx.query("insert $d P999Y12M31DT24H59M59.999999999S isa d;").resolve()
+                answer = tx.query("insert $d isa d P999Y12M31DT24H59M59.999999999S;").resolve()
                 typedb_duration = list(answer.as_concept_rows())[0].get("d").as_attribute().get_duration()
 
                 assert_that(f"{typedb_duration}", is_("months: 12000, days: 31, nanos: 89999999999999"))

--- a/python/typedb/api/concept/concept.py
+++ b/python/typedb/api/concept/concept.py
@@ -341,10 +341,10 @@ class Concept(ABC):
         pass
 
     @abstractmethod
-    def is_long(self) -> bool:
+    def is_integer(self) -> bool:
         """
-        Returns ``True`` if the value which this ``Concept`` holds is of type ``long``
-        or if this ``Concept`` is an ``AttributeType`` of type ``long``.
+        Returns ``True`` if the value which this ``Concept`` holds is of type ``integer``
+        or if this ``Concept`` is an ``AttributeType`` of type ``integer``.
         Otherwise, returns ``False``.
 
         :return:
@@ -353,7 +353,7 @@ class Concept(ABC):
         --------
         ::
 
-            concept.is_long()
+            concept.is_integer()
         """
         pass
 
@@ -512,9 +512,9 @@ class Concept(ABC):
         pass
 
     @abstractmethod
-    def try_get_long(self) -> Optional[int]:
+    def try_get_integer(self) -> Optional[int]:
         """
-        Returns a ``long`` value of this ``Concept``.
+        Returns a ``integer`` value of this ``Concept``.
         If it's not a ``Value`` or it has another type, raises an exception.
 
         :return:
@@ -523,7 +523,7 @@ class Concept(ABC):
         --------
         ::
 
-            value.try_get_long()
+            value.try_get_integer()
         """
         pass
 

--- a/python/typedb/api/concept/instance/attribute.py
+++ b/python/typedb/api/concept/instance/attribute.py
@@ -102,9 +102,9 @@ class Attribute(Instance, ABC):
         pass
 
     @abstractmethod
-    def get_long(self) -> int:
+    def get_integer(self) -> int:
         """
-        Returns a ``long`` value of the value concept that this attribute holds. If the value has
+        Returns a ``integer`` value of the value concept that this attribute holds. If the value has
         another type, raises an exception.
 
         :return:
@@ -113,7 +113,7 @@ class Attribute(Instance, ABC):
         --------
         ::
 
-            attribute.get_long()
+            attribute.get_integer()
         """
         pass
 

--- a/python/typedb/api/concept/value/value.py
+++ b/python/typedb/api/concept/value/value.py
@@ -102,9 +102,9 @@ class Value(Concept, ABC):
         pass
 
     @abstractmethod
-    def get_long(self) -> int:
+    def get_integer(self) -> int:
         """
-        Returns a ``long`` value of this value concept. If the value has
+        Returns a ``integer`` value of this value concept. If the value has
         another type, raises an exception.
 
         :return:
@@ -113,7 +113,7 @@ class Value(Concept, ABC):
         --------
         ::
 
-            value.get_long()
+            value.get_integer()
         """
         pass
 

--- a/python/typedb/concept/concept.py
+++ b/python/typedb/concept/concept.py
@@ -32,11 +32,11 @@ from typedb.concept.concept_factory import wrap_concept
 from typedb.concept.concept_factory import wrap_value
 from typedb.native_driver_wrapper import (concept_try_get_iid, concept_to_string, concept_equals, concept_get_label,
                                           concept_try_get_label, concept_try_get_value_type, concept_try_get_value,
-                                          concept_is_boolean, concept_is_long, concept_is_double, concept_is_decimal,
+                                          concept_is_boolean, concept_is_integer, concept_is_double, concept_is_decimal,
                                           concept_is_string, concept_is_date,
                                           concept_is_datetime, concept_is_datetime_tz, concept_is_duration,
                                           concept_is_struct,
-                                          concept_get_boolean, concept_get_long, concept_get_double,
+                                          concept_get_boolean, concept_get_integer, concept_get_double,
                                           concept_get_decimal, concept_get_string,
                                           concept_get_date_as_seconds, concept_get_datetime, concept_get_datetime_tz,
                                           concept_get_duration, concept_get_struct,
@@ -72,8 +72,8 @@ class _Concept(Concept, NativeWrapper[NativeConcept], ABC):
     def is_boolean(self) -> bool:
         return concept_is_boolean(self.native_object)
 
-    def is_long(self) -> bool:
-        return concept_is_long(self.native_object)
+    def is_integer(self) -> bool:
+        return concept_is_integer(self.native_object)
 
     def is_double(self) -> bool:
         return concept_is_double(self.native_object)
@@ -104,10 +104,10 @@ class _Concept(Concept, NativeWrapper[NativeConcept], ABC):
             return None
         return concept_get_boolean(self.native_object)
 
-    def try_get_long(self) -> Optional[int]:
-        if self.is_type() or not self.is_long():
+    def try_get_integer(self) -> Optional[int]:
+        if self.is_type() or not self.is_integer():
             return None
-        return concept_get_long(self.native_object)
+        return concept_get_integer(self.native_object)
 
     def try_get_double(self) -> Optional[float]:
         if self.is_type() or not self.is_double():

--- a/python/typedb/concept/instance/attribute.py
+++ b/python/typedb/concept/instance/attribute.py
@@ -47,8 +47,8 @@ class _Attribute(Attribute, _Instance):
     def get_boolean(self) -> bool:
         return self._get_value_concept().get_boolean()
 
-    def get_long(self) -> int:
-        return self._get_value_concept().get_long()
+    def get_integer(self) -> int:
+        return self._get_value_concept().get_integer()
 
     def get_double(self) -> float:
         return self._get_value_concept().get_double()

--- a/python/typedb/concept/value/value.py
+++ b/python/typedb/concept/value/value.py
@@ -38,8 +38,8 @@ class _Value(Value, _Concept):
     def get(self) -> Concept.VALUE:
         if self.is_boolean():
             return self.get_boolean()
-        elif self.is_long():
-            return self.get_long()
+        elif self.is_integer():
+            return self.get_integer()
         elif self.is_double():
             return self.get_double()
         elif self.is_decimal():
@@ -64,9 +64,9 @@ class _Value(Value, _Concept):
             raise TypeDBDriverException(INVALID_VALUE_RETRIEVAL, "boolean")
         return value
 
-    def get_long(self) -> int:
-        if (value := self.try_get_long()) is None:
-            raise TypeDBDriverException(INVALID_VALUE_RETRIEVAL, "long")
+    def get_integer(self) -> int:
+        if (value := self.try_get_integer()) is None:
+            raise TypeDBDriverException(INVALID_VALUE_RETRIEVAL, "integer")
         return value
 
     def get_double(self) -> float:

--- a/rust/README.md
+++ b/rust/README.md
@@ -117,7 +117,7 @@ fn typedb_example() {
         define
           entity person, owns name, owns age;
           attribute name, value string;
-          attribute age, value long;
+          attribute age, value integer;
         "#;
         let answer = transaction.query(define_query).await.unwrap();
 

--- a/rust/core_example
+++ b/rust/core_example
@@ -52,7 +52,7 @@ fn typedb_example() {
         define
           entity person, owns name, owns age;
           attribute name, value string;
-          attribute age, value long;
+          attribute age, value integer;
         "#;
         let answer = transaction.query(define_query).await.unwrap();
 

--- a/rust/src/answer/concept_document.rs
+++ b/rust/src/answer/concept_document.rs
@@ -136,7 +136,7 @@ fn json_attribute_type(label: Cow<'static, str>, value_type: Option<ValueType>) 
 fn json_value_type(value_type: Option<ValueType>) -> JSON {
     const NONE: Cow<'static, str> = Cow::Borrowed(ValueType::NONE_STR);
     const BOOLEAN: Cow<'static, str> = Cow::Borrowed(ValueType::BOOLEAN_STR);
-    const LONG: Cow<'static, str> = Cow::Borrowed(ValueType::LONG_STR);
+    const INTEGER: Cow<'static, str> = Cow::Borrowed(ValueType::INTEGER_STR);
     const DOUBLE: Cow<'static, str> = Cow::Borrowed(ValueType::DOUBLE_STR);
     const DECIMAL: Cow<'static, str> = Cow::Borrowed(ValueType::DECIMAL_STR);
     const STRING: Cow<'static, str> = Cow::Borrowed(ValueType::STRING_STR);
@@ -148,7 +148,7 @@ fn json_value_type(value_type: Option<ValueType>) -> JSON {
     JSON::String(match value_type {
         None => NONE,
         Some(ValueType::Boolean) => BOOLEAN,
-        Some(ValueType::Long) => LONG,
+        Some(ValueType::Integer) => INTEGER,
         Some(ValueType::Double) => DOUBLE,
         Some(ValueType::Decimal) => DECIMAL,
         Some(ValueType::String) => STRING,
@@ -163,7 +163,7 @@ fn json_value_type(value_type: Option<ValueType>) -> JSON {
 fn json_value(value: Value) -> JSON {
     match value {
         Value::Boolean(bool) => JSON::Boolean(bool),
-        Value::Long(long) => JSON::Number(long as f64),
+        Value::Integer(integer) => JSON::Number(integer as f64),
         Value::Double(double) => JSON::Number(double),
         Value::String(string) => JSON::String(Cow::Owned(string)),
 

--- a/rust/src/concept/mod.rs
+++ b/rust/src/concept/mod.rs
@@ -176,12 +176,12 @@ impl Concept {
         self.try_get_value().map(|value| value.get_boolean()).flatten()
     }
 
-    /// Retrieves the long value of this Concept, if it exists.
-    /// If this is a long-valued Attribute Instance, returns the long value of this instance.
-    /// If this a long-valued Value, returns the long value.
+    /// Retrieves the integer value of this Concept, if it exists.
+    /// If this is an integer-valued Attribute Instance, returns the integer value of this instance.
+    /// If this an integer-valued Value, returns the integer value.
     /// Otherwise, returns None.
-    pub fn try_get_long(&self) -> Option<i64> {
-        self.try_get_value().map(|value| value.get_long()).flatten()
+    pub fn try_get_integer(&self) -> Option<i64> {
+        self.try_get_value().map(|value| value.get_integer()).flatten()
     }
 
     /// Retrieves the double value of this Concept, if it exists.
@@ -335,9 +335,9 @@ impl Concept {
         matches!(self.try_get_value_type(), Some(ValueType::Boolean))
     }
 
-    /// Check if this Concept holds a long as an AttributeType, an Attribute, or a Value
-    pub fn is_long(&self) -> bool {
-        matches!(self.try_get_value_type(), Some(ValueType::Long))
+    /// Check if this Concept holds an integer as an AttributeType, an Attribute, or a Value
+    pub fn is_integer(&self) -> bool {
+        matches!(self.try_get_value_type(), Some(ValueType::Integer))
     }
 
     /// Check if this Concept holds a fixed-decimal as an AttributeType, an Attribute, or a Value

--- a/rust/src/concept/value.rs
+++ b/rust/src/concept/value.rs
@@ -33,7 +33,7 @@ use crate::Error;
 #[derive(Clone, PartialEq, Eq)]
 pub enum ValueType {
     Boolean,
-    Long,
+    Integer,
     Double,
     Decimal,
     String,
@@ -47,7 +47,7 @@ pub enum ValueType {
 impl ValueType {
     pub(crate) const NONE_STR: &'static str = "none";
     pub(crate) const BOOLEAN_STR: &'static str = "boolean";
-    pub(crate) const LONG_STR: &'static str = "long";
+    pub(crate) const INTEGER_STR: &'static str = "integer";
     pub(crate) const DOUBLE_STR: &'static str = "double";
     pub(crate) const DECIMAL_STR: &'static str = "decimal";
     pub(crate) const STRING_STR: &'static str = "string";
@@ -59,7 +59,7 @@ impl ValueType {
     pub fn name(&self) -> &str {
         match self {
             Self::Boolean => Self::BOOLEAN_STR,
-            Self::Long => Self::LONG_STR,
+            Self::Integer => Self::INTEGER_STR,
             Self::Double => Self::DOUBLE_STR,
             Self::Decimal => Self::DECIMAL_STR,
             Self::String => Self::STRING_STR,
@@ -87,7 +87,7 @@ impl fmt::Debug for ValueType {
 #[derive(Clone, PartialEq)]
 pub enum Value {
     Boolean(bool),
-    Long(i64),
+    Integer(i64),
     Double(f64),
     Decimal(Decimal),
     String(String),
@@ -109,7 +109,7 @@ impl Value {
     pub fn get_type(&self) -> ValueType {
         match self {
             Self::Boolean(_) => ValueType::Boolean,
-            Self::Long(_) => ValueType::Long,
+            Self::Integer(_) => ValueType::Integer,
             Self::Double(_) => ValueType::Double,
             Self::String(_) => ValueType::String,
             Self::Decimal(_) => ValueType::Decimal,
@@ -131,7 +131,7 @@ impl Value {
     pub fn get_type_name(&self) -> &str {
         match self {
             Self::Boolean(_) => ValueType::Boolean.name(),
-            Self::Long(_) => ValueType::Long.name(),
+            Self::Integer(_) => ValueType::Integer.name(),
             Self::Double(_) => ValueType::Double.name(),
             Self::String(_) => ValueType::String.name(),
             Self::Decimal(_) => ValueType::Decimal.name(),
@@ -151,9 +151,9 @@ impl Value {
         }
     }
 
-    pub fn get_long(&self) -> Option<i64> {
-        if let Value::Long(long) = self {
-            Some(*long)
+    pub fn get_integer(&self) -> Option<i64> {
+        if let Value::Integer(integer) = self {
+            Some(*integer)
         } else {
             None
         }
@@ -228,7 +228,7 @@ impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Boolean(bool) => write!(f, "{}", bool),
-            Self::Long(long) => write!(f, "{}", long),
+            Self::Integer(integer) => write!(f, "{}", integer),
             Self::Double(double) => write!(f, "{}", double),
             Self::String(string) => write!(f, "\"{}\"", string),
             Self::Decimal(decimal) => write!(f, "{}", decimal),
@@ -249,7 +249,7 @@ impl fmt::Debug for Value {
         write!(f, "{}: ", self.get_type_name())?;
         match self {
             Value::Boolean(bool) => write!(f, "{}", bool),
-            Value::Long(long) => write!(f, "{}", long),
+            Value::Integer(integer) => write!(f, "{}", integer),
             Value::Double(double) => write!(f, "{}", double),
             Value::Decimal(decimal) => write!(f, "{}", decimal),
             Value::String(string) => write!(f, "\"{}\"", string),

--- a/rust/src/connection/network/proto/concept.rs
+++ b/rust/src/connection/network/proto/concept.rs
@@ -207,7 +207,7 @@ impl FromProto<ValueTypeProto> for ValueType {
     fn from_proto(proto: ValueTypeProto) -> Self {
         match proto {
             ValueTypeProto::Boolean(_) => Self::Boolean,
-            ValueTypeProto::Long(_) => Self::Long,
+            ValueTypeProto::Integer(_) => Self::Integer,
             ValueTypeProto::Double(_) => Self::Double,
             ValueTypeProto::String(_) => Self::String,
             ValueTypeProto::Decimal(_) => Self::Decimal,
@@ -260,7 +260,7 @@ impl TryFromProto<ValueProto> for Value {
     fn try_from_proto(proto: ValueProto) -> Result<Self> {
         match proto.value {
             Some(ValueProtoInner::Boolean(boolean)) => Ok(Self::Boolean(boolean)),
-            Some(ValueProtoInner::Long(long)) => Ok(Self::Long(long)),
+            Some(ValueProtoInner::Integer(integer)) => Ok(Self::Integer(integer)),
             Some(ValueProtoInner::Double(double)) => Ok(Self::Double(double)),
             Some(ValueProtoInner::String(string)) => Ok(Self::String(string)),
             Some(ValueProtoInner::Decimal(decimal)) => {

--- a/rust/tests/behaviour/steps/params.rs
+++ b/rust/tests/behaviour/steps/params.rs
@@ -200,7 +200,10 @@ impl FromStr for Value {
 }
 
 #[derive(Clone, Debug, Parameter)]
-#[param(name = "value_type", regex = r"boolean|integer|double|decimal|string|date|datetime|datetime-tz|duration|struct")]
+#[param(
+    name = "value_type",
+    regex = r"boolean|integer|double|decimal|string|date|datetime|datetime-tz|duration|struct"
+)]
 pub struct ValueType {
     pub value_type: TypeDBValueType,
 }

--- a/rust/tests/behaviour/steps/params.rs
+++ b/rust/tests/behaviour/steps/params.rs
@@ -97,7 +97,7 @@ impl Value {
     pub fn into_typedb(self, value_type: TypeDBValueType) -> TypeDBValue {
         match value_type {
             TypeDBValueType::Boolean => TypeDBValue::Boolean(self.raw_value.parse().unwrap()),
-            TypeDBValueType::Long => TypeDBValue::Long(self.raw_value.parse().unwrap()),
+            TypeDBValueType::Integer => TypeDBValue::Integer(self.raw_value.parse().unwrap()),
             TypeDBValueType::Double => TypeDBValue::Double(self.raw_value.parse().unwrap()),
             TypeDBValueType::Decimal => {
                 let (integer, fractional) = if let Some(split) = self.raw_value.split_once(".") {
@@ -200,7 +200,7 @@ impl FromStr for Value {
 }
 
 #[derive(Clone, Debug, Parameter)]
-#[param(name = "value_type", regex = r"boolean|long|double|decimal|string|date|datetime|datetime-tz|duration|struct")]
+#[param(name = "value_type", regex = r"boolean|integer|double|decimal|string|date|datetime|datetime-tz|duration|struct")]
 pub struct ValueType {
     pub value_type: TypeDBValueType,
 }
@@ -211,7 +211,7 @@ impl FromStr for ValueType {
     fn from_str(type_: &str) -> Result<Self, Self::Err> {
         Ok(match type_ {
             "boolean" => Self { value_type: TypeDBValueType::Boolean },
-            "long" => Self { value_type: TypeDBValueType::Long },
+            "integer" => Self { value_type: TypeDBValueType::Integer },
             "double" => Self { value_type: TypeDBValueType::Double },
             "decimal" => Self { value_type: TypeDBValueType::Decimal },
             "string" => Self { value_type: TypeDBValueType::String },

--- a/rust/tests/behaviour/steps/query.rs
+++ b/rust/tests/behaviour/steps/query.rs
@@ -624,7 +624,7 @@ pub async fn answer_get_row_get_variable_get_value_of_type(
     let type_name = value_type.value_type.name().to_string();
     may_error.check(match value_type.value_type {
         ValueType::Boolean => concept.try_get_boolean().map(|_| ()).ok_or(InvalidValueRetrieval(type_name)),
-        ValueType::Long => concept.try_get_long().map(|_| ()).ok_or(InvalidValueRetrieval(type_name)),
+        ValueType::Integer => concept.try_get_integer().map(|_| ()).ok_or(InvalidValueRetrieval(type_name)),
         ValueType::Double => concept.try_get_double().map(|_| ()).ok_or(InvalidValueRetrieval(type_name)),
         ValueType::Decimal => concept.try_get_decimal().map(|_| ()).ok_or(InvalidValueRetrieval(type_name)),
         ValueType::String => concept.try_get_string().map(|_| ()).ok_or(InvalidValueRetrieval(type_name)),
@@ -683,10 +683,10 @@ pub async fn answer_get_row_get_variable_get_specific_value(
                 _ => is_or_not.check(false),
             }
         }
-        ValueType::Long => {
-            let actual_long = concept.try_get_long().unwrap();
+        ValueType::Integer => {
+            let actual_integer = concept.try_get_integer().unwrap();
             match expected_value {
-                Value::Long(expected_long) => is_or_not.compare(actual_long, expected_long),
+                Value::Integer(expected_integer) => is_or_not.compare(actual_integer, expected_integer),
                 _ => is_or_not.check(false),
             }
         }
@@ -766,18 +766,18 @@ pub async fn answer_get_row_get_variable_is_boolean(
 }
 
 #[apply(generic_step)]
-#[step(expr = r"answer get row\({int}\) get {concept_kind}{is_by_var_index}\({var}\) is long: {boolean}")]
-pub async fn answer_get_row_get_variable_is_long(
+#[step(expr = r"answer get row\({int}\) get {concept_kind}{is_by_var_index}\({var}\) is integer: {boolean}")]
+pub async fn answer_get_row_get_variable_is_integer(
     context: &mut Context,
     index: usize,
     var_kind: params::ConceptKind,
     is_by_var_index: params::IsByVarIndex,
     var: params::Var,
-    is_long: params::Boolean,
+    is_integer: params::Boolean,
 ) {
     let concept = get_answer_rows_var(context, index, is_by_var_index, var).await.unwrap();
     check_concept_is_kind(concept, var_kind, params::Boolean::True);
-    check_boolean!(is_long, concept.is_long());
+    check_boolean!(is_integer, concept.is_integer());
 }
 
 #[apply(generic_step)]

--- a/rust/tests/integration/core/example.rs
+++ b/rust/tests/integration/core/example.rs
@@ -95,7 +95,7 @@ fn example() {
         define
           entity person, owns name, owns age;
           attribute name, value string;
-          attribute age, value long;
+          attribute age, value integer;
         "#;
         let answer = transaction.query(define_query).await.unwrap();
 
@@ -161,14 +161,14 @@ fn example() {
             let concept_by_name = row.get(column_name).unwrap();
             assert!(concept_by_name.is_attribute_type());
             assert!(concept_by_name.is_type());
-            assert!(concept_by_name.is_long() || concept_by_name.is_string());
+            assert!(concept_by_name.is_integer() || concept_by_name.is_string());
 
             // Check if it's an attribute type to safely retrieve its value type
             if concept_by_name.is_attribute_type() {
                 let label = concept_by_name.get_label();
                 let value_type = concept_by_name.try_get_value_type().unwrap();
                 println!("Defined attribute type's label: '{label}', value type: '{value_type}'");
-                assert!(value_type == ValueType::Long || value_type == ValueType::String);
+                assert!(value_type == ValueType::Integer || value_type == ValueType::String);
                 assert!(label == "age" || label == "name");
                 assert_ne!(concept_by_name.get_label(), "person");
                 assert_ne!(concept_by_name.get_label(), "person:age");


### PR DESCRIPTION
## Usage and product changes
Renames the TypeQL `long` datatype to `integer`
