### PR TITLE
Prepend current Docs version to all Docs resource URLs

### DIFF
--- a/docs/modules/ROOT/partials/c/api-reference.adoc
+++ b/docs/modules/ROOT/partials/c/api-reference.adoc
@@ -2,85 +2,85 @@
 [#_connection_header]
 == Connection
 
-include::{page-component-version}@api-ref::partial$c/connection/connection.adoc[]
+include::{page-version}@api-ref::partial$c/connection/connection.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/connection/credential.adoc[]
+include::{page-version}@api-ref::partial$c/connection/credential.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/connection/database.adoc[]
+include::{page-version}@api-ref::partial$c/connection/database.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/connection/replica.adoc[]
+include::{page-version}@api-ref::partial$c/connection/replica.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/connection/user.adoc[]
+include::{page-version}@api-ref::partial$c/connection/user.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-component-version}@api-ref::partial$c/session/session.adoc[]
+include::{page-version}@api-ref::partial$c/session/session.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/session/options.adoc[]
+include::{page-version}@api-ref::partial$c/session/options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-component-version}@api-ref::partial$c/transaction/transaction.adoc[]
+include::{page-version}@api-ref::partial$c/transaction/transaction.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/transaction/query.adoc[]
+include::{page-version}@api-ref::partial$c/transaction/query.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-component-version}@api-ref::partial$c/answer/conceptmap.adoc[]
+include::{page-version}@api-ref::partial$c/answer/conceptmap.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/answer/valuegroup.adoc[]
+include::{page-version}@api-ref::partial$c/answer/valuegroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/answer/primitives.adoc[]
+include::{page-version}@api-ref::partial$c/answer/primitives.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/answer/explanation.adoc[]
+include::{page-version}@api-ref::partial$c/answer/explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-component-version}@api-ref::partial$c/concept/concept.adoc[]
+include::{page-version}@api-ref::partial$c/concept/concept.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/concept/thing.adoc[]
+include::{page-version}@api-ref::partial$c/concept/thing.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/concept/entity.adoc[]
+include::{page-version}@api-ref::partial$c/concept/entity.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/concept/attribute.adoc[]
+include::{page-version}@api-ref::partial$c/concept/attribute.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/concept/relation.adoc[]
+include::{page-version}@api-ref::partial$c/concept/relation.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/concept/roleplayer.adoc[]
+include::{page-version}@api-ref::partial$c/concept/roleplayer.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/concept/value.adoc[]
+include::{page-version}@api-ref::partial$c/concept/value.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-component-version}@api-ref::partial$c/schema/entitytype.adoc[]
+include::{page-version}@api-ref::partial$c/schema/entitytype.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/schema/attributetype.adoc[]
+include::{page-version}@api-ref::partial$c/schema/attributetype.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/schema/relationtype.adoc[]
+include::{page-version}@api-ref::partial$c/schema/relationtype.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/schema/roletype.adoc[]
+include::{page-version}@api-ref::partial$c/schema/roletype.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/schema/annotation.adoc[]
+include::{page-version}@api-ref::partial$c/schema/annotation.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/schema/transitivity.adoc[]
+include::{page-version}@api-ref::partial$c/schema/transitivity.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/schema/valuetype.adoc[]
+include::{page-version}@api-ref::partial$c/schema/valuetype.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-component-version}@api-ref::partial$c/logic/logic.adoc[]
+include::{page-version}@api-ref::partial$c/logic/logic.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/logic/rule.adoc[]
+include::{page-version}@api-ref::partial$c/logic/rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-component-version}@api-ref::partial$c/errors/error.adoc[]
+include::{page-version}@api-ref::partial$c/errors/error.adoc[]
 
-include::{page-component-version}@api-ref::partial$c/errors/schemaexception.adoc[]
+include::{page-version}@api-ref::partial$c/errors/schemaexception.adoc[]

--- a/docs/modules/ROOT/partials/c/api-reference.adoc
+++ b/docs/modules/ROOT/partials/c/api-reference.adoc
@@ -2,85 +2,85 @@
 [#_connection_header]
 == Connection
 
-include::api-ref::partial$c/connection/connection.adoc[]
+include::{page-component-version}@api-ref::partial$c/connection/connection.adoc[]
 
-include::api-ref::partial$c/connection/credential.adoc[]
+include::{page-component-version}@api-ref::partial$c/connection/credential.adoc[]
 
-include::api-ref::partial$c/connection/database.adoc[]
+include::{page-component-version}@api-ref::partial$c/connection/database.adoc[]
 
-include::api-ref::partial$c/connection/replica.adoc[]
+include::{page-component-version}@api-ref::partial$c/connection/replica.adoc[]
 
-include::api-ref::partial$c/connection/user.adoc[]
+include::{page-component-version}@api-ref::partial$c/connection/user.adoc[]
 
 [#_session_header]
 == Session
 
-include::api-ref::partial$c/session/session.adoc[]
+include::{page-component-version}@api-ref::partial$c/session/session.adoc[]
 
-include::api-ref::partial$c/session/options.adoc[]
+include::{page-component-version}@api-ref::partial$c/session/options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::api-ref::partial$c/transaction/transaction.adoc[]
+include::{page-component-version}@api-ref::partial$c/transaction/transaction.adoc[]
 
-include::api-ref::partial$c/transaction/query.adoc[]
+include::{page-component-version}@api-ref::partial$c/transaction/query.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::api-ref::partial$c/answer/conceptmap.adoc[]
+include::{page-component-version}@api-ref::partial$c/answer/conceptmap.adoc[]
 
-include::api-ref::partial$c/answer/valuegroup.adoc[]
+include::{page-component-version}@api-ref::partial$c/answer/valuegroup.adoc[]
 
-include::api-ref::partial$c/answer/primitives.adoc[]
+include::{page-component-version}@api-ref::partial$c/answer/primitives.adoc[]
 
-include::api-ref::partial$c/answer/explanation.adoc[]
+include::{page-component-version}@api-ref::partial$c/answer/explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::api-ref::partial$c/concept/concept.adoc[]
+include::{page-component-version}@api-ref::partial$c/concept/concept.adoc[]
 
-include::api-ref::partial$c/concept/thing.adoc[]
+include::{page-component-version}@api-ref::partial$c/concept/thing.adoc[]
 
-include::api-ref::partial$c/concept/entity.adoc[]
+include::{page-component-version}@api-ref::partial$c/concept/entity.adoc[]
 
-include::api-ref::partial$c/concept/attribute.adoc[]
+include::{page-component-version}@api-ref::partial$c/concept/attribute.adoc[]
 
-include::api-ref::partial$c/concept/relation.adoc[]
+include::{page-component-version}@api-ref::partial$c/concept/relation.adoc[]
 
-include::api-ref::partial$c/concept/roleplayer.adoc[]
+include::{page-component-version}@api-ref::partial$c/concept/roleplayer.adoc[]
 
-include::api-ref::partial$c/concept/value.adoc[]
+include::{page-component-version}@api-ref::partial$c/concept/value.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::api-ref::partial$c/schema/entitytype.adoc[]
+include::{page-component-version}@api-ref::partial$c/schema/entitytype.adoc[]
 
-include::api-ref::partial$c/schema/attributetype.adoc[]
+include::{page-component-version}@api-ref::partial$c/schema/attributetype.adoc[]
 
-include::api-ref::partial$c/schema/relationtype.adoc[]
+include::{page-component-version}@api-ref::partial$c/schema/relationtype.adoc[]
 
-include::api-ref::partial$c/schema/roletype.adoc[]
+include::{page-component-version}@api-ref::partial$c/schema/roletype.adoc[]
 
-include::api-ref::partial$c/schema/annotation.adoc[]
+include::{page-component-version}@api-ref::partial$c/schema/annotation.adoc[]
 
-include::api-ref::partial$c/schema/transitivity.adoc[]
+include::{page-component-version}@api-ref::partial$c/schema/transitivity.adoc[]
 
-include::api-ref::partial$c/schema/valuetype.adoc[]
+include::{page-component-version}@api-ref::partial$c/schema/valuetype.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::api-ref::partial$c/logic/logic.adoc[]
+include::{page-component-version}@api-ref::partial$c/logic/logic.adoc[]
 
-include::api-ref::partial$c/logic/rule.adoc[]
+include::{page-component-version}@api-ref::partial$c/logic/rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::api-ref::partial$c/errors/error.adoc[]
+include::{page-component-version}@api-ref::partial$c/errors/error.adoc[]
 
-include::api-ref::partial$c/errors/schemaexception.adoc[]
+include::{page-component-version}@api-ref::partial$c/errors/schemaexception.adoc[]

--- a/docs/modules/ROOT/partials/cpp/api-reference.adoc
+++ b/docs/modules/ROOT/partials/cpp/api-reference.adoc
@@ -2,122 +2,122 @@
 [#_connection_header]
 == Connection
 
-include::api-ref::partial$cpp/connection/Driver.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/connection/Driver.adoc[]
 
-include::api-ref::partial$cpp/connection/Credential.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/connection/Credential.adoc[]
 
-include::api-ref::partial$cpp/connection/DatabaseManager.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/connection/DatabaseManager.adoc[]
 
-include::api-ref::partial$cpp/connection/Database.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/connection/Database.adoc[]
 
-include::api-ref::partial$cpp/connection/ReplicaInfo.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/connection/ReplicaInfo.adoc[]
 
-include::api-ref::partial$cpp/connection/UserManager.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/connection/UserManager.adoc[]
 
-include::api-ref::partial$cpp/connection/User.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::api-ref::partial$cpp/session/Session.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/session/Session.adoc[]
 
-include::api-ref::partial$cpp/session/SessionType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/session/SessionType.adoc[]
 
-include::api-ref::partial$cpp/session/Options.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/session/Options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::api-ref::partial$cpp/transaction/Transaction.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/transaction/Transaction.adoc[]
 
-include::api-ref::partial$cpp/transaction/TransactionType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/transaction/TransactionType.adoc[]
 
-include::api-ref::partial$cpp/transaction/QueryManager.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::api-ref::partial$cpp/answer/ConceptMapGroup.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/ConceptMapGroup.adoc[]
 
-include::api-ref::partial$cpp/answer/ConceptMap.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/ConceptMap.adoc[]
 
-include::api-ref::partial$cpp/answer/ValueGroup.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/ValueGroup.adoc[]
 
-include::api-ref::partial$cpp/answer/JSON.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/JSON.adoc[]
 
-include::api-ref::partial$cpp/answer/JSONType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/JSONType.adoc[]
 
-include::api-ref::partial$cpp/answer/OwnerAttributePair.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/OwnerAttributePair.adoc[]
 
-include::api-ref::partial$cpp/answer/Explainables.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/Explainables.adoc[]
 
-include::api-ref::partial$cpp/answer/Explainable.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/Explainable.adoc[]
 
-include::api-ref::partial$cpp/answer/Explanation.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/Explanation.adoc[]
 
-include::api-ref::partial$cpp/answer/Future.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/Future.adoc[]
 
-include::api-ref::partial$cpp/answer/Iterable.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/Iterable.adoc[]
 
-include::api-ref::partial$cpp/answer/Iterator.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/Iterator.adoc[]
 
-include::api-ref::partial$cpp/answer/typedefs.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/answer/typedefs.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::api-ref::partial$cpp/concept/ConceptManager.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/concept/ConceptManager.adoc[]
 
-include::api-ref::partial$cpp/concept/Concept.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/concept/Concept.adoc[]
 
-include::api-ref::partial$cpp/concept/ConceptType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/concept/ConceptType.adoc[]
 
-include::api-ref::partial$cpp/concept/Transitivity.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/concept/Transitivity.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::api-ref::partial$cpp/schema/Type.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/schema/Type.adoc[]
 
-include::api-ref::partial$cpp/schema/ThingType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/schema/ThingType.adoc[]
 
-include::api-ref::partial$cpp/schema/EntityType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/schema/EntityType.adoc[]
 
-include::api-ref::partial$cpp/schema/RelationType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/schema/RelationType.adoc[]
 
-include::api-ref::partial$cpp/schema/RoleType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/schema/RoleType.adoc[]
 
-include::api-ref::partial$cpp/schema/AttributeType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/schema/AttributeType.adoc[]
 
-include::api-ref::partial$cpp/schema/Annotation.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/schema/Annotation.adoc[]
 
-//include::api-ref::partial$cpp/schema/Transitivity.adoc[]
+//include::{page-component-version}@api-ref::partial$cpp/schema/Transitivity.adoc[]
 
-include::api-ref::partial$cpp/schema/ValueType.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/schema/ValueType.adoc[]
 
-//include::api-ref::partial$cpp/schema/ScopedLabel.adoc[]
+//include::{page-component-version}@api-ref::partial$cpp/schema/ScopedLabel.adoc[]
 
 [#_data_header]
 == Data
 
-include::api-ref::partial$cpp/data/Thing.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/data/Thing.adoc[]
 
-include::api-ref::partial$cpp/data/Entity.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/data/Entity.adoc[]
 
-include::api-ref::partial$cpp/data/Relation.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/data/Relation.adoc[]
 
-include::api-ref::partial$cpp/data/Attribute.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/data/Attribute.adoc[]
 
-include::api-ref::partial$cpp/data/Value.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::api-ref::partial$cpp/logic/LogicManager.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/logic/LogicManager.adoc[]
 
-include::api-ref::partial$cpp/logic/Rule.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::api-ref::partial$cpp/errors/DriverException.adoc[]
+include::{page-component-version}@api-ref::partial$cpp/errors/DriverException.adoc[]

--- a/docs/modules/ROOT/partials/cpp/api-reference.adoc
+++ b/docs/modules/ROOT/partials/cpp/api-reference.adoc
@@ -2,122 +2,122 @@
 [#_connection_header]
 == Connection
 
-include::{page-component-version}@api-ref::partial$cpp/connection/Driver.adoc[]
+include::{page-version}@api-ref::partial$cpp/connection/Driver.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/connection/Credential.adoc[]
+include::{page-version}@api-ref::partial$cpp/connection/Credential.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/connection/DatabaseManager.adoc[]
+include::{page-version}@api-ref::partial$cpp/connection/DatabaseManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/connection/Database.adoc[]
+include::{page-version}@api-ref::partial$cpp/connection/Database.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/connection/ReplicaInfo.adoc[]
+include::{page-version}@api-ref::partial$cpp/connection/ReplicaInfo.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/connection/UserManager.adoc[]
+include::{page-version}@api-ref::partial$cpp/connection/UserManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/connection/User.adoc[]
+include::{page-version}@api-ref::partial$cpp/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-component-version}@api-ref::partial$cpp/session/Session.adoc[]
+include::{page-version}@api-ref::partial$cpp/session/Session.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/session/SessionType.adoc[]
+include::{page-version}@api-ref::partial$cpp/session/SessionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/session/Options.adoc[]
+include::{page-version}@api-ref::partial$cpp/session/Options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-component-version}@api-ref::partial$cpp/transaction/Transaction.adoc[]
+include::{page-version}@api-ref::partial$cpp/transaction/Transaction.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/transaction/TransactionType.adoc[]
+include::{page-version}@api-ref::partial$cpp/transaction/TransactionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/transaction/QueryManager.adoc[]
+include::{page-version}@api-ref::partial$cpp/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-component-version}@api-ref::partial$cpp/answer/ConceptMapGroup.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/ConceptMapGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/ConceptMap.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/ConceptMap.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/ValueGroup.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/ValueGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/JSON.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/JSON.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/JSONType.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/JSONType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/OwnerAttributePair.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/OwnerAttributePair.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/Explainables.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/Explainables.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/Explainable.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/Explainable.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/Explanation.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/Explanation.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/Future.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/Future.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/Iterable.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/Iterable.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/Iterator.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/Iterator.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/answer/typedefs.adoc[]
+include::{page-version}@api-ref::partial$cpp/answer/typedefs.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-component-version}@api-ref::partial$cpp/concept/ConceptManager.adoc[]
+include::{page-version}@api-ref::partial$cpp/concept/ConceptManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/concept/Concept.adoc[]
+include::{page-version}@api-ref::partial$cpp/concept/Concept.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/concept/ConceptType.adoc[]
+include::{page-version}@api-ref::partial$cpp/concept/ConceptType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/concept/Transitivity.adoc[]
+include::{page-version}@api-ref::partial$cpp/concept/Transitivity.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-component-version}@api-ref::partial$cpp/schema/Type.adoc[]
+include::{page-version}@api-ref::partial$cpp/schema/Type.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/schema/ThingType.adoc[]
+include::{page-version}@api-ref::partial$cpp/schema/ThingType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/schema/EntityType.adoc[]
+include::{page-version}@api-ref::partial$cpp/schema/EntityType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/schema/RelationType.adoc[]
+include::{page-version}@api-ref::partial$cpp/schema/RelationType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/schema/RoleType.adoc[]
+include::{page-version}@api-ref::partial$cpp/schema/RoleType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/schema/AttributeType.adoc[]
+include::{page-version}@api-ref::partial$cpp/schema/AttributeType.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/schema/Annotation.adoc[]
+include::{page-version}@api-ref::partial$cpp/schema/Annotation.adoc[]
 
-//include::{page-component-version}@api-ref::partial$cpp/schema/Transitivity.adoc[]
+//include::{page-version}@api-ref::partial$cpp/schema/Transitivity.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/schema/ValueType.adoc[]
+include::{page-version}@api-ref::partial$cpp/schema/ValueType.adoc[]
 
-//include::{page-component-version}@api-ref::partial$cpp/schema/ScopedLabel.adoc[]
+//include::{page-version}@api-ref::partial$cpp/schema/ScopedLabel.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-component-version}@api-ref::partial$cpp/data/Thing.adoc[]
+include::{page-version}@api-ref::partial$cpp/data/Thing.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/data/Entity.adoc[]
+include::{page-version}@api-ref::partial$cpp/data/Entity.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/data/Relation.adoc[]
+include::{page-version}@api-ref::partial$cpp/data/Relation.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/data/Attribute.adoc[]
+include::{page-version}@api-ref::partial$cpp/data/Attribute.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/data/Value.adoc[]
+include::{page-version}@api-ref::partial$cpp/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-component-version}@api-ref::partial$cpp/logic/LogicManager.adoc[]
+include::{page-version}@api-ref::partial$cpp/logic/LogicManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$cpp/logic/Rule.adoc[]
+include::{page-version}@api-ref::partial$cpp/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-component-version}@api-ref::partial$cpp/errors/DriverException.adoc[]
+include::{page-version}@api-ref::partial$cpp/errors/DriverException.adoc[]

--- a/docs/modules/ROOT/partials/csharp/api-reference.adoc
+++ b/docs/modules/ROOT/partials/csharp/api-reference.adoc
@@ -2,116 +2,116 @@
 [#_connection_header]
 == Connection
 
-include::{page-component-version}@api-ref::partial$csharp/connection/Drivers.adoc[]
+include::{page-version}@api-ref::partial$csharp/connection/Drivers.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/connection/ITypeDBDriver.adoc[]
+include::{page-version}@api-ref::partial$csharp/connection/ITypeDBDriver.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/connection/TypeDBCredential.adoc[]
+include::{page-version}@api-ref::partial$csharp/connection/TypeDBCredential.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/connection/IDatabaseManager.adoc[]
+include::{page-version}@api-ref::partial$csharp/connection/IDatabaseManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/connection/IDatabase.adoc[]
+include::{page-version}@api-ref::partial$csharp/connection/IDatabase.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/connection/IReplica.adoc[]
+include::{page-version}@api-ref::partial$csharp/connection/IReplica.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/connection/IUserManager.adoc[]
+include::{page-version}@api-ref::partial$csharp/connection/IUserManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/connection/IUser.adoc[]
+include::{page-version}@api-ref::partial$csharp/connection/IUser.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-component-version}@api-ref::partial$csharp/session/ITypeDBSession.adoc[]
+include::{page-version}@api-ref::partial$csharp/session/ITypeDBSession.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/session/SessionType.adoc[]
+include::{page-version}@api-ref::partial$csharp/session/SessionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/session/TypeDBOptions.adoc[]
+include::{page-version}@api-ref::partial$csharp/session/TypeDBOptions.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-component-version}@api-ref::partial$csharp/transaction/ITypeDBTransaction.adoc[]
+include::{page-version}@api-ref::partial$csharp/transaction/ITypeDBTransaction.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/transaction/TransactionType.adoc[]
+include::{page-version}@api-ref::partial$csharp/transaction/TransactionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/transaction/IQueryManager.adoc[]
+include::{page-version}@api-ref::partial$csharp/transaction/IQueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-component-version}@api-ref::partial$csharp/answer/IConceptMap.adoc[]
+include::{page-version}@api-ref::partial$csharp/answer/IConceptMap.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/answer/IConceptMapGroup.adoc[]
+include::{page-version}@api-ref::partial$csharp/answer/IConceptMapGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/answer/IValueGroup.adoc[]
+include::{page-version}@api-ref::partial$csharp/answer/IValueGroup.adoc[]
 
-// include::{page-component-version}@api-ref::partial$csharp/answer/JSON.adoc[]
+// include::{page-version}@api-ref::partial$csharp/answer/JSON.adoc[]
 
-// include::{page-component-version}@api-ref::partial$csharp/answer/JSONType.adoc[]
+// include::{page-version}@api-ref::partial$csharp/answer/JSONType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/answer/IExplainables.adoc[]
+include::{page-version}@api-ref::partial$csharp/answer/IExplainables.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/answer/IExplainable.adoc[]
+include::{page-version}@api-ref::partial$csharp/answer/IExplainable.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/answer/IExplanation.adoc[]
+include::{page-version}@api-ref::partial$csharp/answer/IExplanation.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/answer/Promise__T__.adoc[]
+include::{page-version}@api-ref::partial$csharp/answer/Promise__T__.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/answer/VoidPromise.adoc[]
+include::{page-version}@api-ref::partial$csharp/answer/VoidPromise.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-component-version}@api-ref::partial$csharp/concept/IConceptManager.adoc[]
+include::{page-version}@api-ref::partial$csharp/concept/IConceptManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/concept/IConcept.adoc[]
+include::{page-version}@api-ref::partial$csharp/concept/IConcept.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/concept/Transitivity.adoc[]
+include::{page-version}@api-ref::partial$csharp/concept/Transitivity.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-component-version}@api-ref::partial$csharp/schema/IType.adoc[]
+include::{page-version}@api-ref::partial$csharp/schema/IType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/schema/IThingType.adoc[]
+include::{page-version}@api-ref::partial$csharp/schema/IThingType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/schema/IEntityType.adoc[]
+include::{page-version}@api-ref::partial$csharp/schema/IEntityType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/schema/IRelationType.adoc[]
+include::{page-version}@api-ref::partial$csharp/schema/IRelationType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/schema/IRoleType.adoc[]
+include::{page-version}@api-ref::partial$csharp/schema/IRoleType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/schema/IAttributeType.adoc[]
+include::{page-version}@api-ref::partial$csharp/schema/IAttributeType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/schema/Annotation.adoc[]
+include::{page-version}@api-ref::partial$csharp/schema/Annotation.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/schema/Label.adoc[]
+include::{page-version}@api-ref::partial$csharp/schema/Label.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-component-version}@api-ref::partial$csharp/data/IThing.adoc[]
+include::{page-version}@api-ref::partial$csharp/data/IThing.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/data/IEntity.adoc[]
+include::{page-version}@api-ref::partial$csharp/data/IEntity.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/data/IRelation.adoc[]
+include::{page-version}@api-ref::partial$csharp/data/IRelation.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/data/IAttribute.adoc[]
+include::{page-version}@api-ref::partial$csharp/data/IAttribute.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/data/IValue.adoc[]
+include::{page-version}@api-ref::partial$csharp/data/IValue.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/data/ValueType.adoc[]
+include::{page-version}@api-ref::partial$csharp/data/ValueType.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/data/ValueTypeExtensions.adoc[]
+include::{page-version}@api-ref::partial$csharp/data/ValueTypeExtensions.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-component-version}@api-ref::partial$csharp/logic/ILogicManager.adoc[]
+include::{page-version}@api-ref::partial$csharp/logic/ILogicManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$csharp/logic/IRule.adoc[]
+include::{page-version}@api-ref::partial$csharp/logic/IRule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-component-version}@api-ref::partial$csharp/errors/TypeDBDriverException.adoc[]
+include::{page-version}@api-ref::partial$csharp/errors/TypeDBDriverException.adoc[]

--- a/docs/modules/ROOT/partials/csharp/api-reference.adoc
+++ b/docs/modules/ROOT/partials/csharp/api-reference.adoc
@@ -2,116 +2,116 @@
 [#_connection_header]
 == Connection
 
-include::api-ref::partial$csharp/connection/Drivers.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/connection/Drivers.adoc[]
 
-include::api-ref::partial$csharp/connection/ITypeDBDriver.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/connection/ITypeDBDriver.adoc[]
 
-include::api-ref::partial$csharp/connection/TypeDBCredential.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/connection/TypeDBCredential.adoc[]
 
-include::api-ref::partial$csharp/connection/IDatabaseManager.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/connection/IDatabaseManager.adoc[]
 
-include::api-ref::partial$csharp/connection/IDatabase.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/connection/IDatabase.adoc[]
 
-include::api-ref::partial$csharp/connection/IReplica.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/connection/IReplica.adoc[]
 
-include::api-ref::partial$csharp/connection/IUserManager.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/connection/IUserManager.adoc[]
 
-include::api-ref::partial$csharp/connection/IUser.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/connection/IUser.adoc[]
 
 [#_session_header]
 == Session
 
-include::api-ref::partial$csharp/session/ITypeDBSession.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/session/ITypeDBSession.adoc[]
 
-include::api-ref::partial$csharp/session/SessionType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/session/SessionType.adoc[]
 
-include::api-ref::partial$csharp/session/TypeDBOptions.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/session/TypeDBOptions.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::api-ref::partial$csharp/transaction/ITypeDBTransaction.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/transaction/ITypeDBTransaction.adoc[]
 
-include::api-ref::partial$csharp/transaction/TransactionType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/transaction/TransactionType.adoc[]
 
-include::api-ref::partial$csharp/transaction/IQueryManager.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/transaction/IQueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::api-ref::partial$csharp/answer/IConceptMap.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/answer/IConceptMap.adoc[]
 
-include::api-ref::partial$csharp/answer/IConceptMapGroup.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/answer/IConceptMapGroup.adoc[]
 
-include::api-ref::partial$csharp/answer/IValueGroup.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/answer/IValueGroup.adoc[]
 
-// include::api-ref::partial$csharp/answer/JSON.adoc[]
+// include::{page-component-version}@api-ref::partial$csharp/answer/JSON.adoc[]
 
-// include::api-ref::partial$csharp/answer/JSONType.adoc[]
+// include::{page-component-version}@api-ref::partial$csharp/answer/JSONType.adoc[]
 
-include::api-ref::partial$csharp/answer/IExplainables.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/answer/IExplainables.adoc[]
 
-include::api-ref::partial$csharp/answer/IExplainable.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/answer/IExplainable.adoc[]
 
-include::api-ref::partial$csharp/answer/IExplanation.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/answer/IExplanation.adoc[]
 
-include::api-ref::partial$csharp/answer/Promise__T__.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/answer/Promise__T__.adoc[]
 
-include::api-ref::partial$csharp/answer/VoidPromise.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/answer/VoidPromise.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::api-ref::partial$csharp/concept/IConceptManager.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/concept/IConceptManager.adoc[]
 
-include::api-ref::partial$csharp/concept/IConcept.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/concept/IConcept.adoc[]
 
-include::api-ref::partial$csharp/concept/Transitivity.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/concept/Transitivity.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::api-ref::partial$csharp/schema/IType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/schema/IType.adoc[]
 
-include::api-ref::partial$csharp/schema/IThingType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/schema/IThingType.adoc[]
 
-include::api-ref::partial$csharp/schema/IEntityType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/schema/IEntityType.adoc[]
 
-include::api-ref::partial$csharp/schema/IRelationType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/schema/IRelationType.adoc[]
 
-include::api-ref::partial$csharp/schema/IRoleType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/schema/IRoleType.adoc[]
 
-include::api-ref::partial$csharp/schema/IAttributeType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/schema/IAttributeType.adoc[]
 
-include::api-ref::partial$csharp/schema/Annotation.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/schema/Annotation.adoc[]
 
-include::api-ref::partial$csharp/schema/Label.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/schema/Label.adoc[]
 
 [#_data_header]
 == Data
 
-include::api-ref::partial$csharp/data/IThing.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/data/IThing.adoc[]
 
-include::api-ref::partial$csharp/data/IEntity.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/data/IEntity.adoc[]
 
-include::api-ref::partial$csharp/data/IRelation.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/data/IRelation.adoc[]
 
-include::api-ref::partial$csharp/data/IAttribute.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/data/IAttribute.adoc[]
 
-include::api-ref::partial$csharp/data/IValue.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/data/IValue.adoc[]
 
-include::api-ref::partial$csharp/data/ValueType.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/data/ValueType.adoc[]
 
-include::api-ref::partial$csharp/data/ValueTypeExtensions.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/data/ValueTypeExtensions.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::api-ref::partial$csharp/logic/ILogicManager.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/logic/ILogicManager.adoc[]
 
-include::api-ref::partial$csharp/logic/IRule.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/logic/IRule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::api-ref::partial$csharp/errors/TypeDBDriverException.adoc[]
+include::{page-component-version}@api-ref::partial$csharp/errors/TypeDBDriverException.adoc[]

--- a/docs/modules/ROOT/partials/java/api-reference.adoc
+++ b/docs/modules/ROOT/partials/java/api-reference.adoc
@@ -2,112 +2,112 @@
 [#_connection_header]
 == Connection
 
-include::{page-component-version}@api-ref::partial$java/connection/TypeDB.adoc[]
+include::{page-version}@api-ref::partial$java/connection/TypeDB.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/connection/TypeDBDriver.adoc[]
+include::{page-version}@api-ref::partial$java/connection/TypeDBDriver.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/connection/TypeDBCredential.adoc[]
+include::{page-version}@api-ref::partial$java/connection/TypeDBCredential.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/connection/DatabaseManager.adoc[]
+include::{page-version}@api-ref::partial$java/connection/DatabaseManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/connection/Database.adoc[]
+include::{page-version}@api-ref::partial$java/connection/Database.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/connection/Database.Replica.adoc[]
+include::{page-version}@api-ref::partial$java/connection/Database.Replica.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/connection/UserManager.adoc[]
+include::{page-version}@api-ref::partial$java/connection/UserManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/connection/User.adoc[]
+include::{page-version}@api-ref::partial$java/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-component-version}@api-ref::partial$java/session/TypeDBSession.adoc[]
+include::{page-version}@api-ref::partial$java/session/TypeDBSession.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/session/TypeDBSession.Type.adoc[]
+include::{page-version}@api-ref::partial$java/session/TypeDBSession.Type.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/session/TypeDBOptions.adoc[]
+include::{page-version}@api-ref::partial$java/session/TypeDBOptions.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-component-version}@api-ref::partial$java/transaction/TypeDBTransaction.adoc[]
+include::{page-version}@api-ref::partial$java/transaction/TypeDBTransaction.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/transaction/TypeDBTransaction.Type.adoc[]
+include::{page-version}@api-ref::partial$java/transaction/TypeDBTransaction.Type.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/transaction/QueryManager.adoc[]
+include::{page-version}@api-ref::partial$java/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-component-version}@api-ref::partial$java/answer/ConceptMapGroup.adoc[]
+include::{page-version}@api-ref::partial$java/answer/ConceptMapGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/answer/ConceptMap.adoc[]
+include::{page-version}@api-ref::partial$java/answer/ConceptMap.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/answer/ValueGroup.adoc[]
+include::{page-version}@api-ref::partial$java/answer/ValueGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/answer/JSON.adoc[]
+include::{page-version}@api-ref::partial$java/answer/JSON.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/answer/Promise_T_.adoc[]
+include::{page-version}@api-ref::partial$java/answer/Promise_T_.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/answer/ConceptMap.Explainables.adoc[]
+include::{page-version}@api-ref::partial$java/answer/ConceptMap.Explainables.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/answer/ConceptMap.Explainable.adoc[]
+include::{page-version}@api-ref::partial$java/answer/ConceptMap.Explainable.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/answer/Explanation.adoc[]
+include::{page-version}@api-ref::partial$java/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-component-version}@api-ref::partial$java/concept/ConceptManager.adoc[]
+include::{page-version}@api-ref::partial$java/concept/ConceptManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/concept/Concept.adoc[]
+include::{page-version}@api-ref::partial$java/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-component-version}@api-ref::partial$java/schema/Type.adoc[]
+include::{page-version}@api-ref::partial$java/schema/Type.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/Label.adoc[]
+include::{page-version}@api-ref::partial$java/schema/Label.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/ThingType.adoc[]
+include::{page-version}@api-ref::partial$java/schema/ThingType.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/EntityType.adoc[]
+include::{page-version}@api-ref::partial$java/schema/EntityType.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/RelationType.adoc[]
+include::{page-version}@api-ref::partial$java/schema/RelationType.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/RoleType.adoc[]
+include::{page-version}@api-ref::partial$java/schema/RoleType.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/AttributeType.adoc[]
+include::{page-version}@api-ref::partial$java/schema/AttributeType.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/ThingType.Annotation.adoc[]
+include::{page-version}@api-ref::partial$java/schema/ThingType.Annotation.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/Concept.Transitivity.adoc[]
+include::{page-version}@api-ref::partial$java/schema/Concept.Transitivity.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/schema/Value.Type.adoc[]
+include::{page-version}@api-ref::partial$java/schema/Value.Type.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-component-version}@api-ref::partial$java/data/Thing.adoc[]
+include::{page-version}@api-ref::partial$java/data/Thing.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/data/Entity.adoc[]
+include::{page-version}@api-ref::partial$java/data/Entity.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/data/Relation.adoc[]
+include::{page-version}@api-ref::partial$java/data/Relation.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/data/Attribute.adoc[]
+include::{page-version}@api-ref::partial$java/data/Attribute.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/data/Value.adoc[]
+include::{page-version}@api-ref::partial$java/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-component-version}@api-ref::partial$java/logic/LogicManager.adoc[]
+include::{page-version}@api-ref::partial$java/logic/LogicManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$java/logic/Rule.adoc[]
+include::{page-version}@api-ref::partial$java/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-component-version}@api-ref::partial$java/errors/TypeDBDriverException.adoc[]
+include::{page-version}@api-ref::partial$java/errors/TypeDBDriverException.adoc[]
 
-//include::{page-component-version}@api-ref::partial$java/errors/ErrorMessage.adoc[]
+//include::{page-version}@api-ref::partial$java/errors/ErrorMessage.adoc[]

--- a/docs/modules/ROOT/partials/java/api-reference.adoc
+++ b/docs/modules/ROOT/partials/java/api-reference.adoc
@@ -2,112 +2,112 @@
 [#_connection_header]
 == Connection
 
-include::api-ref::partial$java/connection/TypeDB.adoc[]
+include::{page-component-version}@api-ref::partial$java/connection/TypeDB.adoc[]
 
-include::api-ref::partial$java/connection/TypeDBDriver.adoc[]
+include::{page-component-version}@api-ref::partial$java/connection/TypeDBDriver.adoc[]
 
-include::api-ref::partial$java/connection/TypeDBCredential.adoc[]
+include::{page-component-version}@api-ref::partial$java/connection/TypeDBCredential.adoc[]
 
-include::api-ref::partial$java/connection/DatabaseManager.adoc[]
+include::{page-component-version}@api-ref::partial$java/connection/DatabaseManager.adoc[]
 
-include::api-ref::partial$java/connection/Database.adoc[]
+include::{page-component-version}@api-ref::partial$java/connection/Database.adoc[]
 
-include::api-ref::partial$java/connection/Database.Replica.adoc[]
+include::{page-component-version}@api-ref::partial$java/connection/Database.Replica.adoc[]
 
-include::api-ref::partial$java/connection/UserManager.adoc[]
+include::{page-component-version}@api-ref::partial$java/connection/UserManager.adoc[]
 
-include::api-ref::partial$java/connection/User.adoc[]
+include::{page-component-version}@api-ref::partial$java/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::api-ref::partial$java/session/TypeDBSession.adoc[]
+include::{page-component-version}@api-ref::partial$java/session/TypeDBSession.adoc[]
 
-include::api-ref::partial$java/session/TypeDBSession.Type.adoc[]
+include::{page-component-version}@api-ref::partial$java/session/TypeDBSession.Type.adoc[]
 
-include::api-ref::partial$java/session/TypeDBOptions.adoc[]
+include::{page-component-version}@api-ref::partial$java/session/TypeDBOptions.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::api-ref::partial$java/transaction/TypeDBTransaction.adoc[]
+include::{page-component-version}@api-ref::partial$java/transaction/TypeDBTransaction.adoc[]
 
-include::api-ref::partial$java/transaction/TypeDBTransaction.Type.adoc[]
+include::{page-component-version}@api-ref::partial$java/transaction/TypeDBTransaction.Type.adoc[]
 
-include::api-ref::partial$java/transaction/QueryManager.adoc[]
+include::{page-component-version}@api-ref::partial$java/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::api-ref::partial$java/answer/ConceptMapGroup.adoc[]
+include::{page-component-version}@api-ref::partial$java/answer/ConceptMapGroup.adoc[]
 
-include::api-ref::partial$java/answer/ConceptMap.adoc[]
+include::{page-component-version}@api-ref::partial$java/answer/ConceptMap.adoc[]
 
-include::api-ref::partial$java/answer/ValueGroup.adoc[]
+include::{page-component-version}@api-ref::partial$java/answer/ValueGroup.adoc[]
 
-include::api-ref::partial$java/answer/JSON.adoc[]
+include::{page-component-version}@api-ref::partial$java/answer/JSON.adoc[]
 
-include::api-ref::partial$java/answer/Promise_T_.adoc[]
+include::{page-component-version}@api-ref::partial$java/answer/Promise_T_.adoc[]
 
-include::api-ref::partial$java/answer/ConceptMap.Explainables.adoc[]
+include::{page-component-version}@api-ref::partial$java/answer/ConceptMap.Explainables.adoc[]
 
-include::api-ref::partial$java/answer/ConceptMap.Explainable.adoc[]
+include::{page-component-version}@api-ref::partial$java/answer/ConceptMap.Explainable.adoc[]
 
-include::api-ref::partial$java/answer/Explanation.adoc[]
+include::{page-component-version}@api-ref::partial$java/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::api-ref::partial$java/concept/ConceptManager.adoc[]
+include::{page-component-version}@api-ref::partial$java/concept/ConceptManager.adoc[]
 
-include::api-ref::partial$java/concept/Concept.adoc[]
+include::{page-component-version}@api-ref::partial$java/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::api-ref::partial$java/schema/Type.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/Type.adoc[]
 
-include::api-ref::partial$java/schema/Label.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/Label.adoc[]
 
-include::api-ref::partial$java/schema/ThingType.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/ThingType.adoc[]
 
-include::api-ref::partial$java/schema/EntityType.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/EntityType.adoc[]
 
-include::api-ref::partial$java/schema/RelationType.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/RelationType.adoc[]
 
-include::api-ref::partial$java/schema/RoleType.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/RoleType.adoc[]
 
-include::api-ref::partial$java/schema/AttributeType.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/AttributeType.adoc[]
 
-include::api-ref::partial$java/schema/ThingType.Annotation.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/ThingType.Annotation.adoc[]
 
-include::api-ref::partial$java/schema/Concept.Transitivity.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/Concept.Transitivity.adoc[]
 
-include::api-ref::partial$java/schema/Value.Type.adoc[]
+include::{page-component-version}@api-ref::partial$java/schema/Value.Type.adoc[]
 
 [#_data_header]
 == Data
 
-include::api-ref::partial$java/data/Thing.adoc[]
+include::{page-component-version}@api-ref::partial$java/data/Thing.adoc[]
 
-include::api-ref::partial$java/data/Entity.adoc[]
+include::{page-component-version}@api-ref::partial$java/data/Entity.adoc[]
 
-include::api-ref::partial$java/data/Relation.adoc[]
+include::{page-component-version}@api-ref::partial$java/data/Relation.adoc[]
 
-include::api-ref::partial$java/data/Attribute.adoc[]
+include::{page-component-version}@api-ref::partial$java/data/Attribute.adoc[]
 
-include::api-ref::partial$java/data/Value.adoc[]
+include::{page-component-version}@api-ref::partial$java/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::api-ref::partial$java/logic/LogicManager.adoc[]
+include::{page-component-version}@api-ref::partial$java/logic/LogicManager.adoc[]
 
-include::api-ref::partial$java/logic/Rule.adoc[]
+include::{page-component-version}@api-ref::partial$java/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::api-ref::partial$java/errors/TypeDBDriverException.adoc[]
+include::{page-component-version}@api-ref::partial$java/errors/TypeDBDriverException.adoc[]
 
-//include::api-ref::partial$java/errors/ErrorMessage.adoc[]
+//include::{page-component-version}@api-ref::partial$java/errors/ErrorMessage.adoc[]

--- a/docs/modules/ROOT/partials/nodejs/api-reference.adoc
+++ b/docs/modules/ROOT/partials/nodejs/api-reference.adoc
@@ -2,112 +2,112 @@
 [#_connection_header]
 == Connection
 
-include::api-ref::partial$nodejs/connection/TypeDB.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/connection/TypeDB.adoc[]
 
-include::api-ref::partial$nodejs/connection/TypeDBDriver.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/connection/TypeDBDriver.adoc[]
 
-include::api-ref::partial$nodejs/connection/TypeDBCredential.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/connection/TypeDBCredential.adoc[]
 
-include::api-ref::partial$nodejs/connection/DatabaseManager.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/connection/DatabaseManager.adoc[]
 
-include::api-ref::partial$nodejs/connection/Database.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/connection/Database.adoc[]
 
-include::api-ref::partial$nodejs/connection/Replica.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/connection/Replica.adoc[]
 
-include::api-ref::partial$nodejs/connection/UserManager.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/connection/UserManager.adoc[]
 
-include::api-ref::partial$nodejs/connection/User.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::api-ref::partial$nodejs/session/TypeDBSession.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/session/TypeDBSession.adoc[]
 
-include::api-ref::partial$nodejs/session/SessionType.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/session/SessionType.adoc[]
 
-include::api-ref::partial$nodejs/session/TypeDBOptions.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/session/TypeDBOptions.adoc[]
 
-include::api-ref::partial$nodejs/session/Opts.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/session/Opts.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::api-ref::partial$nodejs/transaction/TypeDBTransaction.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/transaction/TypeDBTransaction.adoc[]
 
-include::api-ref::partial$nodejs/transaction/TransactionType.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/transaction/TransactionType.adoc[]
 
-include::api-ref::partial$nodejs/transaction/QueryManager.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::api-ref::partial$nodejs/answer/ConceptMapGroup.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/answer/ConceptMapGroup.adoc[]
 
-include::api-ref::partial$nodejs/answer/ConceptMap.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/answer/ConceptMap.adoc[]
 
-include::api-ref::partial$nodejs/answer/Stream_T_.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/answer/Stream_T_.adoc[]
 
-include::api-ref::partial$nodejs/answer/ValueGroup.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/answer/ValueGroup.adoc[]
 
-include::api-ref::partial$nodejs/answer/Explainables.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/answer/Explainables.adoc[]
 
-include::api-ref::partial$nodejs/answer/Explainable.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/answer/Explainable.adoc[]
 
-include::api-ref::partial$nodejs/answer/Explanation.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::api-ref::partial$nodejs/concept/ConceptManager.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/concept/ConceptManager.adoc[]
 
-include::api-ref::partial$nodejs/concept/Concept.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::api-ref::partial$nodejs/schema/Type.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/Type.adoc[]
 
-include::api-ref::partial$nodejs/schema/Label.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/Label.adoc[]
 
-include::api-ref::partial$nodejs/schema/ThingType.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/ThingType.adoc[]
 
-include::api-ref::partial$nodejs/schema/EntityType.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/EntityType.adoc[]
 
-include::api-ref::partial$nodejs/schema/RelationType.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/RelationType.adoc[]
 
-include::api-ref::partial$nodejs/schema/RoleType.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/RoleType.adoc[]
 
-include::api-ref::partial$nodejs/schema/AttributeType.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/AttributeType.adoc[]
 
-include::api-ref::partial$nodejs/schema/Annotation.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/Annotation.adoc[]
 
-include::api-ref::partial$nodejs/schema/Transitivity.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/Transitivity.adoc[]
 
-include::api-ref::partial$nodejs/schema/ValueType.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/schema/ValueType.adoc[]
 
 [#_data_header]
 == Data
 
-include::api-ref::partial$nodejs/data/Thing.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/data/Thing.adoc[]
 
-include::api-ref::partial$nodejs/data/Entity.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/data/Entity.adoc[]
 
-include::api-ref::partial$nodejs/data/Relation.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/data/Relation.adoc[]
 
-include::api-ref::partial$nodejs/data/Attribute.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/data/Attribute.adoc[]
 
-include::api-ref::partial$nodejs/data/Value.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::api-ref::partial$nodejs/logic/LogicManager.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/logic/LogicManager.adoc[]
 
-include::api-ref::partial$nodejs/logic/Rule.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::api-ref::partial$nodejs/errors/TypeDBDriverError.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/errors/TypeDBDriverError.adoc[]
 
-include::api-ref::partial$nodejs/errors/ErrorMessage.adoc[]
+include::{page-component-version}@api-ref::partial$nodejs/errors/ErrorMessage.adoc[]

--- a/docs/modules/ROOT/partials/nodejs/api-reference.adoc
+++ b/docs/modules/ROOT/partials/nodejs/api-reference.adoc
@@ -2,112 +2,112 @@
 [#_connection_header]
 == Connection
 
-include::{page-component-version}@api-ref::partial$nodejs/connection/TypeDB.adoc[]
+include::{page-version}@api-ref::partial$nodejs/connection/TypeDB.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/connection/TypeDBDriver.adoc[]
+include::{page-version}@api-ref::partial$nodejs/connection/TypeDBDriver.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/connection/TypeDBCredential.adoc[]
+include::{page-version}@api-ref::partial$nodejs/connection/TypeDBCredential.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/connection/DatabaseManager.adoc[]
+include::{page-version}@api-ref::partial$nodejs/connection/DatabaseManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/connection/Database.adoc[]
+include::{page-version}@api-ref::partial$nodejs/connection/Database.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/connection/Replica.adoc[]
+include::{page-version}@api-ref::partial$nodejs/connection/Replica.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/connection/UserManager.adoc[]
+include::{page-version}@api-ref::partial$nodejs/connection/UserManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/connection/User.adoc[]
+include::{page-version}@api-ref::partial$nodejs/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-component-version}@api-ref::partial$nodejs/session/TypeDBSession.adoc[]
+include::{page-version}@api-ref::partial$nodejs/session/TypeDBSession.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/session/SessionType.adoc[]
+include::{page-version}@api-ref::partial$nodejs/session/SessionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/session/TypeDBOptions.adoc[]
+include::{page-version}@api-ref::partial$nodejs/session/TypeDBOptions.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/session/Opts.adoc[]
+include::{page-version}@api-ref::partial$nodejs/session/Opts.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-component-version}@api-ref::partial$nodejs/transaction/TypeDBTransaction.adoc[]
+include::{page-version}@api-ref::partial$nodejs/transaction/TypeDBTransaction.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/transaction/TransactionType.adoc[]
+include::{page-version}@api-ref::partial$nodejs/transaction/TransactionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/transaction/QueryManager.adoc[]
+include::{page-version}@api-ref::partial$nodejs/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-component-version}@api-ref::partial$nodejs/answer/ConceptMapGroup.adoc[]
+include::{page-version}@api-ref::partial$nodejs/answer/ConceptMapGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/answer/ConceptMap.adoc[]
+include::{page-version}@api-ref::partial$nodejs/answer/ConceptMap.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/answer/Stream_T_.adoc[]
+include::{page-version}@api-ref::partial$nodejs/answer/Stream_T_.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/answer/ValueGroup.adoc[]
+include::{page-version}@api-ref::partial$nodejs/answer/ValueGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/answer/Explainables.adoc[]
+include::{page-version}@api-ref::partial$nodejs/answer/Explainables.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/answer/Explainable.adoc[]
+include::{page-version}@api-ref::partial$nodejs/answer/Explainable.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/answer/Explanation.adoc[]
+include::{page-version}@api-ref::partial$nodejs/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-component-version}@api-ref::partial$nodejs/concept/ConceptManager.adoc[]
+include::{page-version}@api-ref::partial$nodejs/concept/ConceptManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/concept/Concept.adoc[]
+include::{page-version}@api-ref::partial$nodejs/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/Type.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/Type.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/Label.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/Label.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/ThingType.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/ThingType.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/EntityType.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/EntityType.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/RelationType.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/RelationType.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/RoleType.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/RoleType.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/AttributeType.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/AttributeType.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/Annotation.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/Annotation.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/Transitivity.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/Transitivity.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/schema/ValueType.adoc[]
+include::{page-version}@api-ref::partial$nodejs/schema/ValueType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-component-version}@api-ref::partial$nodejs/data/Thing.adoc[]
+include::{page-version}@api-ref::partial$nodejs/data/Thing.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/data/Entity.adoc[]
+include::{page-version}@api-ref::partial$nodejs/data/Entity.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/data/Relation.adoc[]
+include::{page-version}@api-ref::partial$nodejs/data/Relation.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/data/Attribute.adoc[]
+include::{page-version}@api-ref::partial$nodejs/data/Attribute.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/data/Value.adoc[]
+include::{page-version}@api-ref::partial$nodejs/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-component-version}@api-ref::partial$nodejs/logic/LogicManager.adoc[]
+include::{page-version}@api-ref::partial$nodejs/logic/LogicManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/logic/Rule.adoc[]
+include::{page-version}@api-ref::partial$nodejs/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-component-version}@api-ref::partial$nodejs/errors/TypeDBDriverError.adoc[]
+include::{page-version}@api-ref::partial$nodejs/errors/TypeDBDriverError.adoc[]
 
-include::{page-component-version}@api-ref::partial$nodejs/errors/ErrorMessage.adoc[]
+include::{page-version}@api-ref::partial$nodejs/errors/ErrorMessage.adoc[]

--- a/docs/modules/ROOT/partials/python/api-reference.adoc
+++ b/docs/modules/ROOT/partials/python/api-reference.adoc
@@ -2,110 +2,110 @@
 [#_connection_header]
 == Connection
 
-include::{page-component-version}@api-ref::partial$python/connection/TypeDB.adoc[]
+include::{page-version}@api-ref::partial$python/connection/TypeDB.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/connection/TypeDBDriver.adoc[]
+include::{page-version}@api-ref::partial$python/connection/TypeDBDriver.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/connection/TypeDBCredential.adoc[]
+include::{page-version}@api-ref::partial$python/connection/TypeDBCredential.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/connection/DatabaseManager.adoc[]
+include::{page-version}@api-ref::partial$python/connection/DatabaseManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/connection/Database.adoc[]
+include::{page-version}@api-ref::partial$python/connection/Database.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/connection/Replica.adoc[]
+include::{page-version}@api-ref::partial$python/connection/Replica.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/connection/UserManager.adoc[]
+include::{page-version}@api-ref::partial$python/connection/UserManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/connection/User.adoc[]
+include::{page-version}@api-ref::partial$python/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-component-version}@api-ref::partial$python/session/TypeDBSession.adoc[]
+include::{page-version}@api-ref::partial$python/session/TypeDBSession.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/session/SessionType.adoc[]
+include::{page-version}@api-ref::partial$python/session/SessionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/session/TypeDBOptions.adoc[]
+include::{page-version}@api-ref::partial$python/session/TypeDBOptions.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-component-version}@api-ref::partial$python/transaction/TypeDBTransaction.adoc[]
+include::{page-version}@api-ref::partial$python/transaction/TypeDBTransaction.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/transaction/TransactionType.adoc[]
+include::{page-version}@api-ref::partial$python/transaction/TransactionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/transaction/QueryManager.adoc[]
+include::{page-version}@api-ref::partial$python/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-component-version}@api-ref::partial$python/answer/ConceptMapGroup.adoc[]
+include::{page-version}@api-ref::partial$python/answer/ConceptMapGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/answer/ConceptMap.adoc[]
+include::{page-version}@api-ref::partial$python/answer/ConceptMap.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/answer/ValueGroup.adoc[]
+include::{page-version}@api-ref::partial$python/answer/ValueGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/answer/Promise.adoc[]
+include::{page-version}@api-ref::partial$python/answer/Promise.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/answer/Explainables.adoc[]
+include::{page-version}@api-ref::partial$python/answer/Explainables.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/answer/Explainable.adoc[]
+include::{page-version}@api-ref::partial$python/answer/Explainable.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/answer/Explanation.adoc[]
+include::{page-version}@api-ref::partial$python/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-component-version}@api-ref::partial$python/concept/ConceptManager.adoc[]
+include::{page-version}@api-ref::partial$python/concept/ConceptManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/concept/Concept.adoc[]
+include::{page-version}@api-ref::partial$python/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-component-version}@api-ref::partial$python/schema/Type.adoc[]
+include::{page-version}@api-ref::partial$python/schema/Type.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/Label.adoc[]
+include::{page-version}@api-ref::partial$python/schema/Label.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/ThingType.adoc[]
+include::{page-version}@api-ref::partial$python/schema/ThingType.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/EntityType.adoc[]
+include::{page-version}@api-ref::partial$python/schema/EntityType.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/RelationType.adoc[]
+include::{page-version}@api-ref::partial$python/schema/RelationType.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/RoleType.adoc[]
+include::{page-version}@api-ref::partial$python/schema/RoleType.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/AttributeType.adoc[]
+include::{page-version}@api-ref::partial$python/schema/AttributeType.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/Annotation.adoc[]
+include::{page-version}@api-ref::partial$python/schema/Annotation.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/Transitivity.adoc[]
+include::{page-version}@api-ref::partial$python/schema/Transitivity.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/schema/ValueType.adoc[]
+include::{page-version}@api-ref::partial$python/schema/ValueType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-component-version}@api-ref::partial$python/data/Thing.adoc[]
+include::{page-version}@api-ref::partial$python/data/Thing.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/data/Entity.adoc[]
+include::{page-version}@api-ref::partial$python/data/Entity.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/data/Relation.adoc[]
+include::{page-version}@api-ref::partial$python/data/Relation.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/data/Attribute.adoc[]
+include::{page-version}@api-ref::partial$python/data/Attribute.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/data/Value.adoc[]
+include::{page-version}@api-ref::partial$python/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-component-version}@api-ref::partial$python/logic/LogicManager.adoc[]
+include::{page-version}@api-ref::partial$python/logic/LogicManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$python/logic/Rule.adoc[]
+include::{page-version}@api-ref::partial$python/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-component-version}@api-ref::partial$python/errors/TypeDBDriverException.adoc[]
+include::{page-version}@api-ref::partial$python/errors/TypeDBDriverException.adoc[]
 
-//include::{page-component-version}@api-ref::partial$python/errors/ErrorMessage.adoc[]
+//include::{page-version}@api-ref::partial$python/errors/ErrorMessage.adoc[]

--- a/docs/modules/ROOT/partials/python/api-reference.adoc
+++ b/docs/modules/ROOT/partials/python/api-reference.adoc
@@ -2,110 +2,110 @@
 [#_connection_header]
 == Connection
 
-include::api-ref::partial$python/connection/TypeDB.adoc[]
+include::{page-component-version}@api-ref::partial$python/connection/TypeDB.adoc[]
 
-include::api-ref::partial$python/connection/TypeDBDriver.adoc[]
+include::{page-component-version}@api-ref::partial$python/connection/TypeDBDriver.adoc[]
 
-include::api-ref::partial$python/connection/TypeDBCredential.adoc[]
+include::{page-component-version}@api-ref::partial$python/connection/TypeDBCredential.adoc[]
 
-include::api-ref::partial$python/connection/DatabaseManager.adoc[]
+include::{page-component-version}@api-ref::partial$python/connection/DatabaseManager.adoc[]
 
-include::api-ref::partial$python/connection/Database.adoc[]
+include::{page-component-version}@api-ref::partial$python/connection/Database.adoc[]
 
-include::api-ref::partial$python/connection/Replica.adoc[]
+include::{page-component-version}@api-ref::partial$python/connection/Replica.adoc[]
 
-include::api-ref::partial$python/connection/UserManager.adoc[]
+include::{page-component-version}@api-ref::partial$python/connection/UserManager.adoc[]
 
-include::api-ref::partial$python/connection/User.adoc[]
+include::{page-component-version}@api-ref::partial$python/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::api-ref::partial$python/session/TypeDBSession.adoc[]
+include::{page-component-version}@api-ref::partial$python/session/TypeDBSession.adoc[]
 
-include::api-ref::partial$python/session/SessionType.adoc[]
+include::{page-component-version}@api-ref::partial$python/session/SessionType.adoc[]
 
-include::api-ref::partial$python/session/TypeDBOptions.adoc[]
+include::{page-component-version}@api-ref::partial$python/session/TypeDBOptions.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::api-ref::partial$python/transaction/TypeDBTransaction.adoc[]
+include::{page-component-version}@api-ref::partial$python/transaction/TypeDBTransaction.adoc[]
 
-include::api-ref::partial$python/transaction/TransactionType.adoc[]
+include::{page-component-version}@api-ref::partial$python/transaction/TransactionType.adoc[]
 
-include::api-ref::partial$python/transaction/QueryManager.adoc[]
+include::{page-component-version}@api-ref::partial$python/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::api-ref::partial$python/answer/ConceptMapGroup.adoc[]
+include::{page-component-version}@api-ref::partial$python/answer/ConceptMapGroup.adoc[]
 
-include::api-ref::partial$python/answer/ConceptMap.adoc[]
+include::{page-component-version}@api-ref::partial$python/answer/ConceptMap.adoc[]
 
-include::api-ref::partial$python/answer/ValueGroup.adoc[]
+include::{page-component-version}@api-ref::partial$python/answer/ValueGroup.adoc[]
 
-include::api-ref::partial$python/answer/Promise.adoc[]
+include::{page-component-version}@api-ref::partial$python/answer/Promise.adoc[]
 
-include::api-ref::partial$python/answer/Explainables.adoc[]
+include::{page-component-version}@api-ref::partial$python/answer/Explainables.adoc[]
 
-include::api-ref::partial$python/answer/Explainable.adoc[]
+include::{page-component-version}@api-ref::partial$python/answer/Explainable.adoc[]
 
-include::api-ref::partial$python/answer/Explanation.adoc[]
+include::{page-component-version}@api-ref::partial$python/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::api-ref::partial$python/concept/ConceptManager.adoc[]
+include::{page-component-version}@api-ref::partial$python/concept/ConceptManager.adoc[]
 
-include::api-ref::partial$python/concept/Concept.adoc[]
+include::{page-component-version}@api-ref::partial$python/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::api-ref::partial$python/schema/Type.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/Type.adoc[]
 
-include::api-ref::partial$python/schema/Label.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/Label.adoc[]
 
-include::api-ref::partial$python/schema/ThingType.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/ThingType.adoc[]
 
-include::api-ref::partial$python/schema/EntityType.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/EntityType.adoc[]
 
-include::api-ref::partial$python/schema/RelationType.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/RelationType.adoc[]
 
-include::api-ref::partial$python/schema/RoleType.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/RoleType.adoc[]
 
-include::api-ref::partial$python/schema/AttributeType.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/AttributeType.adoc[]
 
-include::api-ref::partial$python/schema/Annotation.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/Annotation.adoc[]
 
-include::api-ref::partial$python/schema/Transitivity.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/Transitivity.adoc[]
 
-include::api-ref::partial$python/schema/ValueType.adoc[]
+include::{page-component-version}@api-ref::partial$python/schema/ValueType.adoc[]
 
 [#_data_header]
 == Data
 
-include::api-ref::partial$python/data/Thing.adoc[]
+include::{page-component-version}@api-ref::partial$python/data/Thing.adoc[]
 
-include::api-ref::partial$python/data/Entity.adoc[]
+include::{page-component-version}@api-ref::partial$python/data/Entity.adoc[]
 
-include::api-ref::partial$python/data/Relation.adoc[]
+include::{page-component-version}@api-ref::partial$python/data/Relation.adoc[]
 
-include::api-ref::partial$python/data/Attribute.adoc[]
+include::{page-component-version}@api-ref::partial$python/data/Attribute.adoc[]
 
-include::api-ref::partial$python/data/Value.adoc[]
+include::{page-component-version}@api-ref::partial$python/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::api-ref::partial$python/logic/LogicManager.adoc[]
+include::{page-component-version}@api-ref::partial$python/logic/LogicManager.adoc[]
 
-include::api-ref::partial$python/logic/Rule.adoc[]
+include::{page-component-version}@api-ref::partial$python/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::api-ref::partial$python/errors/TypeDBDriverException.adoc[]
+include::{page-component-version}@api-ref::partial$python/errors/TypeDBDriverException.adoc[]
 
-//include::api-ref::partial$python/errors/ErrorMessage.adoc[]
+//include::{page-component-version}@api-ref::partial$python/errors/ErrorMessage.adoc[]

--- a/docs/modules/ROOT/partials/rust/api-reference.adoc
+++ b/docs/modules/ROOT/partials/rust/api-reference.adoc
@@ -2,130 +2,130 @@
 [#_connection_header]
 == Connection
 
-include::api-ref::partial$rust/connection/Connection.adoc[]
+include::{page-component-version}@api-ref::partial$rust/connection/Connection.adoc[]
 
-include::api-ref::partial$rust/connection/Credential.adoc[]
+include::{page-component-version}@api-ref::partial$rust/connection/Credential.adoc[]
 
-include::api-ref::partial$rust/connection/DatabaseManager.adoc[]
+include::{page-component-version}@api-ref::partial$rust/connection/DatabaseManager.adoc[]
 
-include::api-ref::partial$rust/connection/Database.adoc[]
+include::{page-component-version}@api-ref::partial$rust/connection/Database.adoc[]
 
-include::api-ref::partial$rust/connection/ReplicaInfo.adoc[]
+include::{page-component-version}@api-ref::partial$rust/connection/ReplicaInfo.adoc[]
 
-include::api-ref::partial$rust/connection/UserManager.adoc[]
+include::{page-component-version}@api-ref::partial$rust/connection/UserManager.adoc[]
 
-include::api-ref::partial$rust/connection/User.adoc[]
+include::{page-component-version}@api-ref::partial$rust/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::api-ref::partial$rust/session/Session.adoc[]
+include::{page-component-version}@api-ref::partial$rust/session/Session.adoc[]
 
-include::api-ref::partial$rust/session/SessionType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/session/SessionType.adoc[]
 
-include::api-ref::partial$rust/session/Options.adoc[]
+include::{page-component-version}@api-ref::partial$rust/session/Options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::api-ref::partial$rust/transaction/Transaction.adoc[]
+include::{page-component-version}@api-ref::partial$rust/transaction/Transaction.adoc[]
 
-include::api-ref::partial$rust/transaction/TransactionType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/transaction/TransactionType.adoc[]
 
-include::api-ref::partial$rust/transaction/QueryManager.adoc[]
+include::{page-component-version}@api-ref::partial$rust/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::api-ref::partial$rust/answer/ConceptMapGroup.adoc[]
+include::{page-component-version}@api-ref::partial$rust/answer/ConceptMapGroup.adoc[]
 
-include::api-ref::partial$rust/answer/ConceptMap.adoc[]
+include::{page-component-version}@api-ref::partial$rust/answer/ConceptMap.adoc[]
 
-include::api-ref::partial$rust/answer/ValueGroup.adoc[]
+include::{page-component-version}@api-ref::partial$rust/answer/ValueGroup.adoc[]
 
-include::api-ref::partial$rust/answer/JSON.adoc[]
+include::{page-component-version}@api-ref::partial$rust/answer/JSON.adoc[]
 
-include::api-ref::partial$rust/answer/Trait_Promise.adoc[]
+include::{page-component-version}@api-ref::partial$rust/answer/Trait_Promise.adoc[]
 
-include::api-ref::partial$rust/answer/Explainables.adoc[]
+include::{page-component-version}@api-ref::partial$rust/answer/Explainables.adoc[]
 
-include::api-ref::partial$rust/answer/Explainable.adoc[]
+include::{page-component-version}@api-ref::partial$rust/answer/Explainable.adoc[]
 
-include::api-ref::partial$rust/answer/Explanation.adoc[]
+include::{page-component-version}@api-ref::partial$rust/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::api-ref::partial$rust/concept/ConceptManager.adoc[]
+include::{page-component-version}@api-ref::partial$rust/concept/ConceptManager.adoc[]
 
-include::api-ref::partial$rust/concept/Concept.adoc[]
+include::{page-component-version}@api-ref::partial$rust/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-//include::api-ref::partial$rust/schema/Type.adoc[]
+//include::{page-component-version}@api-ref::partial$rust/schema/Type.adoc[]
 
-include::api-ref::partial$rust/schema/RootThingType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/RootThingType.adoc[]
 
-include::api-ref::partial$rust/schema/ThingType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/ThingType.adoc[]
 
-include::api-ref::partial$rust/schema/Trait_ThingTypeAPI.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/Trait_ThingTypeAPI.adoc[]
 
-include::api-ref::partial$rust/schema/EntityType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/EntityType.adoc[]
 
-include::api-ref::partial$rust/schema/Trait_EntityTypeAPI.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/Trait_EntityTypeAPI.adoc[]
 
-include::api-ref::partial$rust/schema/RelationType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/RelationType.adoc[]
 
-include::api-ref::partial$rust/schema/Trait_RelationTypeAPI.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/Trait_RelationTypeAPI.adoc[]
 
-include::api-ref::partial$rust/schema/RoleType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/RoleType.adoc[]
 
-include::api-ref::partial$rust/schema/Trait_RoleTypeAPI.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/Trait_RoleTypeAPI.adoc[]
 
-include::api-ref::partial$rust/schema/AttributeType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/AttributeType.adoc[]
 
-include::api-ref::partial$rust/schema/Trait_AttributeTypeAPI.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/Trait_AttributeTypeAPI.adoc[]
 
-include::api-ref::partial$rust/schema/Annotation.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/Annotation.adoc[]
 
-include::api-ref::partial$rust/schema/Transitivity.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/Transitivity.adoc[]
 
-include::api-ref::partial$rust/schema/ValueType.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/ValueType.adoc[]
 
-include::api-ref::partial$rust/schema/ScopedLabel.adoc[]
+include::{page-component-version}@api-ref::partial$rust/schema/ScopedLabel.adoc[]
 
 [#_data_header]
 == Data
 
-include::api-ref::partial$rust/data/Thing.adoc[]
+include::{page-component-version}@api-ref::partial$rust/data/Thing.adoc[]
 
-include::api-ref::partial$rust/data/Trait_ThingAPI.adoc[]
+include::{page-component-version}@api-ref::partial$rust/data/Trait_ThingAPI.adoc[]
 
-include::api-ref::partial$rust/data/Entity.adoc[]
+include::{page-component-version}@api-ref::partial$rust/data/Entity.adoc[]
 
-include::api-ref::partial$rust/data/Relation.adoc[]
+include::{page-component-version}@api-ref::partial$rust/data/Relation.adoc[]
 
-include::api-ref::partial$rust/data/Attribute.adoc[]
+include::{page-component-version}@api-ref::partial$rust/data/Attribute.adoc[]
 
-include::api-ref::partial$rust/data/Value.adoc[]
+include::{page-component-version}@api-ref::partial$rust/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::api-ref::partial$rust/logic/LogicManager.adoc[]
+include::{page-component-version}@api-ref::partial$rust/logic/LogicManager.adoc[]
 
-include::api-ref::partial$rust/logic/Rule.adoc[]
+include::{page-component-version}@api-ref::partial$rust/logic/Rule.adoc[]
 
-include::api-ref::partial$rust/logic/Trait_RuleAPI.adoc[]
+include::{page-component-version}@api-ref::partial$rust/logic/Trait_RuleAPI.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::api-ref::partial$rust/errors/SchemaException.adoc[]
+include::{page-component-version}@api-ref::partial$rust/errors/SchemaException.adoc[]
 
-include::api-ref::partial$rust/errors/Error.adoc[]
+include::{page-component-version}@api-ref::partial$rust/errors/Error.adoc[]
 
-include::api-ref::partial$rust/errors/ConnectionError.adoc[]
+include::{page-component-version}@api-ref::partial$rust/errors/ConnectionError.adoc[]
 
-include::api-ref::partial$rust/errors/InternalError.adoc[]
+include::{page-component-version}@api-ref::partial$rust/errors/InternalError.adoc[]

--- a/docs/modules/ROOT/partials/rust/api-reference.adoc
+++ b/docs/modules/ROOT/partials/rust/api-reference.adoc
@@ -2,130 +2,130 @@
 [#_connection_header]
 == Connection
 
-include::{page-component-version}@api-ref::partial$rust/connection/Connection.adoc[]
+include::{page-version}@api-ref::partial$rust/connection/Connection.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/connection/Credential.adoc[]
+include::{page-version}@api-ref::partial$rust/connection/Credential.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/connection/DatabaseManager.adoc[]
+include::{page-version}@api-ref::partial$rust/connection/DatabaseManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/connection/Database.adoc[]
+include::{page-version}@api-ref::partial$rust/connection/Database.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/connection/ReplicaInfo.adoc[]
+include::{page-version}@api-ref::partial$rust/connection/ReplicaInfo.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/connection/UserManager.adoc[]
+include::{page-version}@api-ref::partial$rust/connection/UserManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/connection/User.adoc[]
+include::{page-version}@api-ref::partial$rust/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-component-version}@api-ref::partial$rust/session/Session.adoc[]
+include::{page-version}@api-ref::partial$rust/session/Session.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/session/SessionType.adoc[]
+include::{page-version}@api-ref::partial$rust/session/SessionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/session/Options.adoc[]
+include::{page-version}@api-ref::partial$rust/session/Options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-component-version}@api-ref::partial$rust/transaction/Transaction.adoc[]
+include::{page-version}@api-ref::partial$rust/transaction/Transaction.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/transaction/TransactionType.adoc[]
+include::{page-version}@api-ref::partial$rust/transaction/TransactionType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/transaction/QueryManager.adoc[]
+include::{page-version}@api-ref::partial$rust/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-component-version}@api-ref::partial$rust/answer/ConceptMapGroup.adoc[]
+include::{page-version}@api-ref::partial$rust/answer/ConceptMapGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/answer/ConceptMap.adoc[]
+include::{page-version}@api-ref::partial$rust/answer/ConceptMap.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/answer/ValueGroup.adoc[]
+include::{page-version}@api-ref::partial$rust/answer/ValueGroup.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/answer/JSON.adoc[]
+include::{page-version}@api-ref::partial$rust/answer/JSON.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/answer/Trait_Promise.adoc[]
+include::{page-version}@api-ref::partial$rust/answer/Trait_Promise.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/answer/Explainables.adoc[]
+include::{page-version}@api-ref::partial$rust/answer/Explainables.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/answer/Explainable.adoc[]
+include::{page-version}@api-ref::partial$rust/answer/Explainable.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/answer/Explanation.adoc[]
+include::{page-version}@api-ref::partial$rust/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-component-version}@api-ref::partial$rust/concept/ConceptManager.adoc[]
+include::{page-version}@api-ref::partial$rust/concept/ConceptManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/concept/Concept.adoc[]
+include::{page-version}@api-ref::partial$rust/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-//include::{page-component-version}@api-ref::partial$rust/schema/Type.adoc[]
+//include::{page-version}@api-ref::partial$rust/schema/Type.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/RootThingType.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/RootThingType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/ThingType.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/ThingType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/Trait_ThingTypeAPI.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/Trait_ThingTypeAPI.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/EntityType.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/EntityType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/Trait_EntityTypeAPI.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/Trait_EntityTypeAPI.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/RelationType.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/RelationType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/Trait_RelationTypeAPI.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/Trait_RelationTypeAPI.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/RoleType.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/RoleType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/Trait_RoleTypeAPI.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/Trait_RoleTypeAPI.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/AttributeType.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/AttributeType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/Trait_AttributeTypeAPI.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/Trait_AttributeTypeAPI.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/Annotation.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/Annotation.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/Transitivity.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/Transitivity.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/ValueType.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/ValueType.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/schema/ScopedLabel.adoc[]
+include::{page-version}@api-ref::partial$rust/schema/ScopedLabel.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-component-version}@api-ref::partial$rust/data/Thing.adoc[]
+include::{page-version}@api-ref::partial$rust/data/Thing.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/data/Trait_ThingAPI.adoc[]
+include::{page-version}@api-ref::partial$rust/data/Trait_ThingAPI.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/data/Entity.adoc[]
+include::{page-version}@api-ref::partial$rust/data/Entity.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/data/Relation.adoc[]
+include::{page-version}@api-ref::partial$rust/data/Relation.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/data/Attribute.adoc[]
+include::{page-version}@api-ref::partial$rust/data/Attribute.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/data/Value.adoc[]
+include::{page-version}@api-ref::partial$rust/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-component-version}@api-ref::partial$rust/logic/LogicManager.adoc[]
+include::{page-version}@api-ref::partial$rust/logic/LogicManager.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/logic/Rule.adoc[]
+include::{page-version}@api-ref::partial$rust/logic/Rule.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/logic/Trait_RuleAPI.adoc[]
+include::{page-version}@api-ref::partial$rust/logic/Trait_RuleAPI.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-component-version}@api-ref::partial$rust/errors/SchemaException.adoc[]
+include::{page-version}@api-ref::partial$rust/errors/SchemaException.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/errors/Error.adoc[]
+include::{page-version}@api-ref::partial$rust/errors/Error.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/errors/ConnectionError.adoc[]
+include::{page-version}@api-ref::partial$rust/errors/ConnectionError.adoc[]
 
-include::{page-component-version}@api-ref::partial$rust/errors/InternalError.adoc[]
+include::{page-version}@api-ref::partial$rust/errors/InternalError.adoc[]


### PR DESCRIPTION
## Usage and product changes

All resource URLs in our 2.x Docs now include the `{page-version}` tag.

## Motivation

This is necessary in order to support multi-versioned Docs. Without this tag, URLs are always assumed to point to the latest version - 3.x at the time of writing. This would make 2.x docs incorrect and/or unbuildable.

## Implementation

All resource URLs in our 2.x Docs now include the `{page-version}` tag.

(N.B: these Docs pages were originally handwritten - and we're keeping it that way.)