### PR TITLE
Add 'dec' suffix to notation of 'Decimal' type

### DIFF
--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "42bd82750e77af4e365c7ea697d24c43740a2dc1"
+        commit = "b80b2a70a48bf6808712502509ab0d5526e0218a"
     )
 
 #def typedb_cloud_artifact():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,5 +35,5 @@ def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
         remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "7a0693ef7142480fb29acc42248f2166d0903d09",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        commit = "bc3a83004cc390a62b466aee623c851a0251d48c",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/java/test/behaviour/query/QuerySteps.java
+++ b/java/test/behaviour/query/QuerySteps.java
@@ -717,7 +717,7 @@ public class QuerySteps {
             case DOUBLE:
                 return Double.parseDouble(value);
             case DECIMAL:
-                return new BigDecimal(value).setScale(DECIMAL_SCALE, RoundingMode.UNNECESSARY);
+                return new BigDecimal(value.replace("dec", "")).setScale(DECIMAL_SCALE, RoundingMode.UNNECESSARY);
             case STRING:
                 return value.substring(1, value.length() - 1).replace("\\\"", "\"");
             case DATE:

--- a/java/test/integration/core/ValueTest.java
+++ b/java/test/integration/core/ValueTest.java
@@ -98,7 +98,7 @@ public class ValueTest {
                 Map.entry("name", "\"John\""),
                 Map.entry("is-new", "true"),
                 Map.entry("success", "66.6"),
-                Map.entry("balance", "1234567890.0001234567890"),
+                Map.entry("balance", "1234567890.0001234567890dec"),
                 Map.entry("birth-date", "2024-09-20"),
                 Map.entry("birth-time", "1999-02-26T12:15:05"),
                 Map.entry("current-time", "2024-09-20T16:40:05 Europe/London"),
@@ -175,7 +175,7 @@ public class ValueTest {
                         checked.incrementAndGet();
                     } else if (value.isDecimal()) {
                         BigDecimal valueAsDecimal = value.getDecimal();
-                        assertEquals(new BigDecimal(attributeValues.get(attributeName)).setScale(valueAsDecimal.scale(), RoundingMode.UNNECESSARY), valueAsDecimal);
+                        assertEquals(new BigDecimal(attributeValues.get(attributeName).replace("dec", "")).setScale(valueAsDecimal.scale(), RoundingMode.UNNECESSARY), valueAsDecimal);
                         checked.incrementAndGet();
                     } else if (value.isDate()) {
                         assertEquals(LocalDate.parse(attributeValues.get(attributeName)), value.getDate());

--- a/python/tests/behaviour/query/query_steps.py
+++ b/python/tests/behaviour/query/query_steps.py
@@ -598,7 +598,7 @@ def parse_expected_value(value: str, value_type: Optional[ValueType]):
     elif value_type == ValueType.DOUBLE:
         return float(value)
     elif value_type == ValueType.DECIMAL:
-        return Decimal(value)
+        return Decimal(value.rstrip("dec"))
     elif value_type == ValueType.STRING:
         return value[1:-1].replace('\\"', '"')
     elif value_type == ValueType.DATE:

--- a/python/tests/integration/core/test_values.py
+++ b/python/tests/integration/core/test_values.py
@@ -59,7 +59,7 @@ class TestValues(TestCase):
             "name": "\"John\"",
             "is-new": "true",
             "success": "66.6",
-            "balance": "1234567890.0001234567890",
+            "balance": "1234567890.0001234567890dec",
             "birth-date": "2024-09-20",
             "birth-time": "1999-02-26T12:15:05",
             "current-time": "2024-09-20T16:40:05 Europe/Belfast",
@@ -134,7 +134,7 @@ class TestValues(TestCase):
                         assert_that(value, is_(float(expected)))
                         checked += 1
                     elif attribute.is_decimal():
-                        assert_that(value, is_(Decimal(expected)))
+                        assert_that(value, is_(Decimal(expected.rstrip("dec"))))
                         checked += 1
                     elif attribute.is_date():
                         date_format = "%Y-%m-%d"

--- a/rust/src/concept/value.rs
+++ b/rust/src/concept/value.rs
@@ -356,7 +356,7 @@ impl fmt::Debug for Decimal {
             }
 
             let fractional_width = Self::FRACTIONAL_PART_DENOMINATOR_LOG10 - tail_0s;
-            write!(f, "{}.{:0width$}", self.integer_part(), fractional, width = fractional_width as usize)?;
+            write!(f, "{}.{:0width$}dec", self.integer_part(), fractional, width = fractional_width as usize)?;
         }
         Ok(())
     }

--- a/rust/tests/behaviour/steps/params.rs
+++ b/rust/tests/behaviour/steps/params.rs
@@ -105,11 +105,8 @@ impl Value {
                 } else {
                     self.raw_value.as_str()
                 };
-                let (integer, fractional) = if let Some(split) = stripped.split_once(".") {
-                    split
-                } else {
-                    (stripped, "0")
-                };
+                let (integer, fractional) =
+                    if let Some(split) = stripped.split_once(".") { split } else { (stripped, "0") };
 
                 let integer_parsed: i64 = integer.trim().parse().unwrap();
                 let integer_parsed_abs = integer_parsed.abs();

--- a/rust/tests/behaviour/steps/params.rs
+++ b/rust/tests/behaviour/steps/params.rs
@@ -100,10 +100,15 @@ impl Value {
             TypeDBValueType::Integer => TypeDBValue::Integer(self.raw_value.parse().unwrap()),
             TypeDBValueType::Double => TypeDBValue::Double(self.raw_value.parse().unwrap()),
             TypeDBValueType::Decimal => {
-                let (integer, fractional) = if let Some(split) = self.raw_value.split_once(".") {
+                let stripped = if self.raw_value.ends_with("dec") {
+                    self.raw_value.trim_end_matches("dec")
+                } else {
+                    self.raw_value.as_str()
+                };
+                let (integer, fractional) = if let Some(split) = stripped.split_once(".") {
                     split
                 } else {
-                    (self.raw_value.as_str(), "0")
+                    (stripped, "0")
                 };
 
                 let integer_parsed: i64 = integer.trim().parse().unwrap();


### PR DESCRIPTION
## Usage and product changes
Add 'dec' suffix to notation of 'Decimal' type

## Implementation
Add 'dec' suffix to notation of 'Decimal' type. Covers:
* converting to JSON
* In BDD
* In tests.