### PR TITLE
Optimise driver dispatch loop

### DIFF
--- a/rust/src/connection/network/transmitter/transaction.rs
+++ b/rust/src/connection/network/transmitter/transaction.rs
@@ -260,7 +260,7 @@ impl TransactionTransmitter {
     ) {
         const MAX_GRPC_MESSAGE_LEN: usize = 1_000_000;
         const DISPATCH_INTERVAL: Duration = Duration::from_micros(50);
-        const SLEEP_INTERVAL: Duration = Duration::from_micros(1);
+        const SLEEP_INTERVAL: Duration = Duration::from_micros(10);
         let mut next_dispatch = Instant::now() + DISPATCH_INTERVAL;
 
         let mut request_buffer = TransactionRequestBuffer::default();

--- a/rust/src/connection/network/transmitter/transaction.rs
+++ b/rust/src/connection/network/transmitter/transaction.rs
@@ -290,7 +290,8 @@ impl TransactionTransmitter {
             }
         }
     }
-async fn listen_loop( mut grpc_source: Streaming<transaction::Server>,
+    async fn listen_loop(
+        mut grpc_source: Streaming<transaction::Server>,
         collector: ResponseCollector,
         shutdown_sink: UnboundedSender<()>,
     ) {

--- a/rust/src/connection/network/transmitter/transaction.rs
+++ b/rust/src/connection/network/transmitter/transaction.rs
@@ -259,7 +259,7 @@ impl TransactionTransmitter {
         mut shutdown_signal: UnboundedReceiver<()>,
     ) {
         const MAX_GRPC_MESSAGE_LEN: usize = 1_000_000;
-        const DISPATCH_INTERVAL: Duration = Duration::from_micros(10);
+        const DISPATCH_INTERVAL: Duration = Duration::from_micros(50);
         const SLEEP_INTERVAL: Duration = Duration::from_micros(1);
         let mut next_dispatch = Instant::now() + DISPATCH_INTERVAL;
 

--- a/rust/src/connection/runtime.rs
+++ b/rust/src/connection/runtime.rs
@@ -47,7 +47,7 @@ impl BackgroundRuntime {
     pub(crate) fn new() -> Result<Self> {
         let is_open = AtomicCell::new(true);
         let (shutdown_sink, mut shutdown_source) = unbounded_async();
-        let async_runtime = runtime::Builder::new_current_thread().enable_time().enable_io().build()?;
+        let async_runtime = runtime::Builder::new_multi_thread().enable_time().enable_io().build()?;
         let async_runtime_handle = async_runtime.handle().clone();
         thread::Builder::new().name("gRPC worker".to_owned()).spawn(move || {
             async_runtime.block_on(async move {

--- a/rust/src/connection/runtime.rs
+++ b/rust/src/connection/runtime.rs
@@ -47,7 +47,7 @@ impl BackgroundRuntime {
     pub(crate) fn new() -> Result<Self> {
         let is_open = AtomicCell::new(true);
         let (shutdown_sink, mut shutdown_source) = unbounded_async();
-        let async_runtime = runtime::Builder::new_multi_thread().enable_time().enable_io().build()?;
+        let async_runtime = runtime::Builder::new_current_thread().enable_time().enable_io().build()?;
         let async_runtime_handle = async_runtime.handle().clone();
         thread::Builder::new().name("gRPC worker".to_owned()).spawn(move || {
             async_runtime.block_on(async move {


### PR DESCRIPTION
## Usage and product changes

We optimise the driver dispatch loop: previously, we could dispatch at most 1000 serial messages per second, though in practice tokio would sometimes sleep longer than expected and the query and transaction latencies increased. This stems from Tokio's approximately millisecond resolution. By moving the collect-dispatch loop to a dedicated thread, we can now dispatch messages after microseconds of batching, improving overall driver performance significantly.

## Implementation

We move the dispatch loop to a dedicated thread, which can sleep for sub-millisecond resolution. We also make the background runtime a multi-threaded runtime for scalability.