### PR TITLE
Introduce 3.0 cloud driver tests

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -97,12 +97,13 @@ build:
           export CORE_FAILED= || export CORE_FAILED=1
         tool/test/stop-core-server.sh
         if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
-
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests/integration/cloud/... --test_output=streamed &&
-#          export CLOUD_FAILED= || export CLOUD_FAILED=1
-#        tool/test/stop-cloud-servers.sh
-#        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
+        
+        # TODO: Use cloud server artifact with 3 nodes when available
+        tool/test/start-core-server.sh &&
+          bazel test //rust/tests/integration/cloud/... --test_output=streamed --test_arg=--nocapture &&
+          export CLOUD_FAILED= || export CLOUD_FAILED=1
+        tool/test/stop-core-server.sh
+        if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
     test-rust-behaviour-core:
       image: typedb-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
@@ -120,22 +121,22 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-#    test-rust-behaviour-cloud:
-#      image: typedb-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @typedb_dependencies//distribution/artifact:create-netrc
-#
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //rust/tests/behaviour/... --//rust/tests/behaviour/config:mode=cloud \
-#            --test_output=streamed --test_env=ROOT_CA=$ROOT_CA &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
+    test-rust-behaviour-cloud:
+      image: typedb-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @typedb_dependencies//distribution/artifact:create-netrc
+
+        # TODO: Use cloud server artifact with 3 nodes when available
+        tool/test/start-core-server.sh &&
+          bazel test //rust/tests/behaviour/...  --//rust/tests/behaviour:mode=cloud --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
 
 #    test-c-integration:
 #      image: typedb-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against
@@ -168,11 +169,12 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          .factory/test-cloud.sh //java/test/integration/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
+        # TODO: Use cloud server artifact with 3 nodes when available
+        tool/test/start-core-server.sh &&
+          .factory/test-cloud.sh //java/test/integration/... --test_output=errors &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
 
     test-java-behaviour-core:
       image: typedb-ubuntu-22.04
@@ -190,21 +192,22 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-#    test-java-behaviour-cloud:
-#      image: typedb-ubuntu-22.04
-#      dependencies:
-#        - build
-#      command: |
-#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @typedb_dependencies//distribution/artifact:create-netrc
-#
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          .factory/test-cloud.sh //java/test/behaviour/... --test_env=ROOT_CA=$ROOT_CA --test_output=errors --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
+    test-java-behaviour-cloud:
+      image: typedb-ubuntu-22.04
+      dependencies:
+        - build
+      command: |
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @typedb_dependencies//distribution/artifact:create-netrc
+
+        # TODO: Use cloud server artifact with 3 nodes when available
+        tool/test/start-core-server.sh &&
+          .factory/test-cloud.sh //java/test/behaviour/... --test_output=errors --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
 
     test-python-integration:
       image: typedb-ubuntu-22.04
@@ -224,11 +227,12 @@ build:
         tool/test/stop-core-server.sh
         if [[ -n "$CORE_FAILED" ]]; then exit 1; fi
 
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          bazel test //python/tests/integration/cloud/... --test_output=streamed --jobs=1 &&
-#          export CLOUD_FAILED= || export CLOUD_FAILED=1
-#        tool/test/stop-cloud-servers.sh
-#        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
+        # TODO: Use cloud server artifact with 3 nodes when available
+        tool/test/start-core-server.sh &&
+          bazel test //python/tests/integration/cloud/... --test_output=streamed --jobs=1 &&
+          export CLOUD_FAILED= || export CLOUD_FAILED=1
+        tool/test/stop-core-server.sh
+        if [[ -n "$CLOUD_FAILED" ]]; then exit 1; fi
 
     test-python-behaviour-core:
       image: typedb-ubuntu-22.04
@@ -248,24 +252,25 @@ build:
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
-#    test-python-behaviour-cloud:
-#      image: typedb-ubuntu-22.04
-#      dependencies:
-#        - build
-#      type: foreground
-#      command: |
-#        export PATH="$HOME/.local/bin:$PATH"
-#        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
-#        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
-#        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel run @typedb_dependencies//distribution/artifact:create-netrc
-#
-#        source tool/test/start-cloud-servers.sh 3 && # use source to receive export vars
-#          .factory/test-cloud.sh //python/tests/behaviour/... --test_env=ROOT_CA=$ROOT_CA --test_output=streamed --jobs=1 &&
-#          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
-#        tool/test/stop-cloud-servers.sh
-#        exit $TEST_SUCCESS
-#
+    test-python-behaviour-cloud:
+      image: typedb-ubuntu-22.04
+      dependencies:
+        - build
+      type: foreground
+      command: |
+        export PATH="$HOME/.local/bin:$PATH"
+        export ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
+        export ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
+        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
+        bazel run @typedb_dependencies//distribution/artifact:create-netrc
+
+        # TODO: Use cloud server artifact with 3 nodes when available
+        tool/test/start-core-server.sh &&
+          .factory/test-cloud.sh //python/tests/behaviour/... --test_output=streamed --jobs=1 &&
+          export TEST_SUCCESS=0 || export TEST_SUCCESS=1
+        tool/test/stop-core-server.sh
+        exit $TEST_SUCCESS
+
 #    test-nodejs-integration:
 #      image: typedb-ubuntu-22.04
 #      dependencies:

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -133,7 +133,7 @@ build:
 
         # TODO: Use cloud server artifact with 3 nodes when available
         tool/test/start-core-server.sh &&
-          bazel test //rust/tests/behaviour/...  --//rust/tests/behaviour:mode=cloud --test_output=streamed --jobs=1 &&
+          bazel test //rust/tests/behaviour/...  --//rust/tests/behaviour/config:mode=cloud --test_output=streamed --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
@@ -164,14 +164,14 @@ build:
         bazel run @typedb_dependencies//distribution/artifact:create-netrc
         
         tool/test/start-core-server.sh &&
-          .factory/test-core.sh //java/test/integration/... --test_output=errors &&
+          .factory/test-core.sh //java/test/integration/... --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS
 
         # TODO: Use cloud server artifact with 3 nodes when available
         tool/test/start-core-server.sh &&
-          .factory/test-cloud.sh //java/test/integration/... --test_output=errors &&
+          .factory/test-cloud.sh //java/test/integration/... --test_output=errors --jobs=1 &&
           export TEST_SUCCESS=0 || export TEST_SUCCESS=1
         tool/test/stop-core-server.sh
         exit $TEST_SUCCESS

--- a/java/test/behaviour/connection/BUILD
+++ b/java/test/behaviour/connection/BUILD
@@ -60,11 +60,10 @@ java_library(
     deps = [
         # Package dependencies
         ":steps-base",
+        "//java/test/behaviour/config:parameters",
         "//java:driver-java",
         "//java/api",
-        "//java/test/behaviour/util",
 #        "@maven//:com_typedb_typedb_runner",
-#        "@maven//:com_typedb_typedb_cloud_runner",
         "@maven//:io_cucumber_cucumber_java",
     ],
 )

--- a/java/test/behaviour/connection/ConnectionStepsCloud.java
+++ b/java/test/behaviour/connection/ConnectionStepsCloud.java
@@ -46,7 +46,7 @@ public class ConnectionStepsCloud extends ConnectionStepsBase {
 
     @Override
     Driver createTypeDBDriver(String address, Credentials credentials, DriverOptions driverOptions) {
-        return TypeDB.coreDriver(address, credentials, driverOptions);
+        return TypeDB.cloudDriver(address, credentials, driverOptions);
     }
 
     @Override

--- a/java/test/behaviour/connection/ConnectionStepsCloud.java
+++ b/java/test/behaviour/connection/ConnectionStepsCloud.java
@@ -18,107 +18,102 @@
  */
 package com.typedb.driver.test.behaviour.connection;
 
-// TODO: Uncomment and test when we have replications and encryption
+import com.typedb.driver.TypeDB;
+import com.typedb.driver.api.DriverOptions;
+import com.typedb.driver.api.Credentials;
+import com.typedb.driver.api.Driver;
+import com.typedb.driver.test.behaviour.config.Parameters;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
 
-//import com.typedb.core.tool.runner.TypeDBRunner;
-//import com.typedb.core.tool.runner.TypeDBSingleton;
-//import com.typedb.cloud.tool.runner.TypeDBCloudRunner;
-//import com.typedb.driver.TypeDB;
-//import com.typedb.driver.api.TypeDBDriver;
-//import com.typedb.driver.api.Credentials;
-//import com.typedb.driver.api.Options;
-//import com.typedb.driver.api.database.Database;
-//import io.cucumber.java.After;
-//import io.cucumber.java.Before;
-//import io.cucumber.java.en.Given;
-//import io.cucumber.java.en.When;
-//
-//import java.nio.file.Paths;
-//import java.util.HashMap;
-//import java.util.Map;
-//
-//import static com.typedb.driver.test.behaviour.util.Util.assertThrows;
-//
-//public class ConnectionStepsCloud extends ConnectionStepsBase {
-//
-//    @Override
-//    public void beforeAll() {
-//        super.beforeAll();
-//        TypeDBCloudRunner cloudRunner = TypeDBCloudRunner.create(Paths.get("."), 1, serverOptions);
-//        TypeDBSingleton.setTypeDBRunner(cloudRunner);
-//        cloudRunner.start();
-//    }
-//
-//    @Before
-//    public synchronized void before() {
-//        super.before();
-//    }
-//
-//    @After
-//    public synchronized void after() {
-//        super.after();
-//        try {
-//            // sleep for eventual consistency to catch up with database deletion on all servers
-//            Thread.sleep(100);
-//        } catch (InterruptedException e) {
-//            throw new RuntimeException(e);
-//        }
-//    }
-//
-//    @Override
-//    TypeDBDriver createTypeDBDriver(String address) {
-//        return createTypeDBDriver(address, DEFAULT_USERNAME, DEFAULT_PASSWORD, false); // TODO: Probably requires connection settings with tls enabled by default
-//    }
-//
-//    TypeDBDriver createTypeDBDriver(String address, String username, String password, boolean tlsEnabled) {
-//        return TypeDB.cloudDriver(address, new Credential(username, password, tlsEnabled));
-//    }
-//
+public class ConnectionStepsCloud extends ConnectionStepsBase {
+    @Override
+    public void beforeAll() {
+        super.beforeAll();
+    }
+
+    @Before
+    public synchronized void before() {
+        super.before();
+    }
+
+    @After
+    public synchronized void after() {
+        super.after();
+    }
+
+    @Override
+    Driver createTypeDBDriver(String address, Credentials credentials, DriverOptions driverOptions) {
+        return TypeDB.coreDriver(address, credentials, driverOptions);
+    }
+
+    @Override
+    Driver createDefaultTypeDBDriver() {
+        // TODO: Add encryption to cloud tests
+        return createTypeDBDriver(TypeDB.DEFAULT_ADDRESS, DEFAULT_CREDENTIALS, DEFAULT_CONNECTION_SETTINGS);
+    }
+
 //    @Override
 //    Options createOptions() {
 //        return new Options();
 //    }
-//
-//@When("connection opens with default authentication")
-//public void connection_opens_with_default_authentication() {
-//    driver = createDefaultTypeDBDriver();
-//}
-//
-//@When("connection opens with username '{non_semicolon}', password '{non_semicolon}'{may_error}")
-//public void connection_opens_with_username_password(String username, String password, Parameters.MayError mayError) {
-//    Credential credentials = new Credential(username, password);
-//    mayError.check(() -> driver = createTypeDBDriver(TypeDB.DEFAULT_ADDRESS, credentials, DEFAULT_CONNECTION_SETTINGS)); // TODO: Probably requires connection settings with tls enabled by default
-//}
-//
-//
-//    @Override
-//    @Given("connection has been opened")
-//    public void connection_has_been_opened() {
-//        super.connection_has_been_opened();
-//    }
-//
-//    @Override
-//    @Given("connection has {integer} database(s)")
-//    public void connection_has_count_databases() {
-//        super.connection_has_count_databases();
-//    }
-//
-//    @Override
-//    @When("connection closes")
-//    public void connection_closes() {
-//        super.connection_closes();
-//    }
-//
-//    @Given("typedb has configuration")
-//    public void typedb_has_configuration(Map<String, String> map) {
-//        // no-op: configuration tests are only run on the backend themselves
-//    }
-//
-//    @When("typedb starts")
-//    public void typedb_starts() {
-//        TypeDBRunner runner = TypeDBSingleton.getTypeDBRunner();
-//        if (runner != null && runner.isStopped()) {
-//            runner.start();
-//        }
-//    }
-//}
+
+    @When("typedb starts")
+    public void typedb_starts() {
+    }
+
+    @When("connection opens with default authentication")
+    public void connection_opens_with_default_authentication() {
+        driver = createDefaultTypeDBDriver();
+    }
+
+    @When("connection opens with username '{non_semicolon}', password '{non_semicolon}'{may_error}")
+    public void connection_opens_with_username_password(String username, String password, Parameters.MayError mayError) {
+        Credentials credentials = new Credentials(username, password);
+        mayError.check(() -> driver = createTypeDBDriver(TypeDB.DEFAULT_ADDRESS, credentials, DEFAULT_CONNECTION_SETTINGS));
+    }
+
+    @When("connection opens with a wrong host{may_error}")
+    public void connection_opens_with_a_wrong_host(Parameters.MayError mayError) {
+        mayError.check(() -> driver = createTypeDBDriver(
+                TypeDB.DEFAULT_ADDRESS.replace("localhost", "surely-not-localhost"),
+                DEFAULT_CREDENTIALS,
+                DEFAULT_CONNECTION_SETTINGS
+        ));
+    }
+
+    @When("connection opens with a wrong port{may_error}")
+    public void connection_opens_with_a_wrong_port(Parameters.MayError mayError) {
+        mayError.check(() -> driver = createTypeDBDriver(
+                TypeDB.DEFAULT_ADDRESS.replace("localhost", "surely-not-localhost"),
+                DEFAULT_CREDENTIALS,
+                DEFAULT_CONNECTION_SETTINGS
+        ));
+    }
+
+    @Override
+    @When("connection closes")
+    public void connection_closes() {
+        super.connection_closes();
+    }
+
+    @Override
+    @Given("connection is open: {bool}")
+    public void connection_is_open(boolean isOpen) {
+        super.connection_is_open(isOpen);
+    }
+
+    @Override
+    @Given("connection has {integer} database(s)")
+    public void connection_has_count_databases(int count) {
+        super.connection_has_count_databases(count);
+    }
+
+    @Override
+    @Given("connection has {integer} user(s)")
+    public void connection_has_count_users(int count) {
+        super.connection_has_count_users(count);
+    }
+}

--- a/java/test/behaviour/rules.bzl
+++ b/java/test/behaviour/rules.bzl
@@ -40,12 +40,12 @@ def typedb_behaviour_java_test(
 
     typedb_java_test(
         name = name + "-cloud",
-        server_artifacts = {
-            "@typedb_bazel_distribution//platform:is_linux_arm64": "@typedb_cloud_artifact_linux-arm64//file",
-            "@typedb_bazel_distribution//platform:is_linux_x86_64": "@typedb_cloud_artifact_linux-x86_64//file",
-            "@typedb_bazel_distribution//platform:is_mac_arm64": "@typedb_cloud_artifact_mac-arm64//file",
-            "@typedb_bazel_distribution//platform:is_mac_x86_64": "@typedb_cloud_artifact_mac-x86_64//file",
-            "@typedb_bazel_distribution//platform:is_windows_x86_64": "@typedb_cloud_artifact_windows-x86_64//file",
+        server_artifacts = { # TODO: Use cloud artifacts
+            "@typedb_bazel_distribution//platform:is_linux_arm64": "@typedb_artifact_linux-arm64//file",
+            "@typedb_bazel_distribution//platform:is_linux_x86_64": "@typedb_artifact_linux-x86_64//file",
+            "@typedb_bazel_distribution//platform:is_mac_arm64": "@typedb_artifact_mac-arm64//file",
+            "@typedb_bazel_distribution//platform:is_mac_x86_64": "@typedb_artifact_mac-x86_64//file",
+#            "@typedb_bazel_distribution//platform:is_windows_x86_64": "@typedb_artifact_windows-x86_64//file",
         },
         runtime_deps = runtime_deps + [connection_steps_cloud] + steps,
         **kwargs,

--- a/java/test/behaviour/rules.bzl
+++ b/java/test/behaviour/rules.bzl
@@ -38,15 +38,15 @@ def typedb_behaviour_java_test(
         **kwargs,
     )
 
-#    typedb_java_test(
-#        name = name + "-cloud",
-#        server_artifacts = {
-#            "@typedb_bazel_distribution//platform:is_linux_arm64": "@typedb_cloud_artifact_linux-arm64//file",
-#            "@typedb_bazel_distribution//platform:is_linux_x86_64": "@typedb_cloud_artifact_linux-x86_64//file",
-#            "@typedb_bazel_distribution//platform:is_mac_arm64": "@typedb_cloud_artifact_mac-arm64//file",
-#            "@typedb_bazel_distribution//platform:is_mac_x86_64": "@typedb_cloud_artifact_mac-x86_64//file",
-#            "@typedb_bazel_distribution//platform:is_windows_x86_64": "@typedb_cloud_artifact_windows-x86_64//file",
-#        },
-#        runtime_deps = runtime_deps + [connection_steps_cloud] + steps,
-#        **kwargs,
-#    )
+    typedb_java_test(
+        name = name + "-cloud",
+        server_artifacts = {
+            "@typedb_bazel_distribution//platform:is_linux_arm64": "@typedb_cloud_artifact_linux-arm64//file",
+            "@typedb_bazel_distribution//platform:is_linux_x86_64": "@typedb_cloud_artifact_linux-x86_64//file",
+            "@typedb_bazel_distribution//platform:is_mac_arm64": "@typedb_cloud_artifact_mac-arm64//file",
+            "@typedb_bazel_distribution//platform:is_mac_x86_64": "@typedb_cloud_artifact_mac-x86_64//file",
+            "@typedb_bazel_distribution//platform:is_windows_x86_64": "@typedb_cloud_artifact_windows-x86_64//file",
+        },
+        runtime_deps = runtime_deps + [connection_steps_cloud] + steps,
+        **kwargs,
+    )

--- a/java/test/integration/cloud/BUILD
+++ b/java/test/integration/cloud/BUILD
@@ -16,6 +16,7 @@
 # under the License.
 
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("@typedb_dependencies//builder/java:rules.bzl", "typedb_java_test")
 
 typedb_java_test(
     name = "test-example",

--- a/java/test/integration/cloud/BUILD
+++ b/java/test/integration/cloud/BUILD
@@ -28,7 +28,7 @@ typedb_java_test(
         "@typedb_bazel_distribution//platform:is_mac_x86_64": "@typedb_artifact_mac-x86_64//file",
 #        "@typedb_bazel_distribution//platform:is_windows_x86_64": "@typedb_artifact_windows-x86_64//file",
     },
-    test_class = "com.typedb.driver.test.integration.core.ExampleTest",
+    test_class = "com.typedb.driver.test.integration.cloud.ExampleTest",
     deps = [
         # Internal dependencies
         "//java:driver-java",

--- a/java/test/integration/cloud/BUILD
+++ b/java/test/integration/cloud/BUILD
@@ -17,6 +17,29 @@
 
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
+typedb_java_test(
+    name = "test-example",
+    srcs = ["ExampleTest.java"],
+    server_artifacts = {
+        "@typedb_bazel_distribution//platform:is_linux_arm64": "@typedb_artifact_linux-arm64//file",
+        "@typedb_bazel_distribution//platform:is_linux_x86_64": "@typedb_artifact_linux-x86_64//file",
+        "@typedb_bazel_distribution//platform:is_mac_arm64": "@typedb_artifact_mac-arm64//file",
+        "@typedb_bazel_distribution//platform:is_mac_x86_64": "@typedb_artifact_mac-x86_64//file",
+#        "@typedb_bazel_distribution//platform:is_windows_x86_64": "@typedb_artifact_windows-x86_64//file",
+    },
+    test_class = "com.typedb.driver.test.integration.core.ExampleTest",
+    deps = [
+        # Internal dependencies
+        "//java:driver-java",
+        "//java/api",
+        "//java/common",
+
+        # External dependencies from @typedb
+        "@maven//:org_slf4j_slf4j_api",
+#        "@maven//:com_typedb_typedb_runner",
+    ],
+)
+
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*"]),

--- a/java/test/integration/cloud/ExampleTest.java
+++ b/java/test/integration/cloud/ExampleTest.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.typedb.driver.test.integration.cloud;
+
+// EXAMPLE START MARKER
+
+import com.typedb.driver.TypeDB;
+import com.typedb.driver.api.Credentials;
+import com.typedb.driver.api.Driver;
+import com.typedb.driver.api.DriverOptions;
+import com.typedb.driver.api.QueryType;
+import com.typedb.driver.api.Transaction;
+import com.typedb.driver.api.answer.ConceptRow;
+import com.typedb.driver.api.answer.ConceptRowIterator;
+import com.typedb.driver.api.answer.QueryAnswer;
+import com.typedb.driver.api.concept.Concept;
+import com.typedb.driver.api.concept.type.AttributeType;
+import com.typedb.driver.api.concept.type.EntityType;
+import com.typedb.driver.api.database.Database;
+import com.typedb.driver.common.Promise;
+import com.typedb.driver.common.exception.TypeDBDriverException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@SuppressWarnings("Duplicates")
+// EXAMPLE START MARKER
+public class ExampleTest {
+    // EXAMPLE END MARKER
+    @BeforeClass
+    public static void setUpClass() {
+        Driver typedbDriver = TypeDB.cloudDriver(TypeDB.DEFAULT_ADDRESS, new Credentials("admin", "password"), new DriverOptions(false, null));
+        if (typedbDriver.databases().contains("typedb")) {
+            typedbDriver.databases().get("typedb").delete();
+        }
+        typedbDriver.close();
+    }
+
+    @Test
+    // EXAMPLE START MARKER
+    public void example() {
+        // Open a driver connection. Try-with-resources can be used for automatic driver connection management
+        try (Driver driver = TypeDB.cloudDriver(TypeDB.DEFAULT_ADDRESS, new Credentials("admin", "password"), new DriverOptions(false, null))) {
+            // Create a database
+            driver.databases().create("typedb");
+            Database database = driver.databases().get("typedb");
+            assertEquals(database.name(), "typedb");
+
+            // Open transactions of 3 types
+            Transaction tx = driver.transaction(database.name(), Transaction.Type.READ);
+
+            // Use "try" blocks to catch driver exceptions
+            try {
+                // Execute any TypeDB query using TypeQL. Wrong queries are rejected with an explicit exception
+                Promise<? extends QueryAnswer> promise = tx.query("define entity i-cannot-be-defined-in-read-transactions;");
+
+                System.out.println("The result is still promised, so it needs resolving even in case of errors!");
+                promise.resolve();
+            } catch (TypeDBDriverException expectedException) {
+                System.out.println("Once the query's promise is resolved, the exception is revealed: " + expectedException);
+            } finally {
+                // Don't forget to close the transaction!
+                tx.close();
+            }
+
+            // Open a schema transaction to make schema changes
+            // Use try-with-resources blocks to forget about "close" operations (similarly to connections)
+            try (Transaction transaction = driver.transaction(database.name(), Transaction.Type.SCHEMA)) {
+                String defineQuery = "define " +
+                        "entity person, owns name, owns age; " +
+                        "attribute name, value string;\n" +
+                        "attribute age, value integer;";
+
+                QueryAnswer answer = transaction.query(defineQuery).resolve();
+                assertTrue(answer.isOk());
+                assertEquals(QueryType.SCHEMA, answer.getQueryType());
+
+                // Commit automatically closes the transaction. It can still be safely called inside "try" blocks
+                transaction.commit();
+            }
+
+            // Open a read transaction to safely read anything without database modifications
+            try (Transaction transaction = driver.transaction(database.name(), Transaction.Type.READ)) {
+                QueryAnswer entityAnswer = transaction.query("match entity $x;").resolve();
+                assertTrue(entityAnswer.isConceptRows());
+                assertFalse(entityAnswer.isConceptDocuments());
+                assertEquals(QueryType.READ, entityAnswer.getQueryType());
+
+                // Collect concept rows that represent the answer as a table
+                List<ConceptRow> entityRows = entityAnswer.asConceptRows().stream().collect(Collectors.toList());
+                assertEquals(entityRows.size(), 1);
+                ConceptRow entityRow = entityRows.get(0);
+
+                // Collect column names to get concepts by index if the variable names are lost
+                List<String> entityHeader = entityRow.columnNames().collect(Collectors.toList());
+                assertEquals(entityHeader.size(), 1);
+
+                String columnName = entityHeader.get(0);
+                assertEquals(columnName, "x");
+
+                // Get concept by the variable name (column name)
+                Concept conceptByName = entityRow.get(columnName);
+
+                // Get concept by the header's index
+                Concept conceptByIndex = entityRow.getIndex(0);
+                assertEquals(conceptByName, conceptByIndex);
+
+                System.out.printf("Getting concepts by variable names (%s) and indexes (%s) is equally correct. ",
+                        conceptByName.getLabel(),
+                        conceptByIndex.getLabel());
+
+                // Check if it's an entity type before the conversion
+                if (conceptByName.isEntityType()) {
+                    System.out.printf("Both represent the defined entity type: '%s' (in case of a doubt: '%s')%n",
+                            conceptByName.asEntityType().getLabel(),
+                            conceptByIndex.asEntityType().getLabel());
+                }
+                assertTrue(conceptByName.isEntityType());
+                assertTrue(conceptByName.isType());
+                assertEquals(conceptByName.getLabel(), "person");
+                assertEquals(conceptByName.asEntityType().getLabel(), "person");
+                assertNotEquals(conceptByName.asEntityType().getLabel(), "not person");
+                assertNotEquals(conceptByName.asEntityType().getLabel(), "age");
+
+                // Continue querying in the same transaction if needed
+                QueryAnswer attributeAnswer = transaction.query("match attribute $a;").resolve();
+                assertTrue(attributeAnswer.isConceptRows());
+                assertEquals(QueryType.READ, attributeAnswer.getQueryType());
+
+                // ConceptRowIterator can be used as any other Iterator
+                ConceptRowIterator attributeRowIterator = attributeAnswer.asConceptRows();
+
+                while (attributeRowIterator.hasNext()) {
+                    ConceptRow attributeRow = attributeRowIterator.next();
+
+                    // Column names are a stream, so they can be used in a similar way
+                    Iterator<String> columnNameIterator = attributeRow.columnNames().iterator();
+                    columnName = columnNameIterator.next();
+                    assertFalse(columnNameIterator.hasNext());
+
+                    conceptByName = attributeRow.get(columnName);
+
+                    // Check if it's an attribute type before the conversion
+                    if (conceptByName.isAttributeType()) {
+                        AttributeType attributeType = conceptByName.asAttributeType();
+                        System.out.printf("Defined attribute type's label: '%s', value type: '%s'%n", attributeType.getLabel(), attributeType.tryGetValueType().get());
+                        assertTrue(attributeType.isInteger() || attributeType.isString());
+                        assertTrue(Objects.equals(attributeType.tryGetValueType().get(), "integer") || Objects.equals(attributeType.tryGetValueType().get(), "string"));
+                        assertTrue(Objects.equals(attributeType.getLabel(), "age") || Objects.equals(attributeType.getLabel(), "name"));
+                        assertNotEquals(attributeType.getLabel(), "person");
+                        assertNotEquals(attributeType.getLabel(), "person:age");
+
+                        System.out.printf("It is also possible to just print the concept itself: '%s'%n", conceptByName);
+                        assertTrue(conceptByName.isAttributeType());
+                        assertTrue(conceptByName.isType());
+                    }
+                }
+            }
+
+            // Open a write transaction to insert data
+            try (Transaction transaction = driver.transaction(database.name(), Transaction.Type.WRITE)) {
+                String insertQuery = "insert $z isa person, has age 10; $x isa person, has age 20, has name \"John\";";
+                QueryAnswer answer = transaction.query(insertQuery).resolve();
+                assertTrue(answer.isConceptRows());
+                assertEquals(QueryType.WRITE, answer.getQueryType());
+
+                // Insert queries also return concept rows
+                List<ConceptRow> rows = answer.asConceptRows().stream().collect(Collectors.toList());
+                assertEquals(rows.size(), 1);
+                ConceptRow row = rows.get(0);
+                row.columnNames().iterator().forEachRemaining(columnName -> {
+                    Concept insertedConcept = row.get(columnName);
+                    System.out.printf("Successfully inserted $%s: %s%n", columnName, insertedConcept);
+                    if (insertedConcept.isEntity()) {
+                        System.out.println("This time, it's an entity, not a type!");
+                    }
+                });
+
+                // It is possible to ask for the column names again
+                List<String> header = row.columnNames().collect(Collectors.toList());
+                assertEquals(header.size(), 2);
+                assertTrue(header.contains("x"));
+                assertTrue(header.contains("z"));
+
+                Concept x = row.getIndex(header.indexOf("x"));
+                System.out.printf("As we expect an entity instance, we can try to get its IID (unique identification): %s. ", x.tryGetIID());
+                if (x.isEntity()) {
+                    System.out.println("It can also be retrieved directly and safely after a cast: " + x.asEntity().getIID());
+                }
+
+                // Do not forget to commit if the changes should be persisted
+                transaction.commit();
+            }
+
+            // Open another write transaction to try inserting even more data
+            try (Transaction transaction = driver.transaction(database.name(), Transaction.Type.WRITE)) {
+                // When loading a large dataset, it's often better not to resolve every query's promise immediately.
+                // Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+                // just call `commit`, which will wait for all ongoing operations to finish before executing.
+                List<String> queries = List.of("insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";");
+                for (String query : queries) {
+                    transaction.query(query);
+                }
+                transaction.commit();
+            }
+
+            try (Transaction transaction = driver.transaction(database.name(), Transaction.Type.WRITE)) {
+                // Commit will still fail if at least one of the queries produce an error.
+                List<String> queries = List.of("insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";");
+                List<Promise<? extends QueryAnswer>> promises = new ArrayList<>();
+                for (String query : queries) {
+                    promises.add(transaction.query(query));
+                }
+
+                try {
+                    transaction.commit();
+                    fail("TypeDBDriverException is expected");
+                } catch (TypeDBDriverException expectedException) {
+                    System.out.println("Commit result will contain the unresolved query's error: " + expectedException);
+                }
+            }
+
+            // Open a read transaction to verify that the inserted data is saved
+            try (Transaction transaction = driver.transaction(database.name(), Transaction.Type.READ)) {
+                // A match query can be used for concept row outputs
+                String var = "x";
+                QueryAnswer matchAnswer = transaction.query(String.format("match $%s isa person;", var)).resolve();
+                assertTrue(matchAnswer.isConceptRows());
+                assertEquals(QueryType.READ, matchAnswer.getQueryType());
+
+                // Simple match queries always return concept rows
+                AtomicInteger matchCount = new AtomicInteger(0);
+                matchAnswer.asConceptRows().stream().forEach(row -> {
+                    assertEquals(QueryType.READ, row.getQueryType());
+                    Concept x = row.get(var);
+                    assertTrue(x.isEntity());
+                    assertFalse(x.isEntityType());
+                    assertFalse(x.isAttribute());
+                    assertFalse(x.isType());
+                    assertTrue(x.isInstance());
+                    EntityType xType = x.asEntity().getType().asEntityType();
+                    assertEquals(xType.getLabel(), "person");
+                    assertNotEquals(xType.getLabel(), "not person");
+                    matchCount.incrementAndGet();
+                    System.out.printf("Found a person %s of type %s%n", x, xType);
+                });
+                assertEquals(matchCount.get(), 4);
+                System.out.println("Total persons found: " + matchCount.get());
+
+                // A fetch query can be used for concept document outputs with flexible structure
+                QueryAnswer fetchAnswer = transaction.query("match" +
+                        "  $x isa! person, has $a;" +
+                        "  $a isa! $t;" +
+                        "fetch {" +
+                        "  \"single attribute type\": $t," +
+                        "  \"single attribute\": $a," +
+                        "  \"all attributes\": { $x.* }," +
+                        "};").resolve();
+                assertTrue(fetchAnswer.isConceptDocuments());
+                assertEquals(QueryType.READ, fetchAnswer.getQueryType());
+
+                // Fetch queries always return concept documents
+                AtomicInteger fetchCount = new AtomicInteger(0);
+                fetchAnswer.asConceptDocuments().stream().forEach(document -> {
+                    assertNotNull(document);
+                    System.out.println("Fetched a document: " + document);
+                    System.out.print("This document contains an attribute of type: ");
+                    System.out.println(document.asObject().get("single attribute type").asObject().get("label"));
+
+                    fetchCount.incrementAndGet();
+                });
+                assertEquals(fetchCount.get(), 5);
+                System.out.println("Total documents fetched: " + fetchCount.get());
+            }
+        }
+
+        System.out.println("More examples can be found in the API reference and the documentation.\nWelcome to TypeDB!");
+    }
+}
+// EXAMPLE END MARKER

--- a/python/tests/behaviour/background/cloud/environment.py
+++ b/python/tests/behaviour/background/cloud/environment.py
@@ -15,47 +15,62 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from tests.behaviour.background import environment_base
+from tests.behaviour.context import Context
 from typedb.driver import *
 
-# TODO: Uncomment and test when we have replications and encryption
-# IGNORE_TAGS = ["ignore", "ignore-typedb-driver", "ignore-typedb-driver-python"]
-#
-#
-# def before_all(context: Context):
-#     environment_base.before_all(context)
-#     context.credentials_root_ca_path = os.environ["ROOT_CA"]
-#     context.setup_context_driver_fn = lambda username="admin", password="password": \
-#         setup_context_driver(context, user, password)
-#
-#
-# def before_scenario(context: Context, scenario):
-#     for tag in IGNORE_TAGS:
-#         if tag in scenario.effective_tags:
-#             scenario.skip("tagged with @" + tag)
-#             return
-#     environment_base.before_scenario(context)
-#
-#
-# def setup_context_driver(context, username, password):
-#     credentials = Credentials(username, password, tls_enabled=True, tls_root_ca_path=context.credentials_root_ca_path)
-#     context.driver = TypeDB.cloud_driver(addresses=["localhost:" + context.config.userdata["port"]],
-#                                               credentials=credentials)
-#     context.transaction_options = Options()
-#
-#
-# def after_scenario(context: Context, scenario):
-#     environment_base.after_scenario(context, scenario)
-#
-#     # TODO: reset the database through the TypeDB runner once it exists
-#     context.setup_context_driver_fn()
-#     for database in context.driver.databases.all():
-#         database.delete()
-#
-#     for user in context.driver.users.all():
-#         if user.username() != "admin":
-#             context.driver.users.delete(user.username())
-#     context.driver.close()
-#
-#
-# def after_all(context: Context):
-#     environment_base.after_all(context)
+# TODO: Reuse code from core environment when needed, update for multiple clusters
+IGNORE_TAGS = ["ignore", "ignore-typedb-driver", "ignore-typedb-driver-python"]
+
+
+def before_all(context: Context):
+    environment_base.before_all(context)
+    # context.credentials_root_ca_path = os.environ["ROOT_CA"] # TODO: test root ca with cloud
+    context.create_driver_fn = lambda host="localhost", port=None, user=None, password=None: \
+        create_driver(context, host, port, user, password)
+    context.setup_context_driver_fn = lambda host="localhost", port=None, username=None, password=None: \
+        setup_context_driver(context, host, port, username, password)
+    context.setup_context_driver_fn()
+
+
+def before_scenario(context: Context, scenario):
+    for tag in IGNORE_TAGS:
+        if tag in scenario.effective_tags:
+            scenario.skip("tagged with @" + tag)
+            return
+    environment_base.before_scenario(context)
+
+
+def setup_context_driver(context, host="localhost", port=None, username=None, password=None):
+    # TODO: Use root_ca_path in connection
+    context.driver = create_driver(context, host, port, username, password)
+    # context.transaction_options = Options(infer=True)
+
+
+def create_driver(context, host="localhost", port=None, username=None, password=None) -> Driver:
+    if port is None:
+        port = int(context.config.userdata["port"])
+    if username is None:
+        username = "admin"
+    if password is None:
+        password = "password"
+    credentials = Credentials(username, password)
+    return TypeDB.core_driver(address=f"{host}:{port}", credentials=credentials, driver_options=DriverOptions())
+
+
+def after_scenario(context: Context, scenario):
+    environment_base.after_scenario(context, scenario)
+
+    # TODO: reset the database through the TypeDB runner once it exists
+    context.setup_context_driver_fn()
+    for database in context.driver.databases.all():
+        database.delete()
+    for user in context.driver.users.all():
+        if user.name == "admin":
+            continue
+        context.driver.users.get(user.name).delete()
+    context.driver.close()
+
+
+def after_all(context: Context):
+    environment_base.after_all(context)

--- a/python/tests/behaviour/behave_rule.bzl
+++ b/python/tests/behaviour/behave_rule.bzl
@@ -42,7 +42,6 @@ def py_behave_test(*, name, background, native_typedb_artifact, steps, feats, de
         main = "//python/tests/behaviour:entry_point_behave.py",
     )
 
-
 def typedb_behaviour_py_test_core(name, **kwargs):
     py_behave_test(
         name = name + "-core",
@@ -53,16 +52,16 @@ def typedb_behaviour_py_test_core(name, **kwargs):
         **kwargs,
     )
 
-#def typedb_behaviour_py_test_cloud(name, **kwargs):
-#    py_behave_test(
-#        name = name + "-cloud",
-#        background = "@//python/tests/behaviour/background:cloud",
-#        native_typedb_artifact = "@//tool/test:native-typedb-cloud-artifact",
-#        toolchains = ["@rules_python//python:current_py_toolchain"],
-#        typedb_port = "11729",
-#        **kwargs,
-#    )
+def typedb_behaviour_py_test_cloud(name, **kwargs):
+    py_behave_test(
+        name = name + "-cloud",
+        background = "@//python/tests/behaviour/background:cloud",
+        native_typedb_artifact = "@//tool/test:native-typedb-artifact", # TODO: Change to cloud artifact when available
+        toolchains = ["@rules_python//python:current_py_toolchain"],
+        typedb_port = "1729", # TODO: Might want to change back to 11729 when cloud has multiple nodes
+        **kwargs,
+    )
 
 def typedb_behaviour_py_test(name, **kwargs):
     typedb_behaviour_py_test_core(name, **kwargs)
-#    typedb_behaviour_py_test_cloud(name, **kwargs)
+    typedb_behaviour_py_test_cloud(name, **kwargs)

--- a/python/tests/integration/cloud/BUILD
+++ b/python/tests/integration/cloud/BUILD
@@ -20,16 +20,16 @@ load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@typedb_driver_pip//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
-#py_test(
-#    name = "test_example",
-#    srcs = ["test_example.py"],
-#    deps = [
-#        "//python:driver_python",
-#        requirement("PyHamcrest"),
-#    ],
-#    data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
-#    python_version = "PY3"
-#)
+py_test(
+    name = "test_example",
+    srcs = ["test_example.py"],
+    deps = [
+        "//python:driver_python",
+        requirement("PyHamcrest"),
+    ],
+    data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
+    python_version = "PY3"
+)
 
 #typedb_cloud_py_test(
 #    name = "test_failover",

--- a/python/tests/integration/cloud/test_example.py
+++ b/python/tests/integration/cloud/test_example.py
@@ -15,51 +15,250 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# TODO: Rewrite this as a full cloud driver's usage example for README similar to core.
+import unittest
+from unittest import TestCase
 
-# import os
-# import unittest
-# from unittest import TestCase
-#
-# from hamcrest import *
-#
-# from typedb.driver import *
-#
-# TYPEDB = "typedb"
-# DATA = SessionType.DATA
-# WRITE = TransactionType.WRITE
-# CREDENTIAL = Credentials("admin", "password", tls_enabled=True, tls_root_ca_path=os.environ["ROOT_CA"])
-#
-#
-# class TestExample(TestCase):
-#
-#     def test_core_driver_while_running_cloud(self):
-#         assert_that(calling(lambda: TypeDB.core_driver("localhost:11729")), raises(TypeDBDriverException))
-#
-#     def test_open_close_transaction(self):
-#         addresses = [
-#             "localhost:11729",
-#             "localhost:21729",
-#             "localhost:31729"
-#         ]
-#         driver = TypeDB.cloud_driver(addresses, CREDENTIAL)
-#         assert_that(driver.is_open(), is_(True))
-#         driver.close()
-#         assert_that(driver.is_open(), is_(False))
-#
-#     def test_address_translation(self):
-#         address_translation = {
-#             "localhost:11729": "localhost:11729",
-#             "localhost:21729": "localhost:21729",
-#             "localhost:31729": "localhost:31729"
-#         }
-#         with TypeDB.cloud_driver(address_translation, CREDENTIAL) as driver:
-#             if TYPEDB not in [db.name for db in driver.databases.all()]:
-#                 driver.databases.create(TYPEDB)
-#             with driver.transaction(TYPEDB, WRITE) as tx:
-#                 root = tx.getQueryType.get_root_entity_type()
-#                 assert_that(len(list(root.get_subtypes(tx))), equal_to(1))
-#
-#
-# if __name__ == "__main__":
-#     unittest.main(verbosity=2)
+from hamcrest import *
+# EXAMPLE START MARKER
+from typedb.driver import *
+
+# EXAMPLE END MARKER
+
+
+class TestExample(TestCase):
+
+    def setUp(self):
+        with TypeDB.cloud_driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+            if driver.databases.contains("typedb"):
+                driver.databases.get("typedb").delete()
+
+    # EXAMPLE START MARKER
+
+    def test_example(self):
+        # Open a driver connection. The connection will be automatically closed on the "with" block exit
+        with TypeDB.cloud_driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+            # Create a database
+            driver.databases.create("typedb")
+            database = driver.databases.get("typedb")
+            assert_that(database.name, is_("typedb"))
+
+            # Use "try" blocks to catch driver exceptions
+            try:
+                # Open transactions of 3 types
+                tx = driver.transaction(database.name, TransactionType.READ)
+
+                # Execute any TypeDB query using TypeQL. Wrong queries are rejected with an explicit exception
+                result_promise = tx.query("define entity i-cannot-be-defined-in-read-transactions;")
+
+                print("The result is still promised, so it needs resolving even in case of errors!")
+                result_promise.resolve()
+            except TypeDBDriverException as expected_exception:
+                print(f"Once the query's promise is resolved, the exception is revealed: {expected_exception}")
+            finally:
+                # Don't forget to close the transaction!
+                tx.close()
+
+            # Open a schema transaction to make schema changes
+            # Use "with" blocks to forget about "close" operations (similarly to connections)
+            with driver.transaction(database.name, TransactionType.SCHEMA) as tx:
+                define_query = """
+                define 
+                  entity person, owns name, owns age; 
+                  attribute name, value string;
+                  attribute age, value integer;
+                """
+                answer = tx.query(define_query).resolve()
+                if answer.is_ok():
+                    print(f"OK results do not give any extra interesting information, but they mean that the query "
+                          f"is successfully executed!")
+                assert_that(answer.is_ok(), is_(True))
+                assert_that(answer.query_type, is_(QueryType.SCHEMA))
+
+                # Commit automatically closes the transaction. It can still be safely called inside "with" blocks
+                tx.commit()
+
+            # Open a read transaction to safely read anything without database modifications
+            with driver.transaction(database.name, TransactionType.READ) as tx:
+                answer = tx.query("match entity $x;").resolve()
+                assert_that(answer.is_concept_rows(), is_(True))
+                assert_that(answer.is_concept_documents(), is_(False))
+                assert_that(answer.query_type, is_(QueryType.READ))
+
+                # Collect concept rows that represent the answer as a table
+                rows = list(answer.as_concept_rows())
+                assert_that(len(rows), is_(1))
+                row = rows[0]
+
+                # Collect column names to get concepts by index if the variable names are lost
+                header = list(row.column_names())
+                assert_that(len(header), is_(1))
+
+                column_name = header[0]
+                assert_that(column_name, is_("x"))
+
+                # Get concept by the variable name (column name)
+                concept_by_name = row.get(column_name)
+
+                # Get concept by the header's index
+                concept_by_index = row.get_index(0)
+                assert_that(concept_by_name, is_(equal_to(concept_by_index)))
+
+                print(f"Getting concepts by variable names ({concept_by_name.get_label()}) and "
+                      f"indexes ({concept_by_index.get_label()}) is equally correct. ")
+
+                # Check if it's an entity type before the conversion
+                if concept_by_name.is_entity_type():
+                    print(f"Both represent the defined entity type: '{concept_by_name.as_entity_type().get_label()}' "
+                          f"(in case of a doubt: '{concept_by_index.as_entity_type().get_label()}')")
+                assert_that(concept_by_name.is_entity_type(), is_(True))
+                assert_that(concept_by_name.is_type(), is_(True))
+                assert_that(concept_by_name.get_label(), is_("person"))
+                assert_that(concept_by_name.as_entity_type().get_label(), is_("person"))
+                assert_that(concept_by_name.as_entity_type().get_label(), is_not("not person"))
+                assert_that(concept_by_name.as_entity_type().get_label(), is_not("age"))
+
+                # Continue querying in the same transaction if needed
+                answer = tx.query("match attribute $a;").resolve()
+                assert_that(answer.is_concept_rows(), is_(True))
+                assert_that(answer.query_type, is_(QueryType.READ))
+
+                # Concept rows can be used as any other iterator
+                rows = [row for row in answer.as_concept_rows()]
+                assert_that(len(rows), is_(2))
+
+                for row in rows:
+                    # Same for column names
+                    column_names_iter = row.column_names()
+                    column_name = next(column_names_iter)
+                    assert_that(lambda: next(column_names_iter), raises(StopIteration))
+
+                    concept_by_name = row.get(column_name)
+
+                    # Check if it's an attribute type before the conversion
+                    if concept_by_name.is_attribute_type():
+                        attribute_type = concept_by_name.as_attribute_type()
+                        print(f"Defined attribute type's label: '{attribute_type.get_label()}', "
+                              f"value type: '{attribute_type.try_get_value_type()}'")
+
+                        assert_that(attribute_type.is_integer() or attribute_type.is_string(), is_(True))
+                        assert_that(attribute_type.try_get_value_type(), is_in(["integer", "string"]))
+                        assert_that(attribute_type.get_label(), is_in(["age", "name"]))
+                        assert_that(attribute_type.get_label(), is_not("person"))
+                        assert_that(attribute_type.get_label(), is_not("person:age"))
+
+                    print(f"It is also possible to just print the concept itself: '{concept_by_name}'")
+                    assert_that(concept_by_name.is_attribute_type(), is_(True))
+                    assert_that(concept_by_name.is_type(), is_(True))
+
+            # Open a write transaction to insert data
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                insert_query = "insert $z isa person, has age 10; $x isa person, has age 20, has name \"John\";"
+                answer = tx.query(insert_query).resolve()
+                assert_that(answer.is_concept_rows(), is_(True))
+                assert_that(answer.query_type, is_(QueryType.WRITE))
+
+                # Insert queries also return concept rows
+                rows = list(answer.as_concept_rows())
+                assert_that(len(rows), is_(1))
+                row = rows[0]
+
+                for column_name in row.column_names():
+                    inserted_concept = row.get(column_name)
+                    print(f"Successfully inserted ${column_name}: {inserted_concept}")
+                    if inserted_concept.is_entity():
+                        print("This time, it's an entity, not a type!")
+
+                # It is possible to ask for the column names again
+                header = [name for name in row.column_names()]
+                assert_that(len(header), is_(2))
+                assert_that("x" in header, is_(True))
+                assert_that("z" in header, is_(True))
+
+                x = row.get_index(header.index("x"))
+                print(
+                    "As we expect an entity instance, we can try to get its IID (unique identification): {x.try_get_iid()}. ")
+                if x.is_entity():
+                    print(f"It can also be retrieved directly and safely after a cast: {x.as_entity().get_iid()}")
+
+                # Do not forget to commit if the changes should be persisted
+                tx.commit()
+
+            # Open another write transaction to try inserting even more data
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                # When loading a large dataset, it's often better not to resolve every query's promise immediately.
+                # Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+                # just call `commit`, which will wait for all ongoing operations to finish before executing.
+                queries = ["insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";"]
+                for query in queries:
+                    tx.query(query)
+                tx.commit()
+
+            with driver.transaction(database.name, TransactionType.WRITE) as tx:
+                # Commit will still fail if at least one of the queries produce an error.
+                queries = ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"]
+                promises = []
+                for query in queries:
+                    promises.append(tx.query(query))
+
+                try:
+                    tx.commit()
+                    assert False, "TypeDBDriverException is expected"
+                except TypeDBDriverException as expected_exception:
+                    print(f"Commit result will contain the unresolved query's error: {expected_exception}")
+
+            # Open a read transaction to verify that the previously inserted data is saved
+            with driver.transaction(database.name, TransactionType.READ) as tx:
+                # A match query can be used for concept row outputs
+                var = "x"
+                answer = tx.query(f"match ${var} isa person;").resolve()
+                assert_that(answer.is_concept_rows(), is_(True))
+                assert_that(answer.query_type, is_(QueryType.READ))
+
+                # Simple match queries always return concept rows
+                count = 0
+                for row in answer.as_concept_rows():
+                    x = row.get(var)
+                    assert_that(x.is_entity(), is_(True))
+                    assert_that(x.is_entity_type(), is_(False))
+                    assert_that(x.is_attribute(), is_(False))
+                    assert_that(x.is_type(), is_(False))
+                    assert_that(x.is_instance(), is_(True))
+                    x_type = x.as_entity().get_type().as_entity_type()
+                    assert_that(x_type.get_label(), is_("person"))
+                    assert_that(x_type.get_label(), is_not("not person"))
+                    count += 1
+                    print(f"Found a person {x} of type {x_type}")
+                assert_that(count, is_(4))
+                print(f"Total persons found: {count}")
+
+                # A fetch query can be used for concept document outputs with flexible structure
+                fetch_query = """
+                match
+                  $x isa! person, has $a;
+                  $a isa! $t;
+                fetch {
+                  "single attribute type": $t,
+                  "single attribute": $a,
+                  "all attributes": { $x.* },
+                };
+                """
+                answer = tx.query(fetch_query).resolve()
+                assert_that(answer.is_concept_documents(), is_(True))
+                assert_that(answer.query_type, is_(QueryType.READ))
+
+                # Fetch queries always return concept documents
+                count = 0
+                for document in answer.as_concept_documents():
+                    count += 1
+                    print(f"Fetched a document: {document}.")
+                    print(f"This document contains an attribute of type: {document['single attribute type']['label']}")
+                assert_that(count, is_(5))
+                print(f"Total documents fetched: {count}")
+
+        print("More examples can be found in the API reference and the documentation.\nWelcome to TypeDB!")
+
+
+# EXAMPLE END MARKER
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/python/typedb/connection/driver.py
+++ b/python/typedb/connection/driver.py
@@ -43,12 +43,14 @@ class _Driver(Driver, NativeWrapper[NativeDriver]):
         try:
             if is_cloud:
                 if isinstance(addresses, list):
-                    native_driver = driver_open_cloud(addresses, credentials.native_object, Driver.LANGUAGE)
+                    native_driver = driver_open_cloud(addresses, credentials.native_object,
+                                                      driver_options.native_object, Driver.LANGUAGE)
                 else:
                     public_addresses = list(addresses.keys())
                     private_addresses = [addresses[public] for public in public_addresses]
                     native_driver = driver_open_cloud_translated(
-                        public_addresses, private_addresses, credentials.native_object)
+                        public_addresses, private_addresses, credentials.native_object, driver_options.native_object,
+                        Driver.LANGUAGE)
             else:
                 native_driver = driver_open_core(addresses[0], credentials.native_object,
                                                  driver_options.native_object,

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -130,7 +130,8 @@ impl fmt::Debug for Context {
 
 impl Context {
     const DEFAULT_CORE_ADDRESS: &'static str = "127.0.0.1:1729";
-    const DEFAULT_CLOUD_ADDRESSES: [&'static str; 3] = ["127.0.0.1:11729", "127.0.0.1:21729", "127.0.0.1:31729"];
+    // TODO when multiple nodes are available: "127.0.0.1:11729", "127.0.0.1:21729", "127.0.0.1:31729"
+    const DEFAULT_CLOUD_ADDRESSES: [&'static str; 1] = ["127.0.0.1:1729"];
     const DEFAULT_DATABASE: &'static str = "test";
     const ADMIN_USERNAME: &'static str = "admin";
     const ADMIN_PASSWORD: &'static str = "password";

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -391,7 +391,7 @@ impl Context {
     ) -> TypeDBResult<TypeDBDriver> {
         assert!(self.is_cloud); // TODO: Probably requires connection settings with tls enabled by default for cloud
         let addresses = addresses.iter().collect_vec(); // TODO: Remove when new_cloud accepts a slice
-        // TODO: Add encryption to cloud tests
+                                                        // TODO: Add encryption to cloud tests
         TypeDBDriver::new_cloud(&addresses, Credentials::new(username, password), DriverOptions::new(false, None)?)
             .await
     }

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -391,6 +391,7 @@ impl Context {
     ) -> TypeDBResult<TypeDBDriver> {
         assert!(self.is_cloud); // TODO: Probably requires connection settings with tls enabled by default for cloud
         let addresses = addresses.iter().collect_vec(); // TODO: Remove when new_cloud accepts a slice
+        // TODO: Add encryption to cloud tests
         TypeDBDriver::new_cloud(&addresses, Credentials::new(username, password), DriverOptions::new(false, None)?)
             .await
     }

--- a/rust/tests/integration/cloud/BUILD
+++ b/rust/tests/integration/cloud/BUILD
@@ -17,26 +17,26 @@
 
 package(default_visibility = ["//visibility:public"])
 
-#load("@rules_rust//rust:defs.bzl", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_test")
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
-#rust_test(
-#    name = "test_example",
-#    srcs = glob(["example.rs"]),
-#    deps = [
-#        "//rust:typedb_driver",
-#        "@crates//:async-std",
-#        "@crates//:chrono",
-#        "@crates//:futures",
-#        "@crates//:itertools",
-#        "@crates//:regex",
-#        "@crates//:serde_json",
-#        "@crates//:serial_test",
-#        "@crates//:smol",
-#        "@crates//:tokio",
-#        "@crates//:uuid",
-#    ],
-#)
+rust_test(
+    name = "test_example",
+    srcs = glob(["example.rs"]),
+    deps = [
+        "//rust:typedb_driver",
+        "@crates//:async-std",
+        "@crates//:chrono",
+        "@crates//:futures",
+        "@crates//:itertools",
+        "@crates//:regex",
+        "@crates//:serde_json",
+        "@crates//:serial_test",
+        "@crates//:smol",
+        "@crates//:tokio",
+        "@crates//:uuid",
+    ],
+)
 
 checkstyle_test(
     name = "checkstyle",

--- a/rust/tests/integration/cloud/example.rs
+++ b/rust/tests/integration/cloud/example.rs
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// EXAMPLE START MARKER
+use futures::{StreamExt, TryStreamExt};
+// EXAMPLE END MARKER
+use serial_test::serial;
+// EXAMPLE START MARKER
+use typedb_driver::{
+    answer::{
+        concept_document::{Leaf, Node},
+        ConceptRow, QueryAnswer,
+    },
+    concept::{Concept, ValueType},
+    Credentials, DriverOptions, Error, TransactionType, TypeDBDriver,
+};
+
+// EXAMPLE END MARKER
+
+async fn cleanup() {
+    let driver = TypeDBDriver::new_cloud(
+        TypeDBDriver::DEFAULT_ADDRESS,
+        Credentials::new("admin", "password"),
+        DriverOptions::new(false, None).unwrap(),
+    )
+    .await
+    .unwrap();
+    if driver.databases().contains("typedb").await.unwrap() {
+        driver.databases().get("typedb").await.unwrap().delete().await.unwrap();
+    }
+}
+
+#[test]
+#[serial]
+// EXAMPLE START MARKER
+fn example() {
+    async_std::task::block_on(async {
+        // EXAMPLE END MARKER
+        cleanup().await;
+        // EXAMPLE START MARKER
+        // Open a driver connection
+        let driver = TypeDBDriver::new_cloud(
+            TypeDBDriver::DEFAULT_ADDRESS,
+            Credentials::new("admin", "password"),
+            DriverOptions::new(false, None).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        // Create a database
+        driver.databases().create("typedb").await.unwrap();
+        let database = driver.databases().get("typedb").await.unwrap();
+        assert_eq!(database.name(), "typedb");
+
+        // Dropped transactions are closed
+        {
+            // Open transactions of 3 types
+            let transaction = driver.transaction(database.name(), TransactionType::Read).await.unwrap();
+
+            // Execute any TypeDB query using TypeQL. Wrong queries are rejected with an explicit error
+            let result = transaction.query("define entity i-cannot-be-defined-in-read-transactions;").await;
+            match result {
+                Ok(_) => println!("This line will not be printed"),
+                // Handle errors
+                Err(error) => match error {
+                    Error::Connection(connection) => println!("Could not connect: {connection}"),
+                    Error::Server(server) => {
+                        println!("Received a detailed server error regarding the executed query: {server}")
+                    }
+                    Error::Internal(_) => panic!("Unexpected internal error"),
+                    _ => println!("Received an unexpected external error: {error}"),
+                },
+            }
+        }
+
+        // Open a schema transaction to make schema changes
+        let transaction = driver.transaction(database.name(), TransactionType::Schema).await.unwrap();
+        let define_query = r#"
+        define
+          entity person, owns name, owns age;
+          attribute name, value string;
+          attribute age, value integer;
+        "#;
+        let answer = transaction.query(define_query).await.unwrap();
+
+        // Work with the driver's enums in a classic way or using helper methods
+        if answer.is_ok() && matches!(answer, QueryAnswer::Ok(_)) {
+            println!("OK results do not give any extra interesting information, but they mean that the query is successfully executed!");
+        }
+        assert!(answer.is_ok());
+
+        // Commit automatically closes the transaction (don't forget to await the result!)
+        transaction.commit().await.unwrap();
+
+        // Open a read transaction to safely read anything without database modifications
+        let transaction = driver.transaction(database.name(), TransactionType::Read).await.unwrap();
+        let answer = transaction.query("match entity $x;").await.unwrap();
+        assert!(answer.is_row_stream());
+
+        // Collect concept rows that represent the answer as a table
+        let rows: Vec<ConceptRow> = answer.into_rows().try_collect().await.unwrap();
+        assert_eq!(rows.len(), 1);
+        let row = rows.get(0).unwrap();
+
+        // Retrieve column names to get concepts by index if the variable names are lost
+        let column_names = row.get_column_names();
+        assert_eq!(column_names.len(), 1);
+
+        let column_name = column_names.get(0).unwrap();
+        assert_eq!(column_name.as_str(), "x");
+
+        // Get concept by the variable name (column name)
+        let concept_by_name = row.get(column_name).unwrap();
+
+        // Get concept by the header's index
+        let concept_by_index = row.get_index(0).unwrap();
+        assert_eq!(concept_by_name, concept_by_index);
+
+        // Check if it's an entity type
+        if concept_by_name.is_entity_type() {
+            print!("Getting concepts by variable names and indexes is equally correct. ");
+            println!(
+                "Both represent the defined entity type: '{}' (in case of a doubt: '{}')",
+                concept_by_name.get_label(),
+                concept_by_index.get_label()
+            );
+        }
+        assert!(concept_by_name.is_entity_type());
+        assert!(concept_by_name.is_type());
+        assert_eq!(concept_by_name.get_label(), "person");
+        assert_ne!(concept_by_name.get_label(), "not person");
+        assert_ne!(concept_by_name.get_label(), "age");
+
+        // Continue querying in the same transaction if needed
+        let answer = transaction.query("match attribute $a;").await.unwrap();
+        assert!(answer.is_row_stream());
+
+        // Concept rows can be used as a stream of results
+        let mut rows_stream = answer.into_rows();
+        while let Some(Ok(row)) = rows_stream.next().await {
+            let mut column_names_iter = row.get_column_names().into_iter();
+            let column_name = column_names_iter.next().unwrap();
+            assert_eq!(column_names_iter.next(), None);
+
+            let concept_by_name = row.get(column_name).unwrap();
+            assert!(concept_by_name.is_attribute_type());
+            assert!(concept_by_name.is_type());
+            assert!(concept_by_name.is_integer() || concept_by_name.is_string());
+
+            // Check if it's an attribute type to safely retrieve its value type
+            if concept_by_name.is_attribute_type() {
+                let label = concept_by_name.get_label();
+                let value_type = concept_by_name.try_get_value_type().unwrap();
+                println!("Defined attribute type's label: '{label}', value type: '{value_type}'");
+                assert!(value_type == ValueType::Integer || value_type == ValueType::String);
+                assert!(label == "age" || label == "name");
+                assert_ne!(concept_by_name.get_label(), "person");
+                assert_ne!(concept_by_name.get_label(), "person:age");
+            }
+
+            println!("It is also possible to just print the concept itself: '{}'", concept_by_name);
+        }
+
+        // Open a write transaction to insert data
+        let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+        let answer = transaction
+            .query("insert $z isa person, has age 10; $x isa person, has age 20, has name \"John\";")
+            .await
+            .unwrap();
+        assert!(answer.is_row_stream());
+
+        // Insert queries also return concept rows
+        let mut rows = Vec::new();
+        let mut rows_stream = answer.into_rows();
+        while let Some(Ok(row)) = rows_stream.next().await {
+            rows.push(row);
+        }
+        assert_eq!(rows.len(), 1);
+        let row = rows.get(0).unwrap();
+
+        for column_name in row.get_column_names() {
+            let inserted_concept = row.get(column_name).unwrap();
+            println!("Successfully inserted ${}: {}", column_name, inserted_concept);
+            if inserted_concept.is_entity() {
+                println!("This time, it's an entity, not a type!");
+            }
+        }
+
+        // It is possible to ask for the column names again
+        let column_names = row.get_column_names();
+        assert_eq!(column_names.len(), 2);
+        assert!(column_names.contains(&"x".to_owned()));
+        assert!(column_names.contains(&"z".to_owned()));
+
+        let x = row.get_index(column_names.iter().position(|r| r == "x").unwrap()).unwrap();
+        if let Some(iid) = x.try_get_iid() {
+            println!("Each entity receives a unique IID. It can be retrieved directly: {}", iid);
+        }
+
+        // Do not forget to commit if the changes should be persisted
+        transaction.commit().await.unwrap();
+
+        // Open another write transaction to try inserting even more data
+        let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+        // When loading a large dataset, it's often better not to resolve every query's promise immediately.
+        // Instead, collect promises and handle them later. Alternatively, if a commit is expected in the end,
+        // just call `commit`, which will wait for all ongoing operations to finish before executing.
+        let queries = ["insert $a isa person, has name \"Alice\";", "insert $b isa person, has name \"Bob\";"];
+        for query in queries {
+            transaction.query(query);
+        }
+        transaction.commit().await.unwrap();
+
+        {
+            let transaction = driver.transaction(database.name(), TransactionType::Write).await.unwrap();
+
+            // Commit will still fail if at least one of the queries produce an error.
+            let queries =
+                ["insert $c isa not-person, has name \"Chris\";", "insert $d isa person, has name \"David\";"];
+            let mut promises = vec![];
+            for query in queries {
+                promises.push(transaction.query(query));
+            }
+
+            let result = transaction.commit().await;
+            println!("Commit result will contain the unresolved query's error: {}", result.unwrap_err());
+        }
+
+        // Open a read transaction to verify that the inserted data is saved
+        let transaction = driver.transaction(database.name(), TransactionType::Read).await.unwrap();
+
+        // A match query can be used for concept row outputs
+        let var = "x";
+        let answer = transaction.query(format!("match ${} isa person;", var)).await.unwrap();
+        assert!(answer.is_row_stream());
+
+        // Simple match queries always return concept rows
+        let mut count = 0;
+        let mut stream = answer.into_rows().map(|result| result.unwrap());
+        while let Some(row) = stream.next().await {
+            let x = row.get(var).unwrap();
+            assert!(x.is_entity());
+            assert!(!x.is_entity_type());
+            assert!(!x.is_attribute());
+            assert!(!x.is_type());
+            assert!(x.is_instance());
+            assert_eq!(x.get_label(), "person");
+            match x {
+                Concept::Entity(x_entity) => {
+                    let x_type = x_entity.type_().unwrap();
+                    assert_eq!(x_type.label(), "person");
+                    assert_ne!(x_type.label(), "not person");
+                    count += 1;
+                    println!("Found a person {} of type {}", x, x_type);
+                }
+                _ => unreachable!("An entity is expected"),
+            }
+        }
+        assert_eq!(count, 4);
+        println!("Total persons found: {}", count);
+
+        // A fetch query can be used for concept document outputs with flexible structure
+        let fetch_query = r#"
+        match
+          $x isa! person, has $a;
+          $a isa! $t;
+        fetch {
+          "single attribute type": $t,
+          "single attribute": $a,
+          "all attributes": { $x.* },
+        };
+        "#;
+        let answer = transaction.query(fetch_query).await.unwrap();
+        assert!(answer.is_document_stream());
+
+        // Fetch queries always return concept documents
+        let mut count = 0;
+        let mut stream = answer.into_documents().map(|result| result.unwrap());
+        while let Some(document) = stream.next().await {
+            // The content of the document can be explored in details
+            match document.root.as_ref().unwrap() {
+                Node::Map(map) => {
+                    println!("Found a map document:\n{{");
+                    for (parameter_name, node) in map {
+                        print!("  \"{parameter_name}\": ");
+                        match node {
+                            Node::Map(map) => println!("map of {} element(s)", map.len()),
+                            Node::Leaf(leaf) => match leaf.as_ref().unwrap() {
+                                Leaf::Concept(concept) => match concept {
+                                    Concept::AttributeType(type_) => println!("attribute type '{}'", type_.label()),
+                                    Concept::Attribute(attribute) => println!("attribute '{}'", attribute.value),
+                                    _ => unreachable!("Unexpected concept is fetched"),
+                                },
+                                _ => unreachable!("Unexpected leaf type is fetched"),
+                            },
+                            _ => unreachable!("Expected lists in inner maps"),
+                        }
+                        print!("")
+                    }
+                    println!("}}");
+                }
+                _ => unreachable!("Unexpected document type is fetched"),
+            }
+
+            // The document can be converted to a JSON
+            count += 1;
+            println!("JSON representation of the fetched document:\n{}", document.into_json().to_string());
+        }
+        assert_eq!(count, 5);
+        println!("Total documents fetched: {}", count);
+        // EXAMPLE END MARKER
+    });
+
+    async_std::task::block_on(async {
+        cleanup().await;
+        // EXAMPLE START MARKER
+        println!("More examples can be found in the API reference and the documentation.\nWelcome to TypeDB!");
+    })
+}
+// EXAMPLE END MARKER

--- a/rust/tests/integration/cloud/example.rs
+++ b/rust/tests/integration/cloud/example.rs
@@ -32,10 +32,9 @@ use typedb_driver::{
 };
 
 // EXAMPLE END MARKER
-
 async fn cleanup() {
     let driver = TypeDBDriver::new_cloud(
-        TypeDBDriver::DEFAULT_ADDRESS,
+        &Vec::from([TypeDBDriver::DEFAULT_ADDRESS]),
         Credentials::new("admin", "password"),
         DriverOptions::new(false, None).unwrap(),
     )
@@ -55,8 +54,9 @@ fn example() {
         cleanup().await;
         // EXAMPLE START MARKER
         // Open a driver connection
+
         let driver = TypeDBDriver::new_cloud(
-            TypeDBDriver::DEFAULT_ADDRESS,
+            &Vec::from([TypeDBDriver::DEFAULT_ADDRESS]),
             Credentials::new("admin", "password"),
             DriverOptions::new(false, None).unwrap(),
         )


### PR DESCRIPTION
## Usage and product changes
We fix cloud drivers creation interfaces and introduce integration and behavior tests to cover these public methods.

## Implementation
The integration tests are currently just a copypaste of the core integration tests with another interface. Not sure if we want to change it, but it would be smarter to reuse this code differently in the future.

The behavior tests are actually currently similar to the core tests: they don't use encryption and they only use one node. We'll need to update it with more nodes in action when it's ready. Encryption can be added earlier in a separate PR: there are all the relevant TODOs in the code.