### PR TITLE
Replay JNI loader fixes

### DIFF
--- a/java/BUILD
+++ b/java/BUILD
@@ -71,6 +71,7 @@ deploy_maven(
 
 swig_native_java_library(
     name = "typedb_driver_jni",
+    library_name_with_platform = "typedb_driver_jni-{platform}",
     lib = "//c:typedb_driver_clib_headers",
     package = "com.typedb.driver.jni",
     interface = "//c:typedb_driver.i",

--- a/java/common/Loader.java
+++ b/java/common/Loader.java
@@ -38,11 +38,15 @@ import static com.typedb.driver.common.exception.ErrorMessage.Driver.UNRECOGNISE
 public class Loader {
 
     private static final String DRIVER_JNI_LIB_RESOURCE = "typedb_driver_jni";
-    private static final String DRIVER_JNI_LIBRARY_NAME = System.mapLibraryName(DRIVER_JNI_LIB_RESOURCE);
-
     private static final Map<Pair<OS, Arch>, String> DRIVER_JNI_JAR_NAME = Map.of(new Pair<>(OS.WINDOWS, Arch.x86_64), "windows-x86_64",
             new Pair<>(OS.MAC, Arch.x86_64), "macosx-x86_64", new Pair<>(OS.MAC, Arch.ARM64), "macosx-arm64", new Pair<>(OS.LINUX, Arch.x86_64),
             "linux-x86_64", new Pair<>(OS.LINUX, Arch.ARM64), "linux-arm64");
+    private static final String DRIVER_JNI_LIBRARY_NAME = Loader.mapLibraryName();
+
+    private static String mapLibraryName() {
+        String fullName = DRIVER_JNI_LIB_RESOURCE + "-" + DRIVER_JNI_JAR_NAME.get(new Pair<>(OS.detect(), Arch.detect()));
+        return System.mapLibraryName(fullName);
+    }
 
     private static boolean loaded = false;
 


### PR DESCRIPTION
## Usage and product changes
Replays (#702), updating the jni libraries to include the platform in their filename. 

e.g. `libtypedb_driver_jni-linux-arm64.so` in place of `libtypedb-driver-jni.so` 

 Since the main maven package for the driver depends on all the jni packages, flattening these jars would lead to two`libtypedb-driver.so` being extracted - only one of which survives - leading to errors when the loader attempts to load it.


## Implementation
Check out the files from #702, since nothing on 3.0 had changed since.
Looked at the local jar contents with `jar -tf` 