### PR TITLE
Fix incorrect resource ownership transmission in schema retrieval C functions

### DIFF
--- a/c/src/database.rs
+++ b/c/src/database.rs
@@ -49,13 +49,13 @@ pub extern "C" fn database_delete(database: *const Database) {
 /// A full schema text as a valid TypeQL define query string.
 #[no_mangle]
 pub extern "C" fn database_schema(database: *const Database) -> *mut c_char {
-    try_release_string(take_arc(database).schema())
+    try_release_string(borrow(database).schema())
 }
 
 /// The types in the schema as a valid TypeQL define query string.
 #[no_mangle]
 pub extern "C" fn database_type_schema(database: *const Database) -> *mut c_char {
-    try_release_string(take_arc(database).type_schema())
+    try_release_string(borrow(database).type_schema())
 }
 
 // /// Iterator over the <code>ReplicaInfo</code> corresponding to each replica of a TypeDB cloud database.

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "fed272ee65df1e854c72c4066fdb2c4241565bb0"
+        commit = "16eca5f4238a772532a6824966e2fc78437467dc"
     )
 
 #def typedb_cloud_artifact():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -32,8 +32,9 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
+    # TODO: Return typedb
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "569b59cad1355bfaaf1ca18a8f4adf40e5d1da4f",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/farost/typedb-behaviour",
+        commit = "543fbb769687f78fc88291c190df9a5c7a008d81",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -32,9 +32,8 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/farost/typedb-behaviour",
-        commit = "543fbb769687f78fc88291c190df9a5c7a008d81",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "8f9345de853ad7d0ae66e7afefd16be2cfa3dced",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/java/test/behaviour/debug/BUILD
+++ b/java/test/behaviour/debug/BUILD
@@ -28,6 +28,8 @@ typedb_java_test(
     deps = [
         # Internal package dependencies
         "//java/test/behaviour:behaviour",
+        "//java/test/behaviour/query:steps",
+        "//java/test/behaviour/util:steps",
 
         # TODO: Add your addition debugging dependencies here
         # e.g. "//java/test/behaviour/connection/steps:connection-database",

--- a/java/test/integration/ExampleTest.java
+++ b/java/test/integration/ExampleTest.java
@@ -19,6 +19,7 @@
 
 // EXAMPLE START MARKER
 // EXAMPLE START MARKER
+// EXAMPLE START MARKER
 package com.typedb.driver.test.integration;
 
 import com.typedb.driver.TypeDB;
@@ -48,6 +49,8 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+
+// EXAMPLE END MARKER
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -56,6 +59,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings("Duplicates")
+// EXAMPLE START MARKER
 public class ExampleTest {
     // EXAMPLE END MARKER
     @BeforeClass

--- a/rust/README.md
+++ b/rust/README.md
@@ -72,7 +72,7 @@ use typedb_driver::{
         ConceptRow, QueryAnswer,
     },
     concept::{Concept, ValueType},
-    Credentials, DriverOptions, Error, TransactionOptions, TransactionType, TypeDBDriver, QueryOptions,
+    Credentials, DriverOptions, Error, QueryOptions, TransactionOptions, TransactionType, TypeDBDriver,
 };
 
 fn typedb_example() {

--- a/rust/example.rs
+++ b/rust/example.rs
@@ -9,7 +9,7 @@ use typedb_driver::{
         ConceptRow, QueryAnswer,
     },
     concept::{Concept, ValueType},
-    Credentials, DriverOptions, Error, TransactionOptions, TransactionType, TypeDBDriver, QueryOptions,
+    Credentials, DriverOptions, Error, QueryOptions, TransactionOptions, TransactionType, TypeDBDriver,
 };
 
 fn typedb_example() {

--- a/rust/tests/behaviour/steps/connection/transaction.rs
+++ b/rust/tests/behaviour/steps/connection/transaction.rs
@@ -28,7 +28,7 @@ use crate::{
     generic_step, in_background, in_oneshot_background, params, params::check_boolean, util::iter_table, Context,
 };
 
-async fn open_transaction_for_database(
+pub(crate) async fn open_transaction_for_database(
     driver: &TypeDBDriver,
     database_name: impl AsRef<str>,
     transaction_type: TransactionType,

--- a/rust/tests/behaviour/steps/query.rs
+++ b/rust/tests/behaviour/steps/query.rs
@@ -38,7 +38,7 @@ use crate::{
     BehaviourTestOptionalError, Context,
 };
 
-async fn run_query(
+pub(crate) async fn run_query(
     transaction: &Transaction,
     query: impl AsRef<str>,
     query_options: Option<QueryOptions>,


### PR DESCRIPTION
## Usage and product changes
Fix a crash caused by an incorrect database's ownership acquisition in the C layer of the `schema` and `type_schema` functions, affecting Python and Java drivers.

Add respective BDD steps implementations for these functions in Rust, Python, and Java.

## Implementation
Borrow instead of taking ownership of the referenced database resource.