### PR TITLE
Introduce file-based database export and import

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -80,11 +80,17 @@ build:
         find "${DOCS_DIRS[@]}" -type f ! -name 'api-reference.adoc' -exec rm -f {} \;
         tool/docs/update.sh
         git add "${DOCS_DIRS[@]}"
-        git diff --exit-code HEAD "${DOCS_DIRS[@]}" || echo "Failed to verify docs files: please update it manually and verify the changes"
+        git diff --exit-code HEAD "${DOCS_DIRS[@]}" || { 
+          echo "Failed to verify docs files: please update it manually and verify the changes"
+          exit 1
+        }
         
         tool/docs/update_readme.sh
         git add .
-        git diff --exit-code || echo "Failed to verify README files: please update it manually and verify the changes"
+        git diff --exit-code || { 
+          echo "Failed to verify README files: plese update it manually and verify the changes"
+          exit 1
+        }
 
     test-rust-unit-integration:
       image: typedb-ubuntu-20.04 # Ubuntu 20.04 has GLIBC version 2.31 (2020) which we should verify to compile against

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?tag=3.2.0#d4350c004c5d44436b256f291a3ecbaad77dae64"
+source = "git+https://github.com/typedb/typedb-protocol?rev=9ef738d2e0f5d9ebb57d1281a66b38267c430c15#9ef738d2e0f5d9ebb57d1281a66b38267c430c15"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=9ef738d2e0f5d9ebb57d1281a66b38267c430c15#9ef738d2e0f5d9ebb57d1281a66b38267c430c15"
+source = "git+https://github.com/typedb/typedb-protocol?rev=7ec14787622df5809b3ef86138eb331762a34083#7ec14787622df5809b3ef86138eb331762a34083"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=4520ca7f461cfca8f007403fdd09bdb9a66ed428#4520ca7f461cfca8f007403fdd09bdb9a66ed428"
+source = "git+https://github.com/typedb/typedb-protocol?rev=8c9dae847b4d816d02727541bd9db9828b038ad9#8c9dae847b4d816d02727541bd9db9828b038ad9"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=7ec14787622df5809b3ef86138eb331762a34083#7ec14787622df5809b3ef86138eb331762a34083"
+source = "git+https://github.com/typedb/typedb-protocol?rev=4520ca7f461cfca8f007403fdd09bdb9a66ed428#4520ca7f461cfca8f007403fdd09bdb9a66ed428"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_load"
+version = "0.0.0"
+dependencies = [
+ "async-std",
+ "chrono",
+ "futures",
+ "itertools 0.10.5",
+ "rand 0.8.5",
+ "regex",
+ "serde_json",
+ "serial_test",
+ "smol",
+ "tokio",
+ "typedb-driver",
+ "uuid",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2753,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=59ad51a9e9dcde8e5ac47015be7956f9b2b27fef#59ad51a9e9dcde8e5ac47015be7956f9b2b27fef"
+source = "git+https://github.com/typedb/typedb-protocol?rev=f6528beec33d6e3c31cb5dafc30e8f0f097c3f82#f6528beec33d6e3c31cb5dafc30e8f0f097c3f82"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,9 +507,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2522,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=1480387a62e48b64b34d5d8626211c3d139e0465#1480387a62e48b64b34d5d8626211c3d139e0465"
+source = "git+https://github.com/typedb/typedb-protocol?rev=59ad51a9e9dcde8e5ac47015be7956f9b2b27fef#59ad51a9e9dcde8e5ac47015be7956f9b2b27fef"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=8c9dae847b4d816d02727541bd9db9828b038ad9#8c9dae847b4d816d02727541bd9db9828b038ad9"
+source = "git+https://github.com/typedb/typedb-protocol?rev=1480387a62e48b64b34d5d8626211c3d139e0465#1480387a62e48b64b34d5d8626211c3d139e0465"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,24 +2490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test_load"
-version = "0.0.0"
-dependencies = [
- "async-std",
- "chrono",
- "futures",
- "itertools 0.10.5",
- "rand 0.8.5",
- "regex",
- "serde_json",
- "serial_test",
- "smol",
- "tokio",
- "typedb-driver",
- "uuid",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 
 [workspace]
 	resolver = "2"
-	members = ["rust", "rust/tests/integration", "rust/tests/behaviour/config", "rust/tests/behaviour/steps", "c"]
+	members = ["rust", "rust/tests/behaviour/config", "rust/tests/behaviour/steps", "c"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 
 [workspace]
 	resolver = "2"
-	members = ["rust", "rust/tests/behaviour/config", "rust/tests/behaviour/steps", "c"]
+	members = ["rust", "rust/tests/integration", "rust/tests/behaviour/config", "rust/tests/behaviour/steps", "c"]
 

--- a/c/Cargo.toml
+++ b/c/Cargo.toml
@@ -31,7 +31,7 @@ features = {}
 
 	[dependencies.chrono]
 		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.40"
+		version = "0.4.41"
 		default-features = false
 
 	[dependencies.itertools]

--- a/c/src/connection.rs
+++ b/c/src/connection.rs
@@ -19,14 +19,13 @@
 
 use std::{ffi::c_char, path::Path};
 
-use itertools::Itertools;
 use typedb_driver::{Credentials, DriverOptions, TypeDBDriver};
 
 use super::{
     error::{try_release, unwrap_void},
     memory::{borrow, free, string_view},
 };
-use crate::memory::{release, string_array_view};
+use crate::memory::release;
 
 const DRIVER_LANG: &'static str = "c";
 

--- a/c/src/database.rs
+++ b/c/src/database.rs
@@ -65,14 +65,14 @@ pub extern "C" fn database_type_schema(database: *const Database) -> *mut c_char
 /// @param schema_file The path to the schema definition file to be created.
 /// @param data_file The path to the data file to be created.
 #[no_mangle]
-pub extern "C" fn database_export_file(
+pub extern "C" fn database_export_to_file(
     database: *const Database,
     schema_file: *const c_char,
     data_file: *const c_char,
 ) {
     let schema_file_path = Path::new(string_view(schema_file));
     let data_file_path = Path::new(string_view(data_file));
-    unwrap_void(borrow(database).export_file(schema_file_path, data_file_path))
+    unwrap_void(borrow(database).export_to_file(schema_file_path, data_file_path))
 }
 
 // /// Iterator over the <code>ReplicaInfo</code> corresponding to each replica of a TypeDB cloud database.

--- a/c/src/database.rs
+++ b/c/src/database.rs
@@ -62,8 +62,8 @@ pub extern "C" fn database_type_schema(database: *const Database) -> *mut c_char
 /// This is a blocking operation and may take a significant amount of time depending on the database size.
 ///
 /// @param database The <code>Database</code> object to export from.
-/// @param schema_file_path The path to the schema definition file to be created.
-/// @param data_file_path The path to the data file to be created.
+/// @param schema_file The path to the schema definition file to be created.
+/// @param data_file The path to the data file to be created.
 #[no_mangle]
 pub extern "C" fn database_export_file(
     database: *const Database,

--- a/c/src/database_manager.rs
+++ b/c/src/database_manager.rs
@@ -26,7 +26,7 @@ use super::{
     iterator::CIterator,
     memory::{borrow_mut, free, string_view},
 };
-use crate::{error::try_release_arc, iterator::iterator_arc_next, memory::borrow};
+use crate::{error::try_release_arc, iterator::iterator_arc_next};
 
 /// An <code>Iterator</code> over databases present on the TypeDB server.
 pub struct DatabaseIterator(CIterator<Arc<Database>>);

--- a/c/src/database_manager.rs
+++ b/c/src/database_manager.rs
@@ -68,14 +68,14 @@ pub extern "C" fn databases_create(driver: *mut TypeDBDriver, name: *const c_cha
 /// @param schema The schema definition query string for the database.
 /// @param data_file The exported database file path to import the data from.
 #[no_mangle]
-pub extern "C" fn databases_import_file(
+pub extern "C" fn databases_import_from_file(
     driver: *mut TypeDBDriver,
     name: *const c_char,
     schema: *const c_char,
     data_file: *const c_char,
 ) {
     let data_file_path = Path::new(string_view(data_file));
-    unwrap_void(borrow_mut(driver).databases().import_file(string_view(name), string_view(schema), data_file_path))
+    unwrap_void(borrow_mut(driver).databases().import_from_file(string_view(name), string_view(schema), data_file_path))
 }
 
 /// Checks if a database with the given name exists.

--- a/c/src/database_manager.rs
+++ b/c/src/database_manager.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-use std::{ffi::c_char, ptr::addr_of_mut, sync::Arc};
+use std::{ffi::c_char, path::Path, ptr::addr_of_mut, sync::Arc};
 
 use typedb_driver::{box_stream, Database, TypeDBDriver};
 
@@ -26,9 +26,9 @@ use super::{
     iterator::CIterator,
     memory::{borrow_mut, free, string_view},
 };
-use crate::{error::try_release_arc, iterator::iterator_arc_next};
+use crate::{error::try_release_arc, iterator::iterator_arc_next, memory::borrow};
 
-/// An <code>Iterator</code> over databases present on the TypeDB server
+/// An <code>Iterator</code> over databases present on the TypeDB server.
 pub struct DatabaseIterator(CIterator<Arc<Database>>);
 
 /// Forwards the <code>DatabaseIterator</code> and returns the next <code>Database</code> if it exists,
@@ -38,13 +38,13 @@ pub extern "C" fn database_iterator_next(it: *mut DatabaseIterator) -> *const Da
     unsafe { iterator_arc_next(addr_of_mut!((*it).0)) }
 }
 
-/// Frees the native rust <code>DatabaseIterator</code> object
+/// Frees the native rust <code>DatabaseIterator</code> object.
 #[no_mangle]
 pub extern "C" fn database_iterator_drop(it: *mut DatabaseIterator) {
     free(it);
 }
 
-/// Returns a <code>DatabaseIterator</code> over all databases present on the TypeDB server
+/// Returns a <code>DatabaseIterator</code> over all databases present on the TypeDB server.
 #[no_mangle]
 pub extern "C" fn databases_all(driver: *mut TypeDBDriver) -> *mut DatabaseIterator {
     try_release(
@@ -52,13 +52,33 @@ pub extern "C" fn databases_all(driver: *mut TypeDBDriver) -> *mut DatabaseItera
     )
 }
 
-/// Create a database with the given name
+/// Create a database with the given name.
 #[no_mangle]
 pub extern "C" fn databases_create(driver: *mut TypeDBDriver, name: *const c_char) {
     unwrap_void(borrow_mut(driver).databases().create(string_view(name)));
 }
 
-/// Checks if a database with the given name exists
+/// Create a database with the given name based on previously exported another database's data
+/// loaded from a file.
+/// This is a blocking operation and may take a significant amount of time depending on the database
+/// size.
+///
+/// @param driver The <code>TypeDBDriver</code> object.
+/// @param name The name of the database to be created.
+/// @param schema The schema definition query string for the database.
+/// @param data_file The exported database file path to import the data from.
+#[no_mangle]
+pub extern "C" fn databases_import_file(
+    driver: *mut TypeDBDriver,
+    name: *const c_char,
+    schema: *const c_char,
+    data_file: *const c_char,
+) {
+    let data_file_path = Path::new(string_view(data_file));
+    unwrap_void(borrow_mut(driver).databases().import_file(string_view(name), string_view(schema), data_file_path))
+}
+
+/// Checks if a database with the given name exists.
 #[no_mangle]
 pub extern "C" fn databases_contains(driver: *mut TypeDBDriver, name: *const c_char) -> bool {
     unwrap_or_default(borrow_mut(driver).databases().contains(string_view(name)))

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,7 +25,7 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "d83f3b2b40c673c30d00b377ce327ac0ff233056"
+        commit = "a45d7b0003bb95e7b36ab097be468acf2398991b"
     )
 
 #def typedb_cloud_artifact():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -29,7 +29,7 @@ def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
         remote = "https://github.com/farost/typedb-protocol",
-        commit = "4520ca7f461cfca8f007403fdd09bdb9a66ed428",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        commit = "8c9dae847b4d816d02727541bd9db9828b038ad9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -25,10 +25,11 @@ def typedb_dependencies():
     )
 
 def typedb_protocol():
+    # TODO: Return typedb
     git_repository(
         name = "typedb_protocol",
         remote = "https://github.com/farost/typedb-protocol",
-        commit = "9ef738d2e0f5d9ebb57d1281a66b38267c430c15",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        commit = "7ec14787622df5809b3ef86138eb331762a34083",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -27,8 +27,8 @@ def typedb_dependencies():
 def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
-        remote = "https://github.com/typedb/typedb-protocol",
-        tag = "3.2.0",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        remote = "https://github.com/farost/typedb-protocol",
+        commit = "9ef738d2e0f5d9ebb57d1281a66b38267c430c15",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -29,7 +29,7 @@ def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
         remote = "https://github.com/farost/typedb-protocol",
-        commit = "7ec14787622df5809b3ef86138eb331762a34083",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        commit = "4520ca7f461cfca8f007403fdd09bdb9a66ed428",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -30,12 +30,13 @@ def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
         remote = "https://github.com/farost/typedb-protocol",
-        commit = "59ad51a9e9dcde8e5ac47015be7956f9b2b27fef",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        commit = "3779844e23f2f6e022445fb8caa6b2f7cd6d99eb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():
+    # TODO: Return typedb
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "8f9345de853ad7d0ae66e7afefd16be2cfa3dced",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/farost/typedb-behaviour",
+        commit = "f7c80395b00a1177194d2648e830f41afb059667",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -18,19 +18,17 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def typedb_dependencies():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/farost/typedb-dependencies",
-        commit = "b198f8d11a0b437ee9f9cf1e4eead8bedcdb7312",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/typedb/typedb-dependencies",
+        commit = "4ffeaabde31c41cee271cbb563f17168f4229a93",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_protocol():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_protocol",
-        remote = "https://github.com/farost/typedb-protocol",
-        commit = "3779844e23f2f6e022445fb8caa6b2f7cd6d99eb",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        remote = "https://github.com/typedb/typedb-protocol",
+        commit = "f6528beec33d6e3c31cb5dafc30e8f0f097c3f82",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -18,10 +18,11 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def typedb_dependencies():
+    # TODO: Return typedb
     git_repository(
         name = "typedb_dependencies",
-        remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "ab777bf067b1930e35146fd8e25a76a4a360aa74",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        remote = "https://github.com/farost/typedb-dependencies",
+        commit = "b198f8d11a0b437ee9f9cf1e4eead8bedcdb7312",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typedb_protocol():
@@ -29,7 +30,7 @@ def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
         remote = "https://github.com/farost/typedb-protocol",
-        commit = "1480387a62e48b64b34d5d8626211c3d139e0465",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        commit = "59ad51a9e9dcde8e5ac47015be7956f9b2b27fef",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -32,9 +32,8 @@ def typedb_protocol():
     )
 
 def typedb_behaviour():
-    # TODO: Return typedb
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/farost/typedb-behaviour",
-        commit = "f7c80395b00a1177194d2648e830f41afb059667",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "65258a4a3ad80be5918f33b74b1b08e25ee6fd7b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -29,7 +29,7 @@ def typedb_protocol():
     git_repository(
         name = "typedb_protocol",
         remote = "https://github.com/farost/typedb-protocol",
-        commit = "8c9dae847b4d816d02727541bd9db9828b038ad9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
+        commit = "1480387a62e48b64b34d5d8626211c3d139e0465",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_protocol
     )
 
 def typedb_behaviour():

--- a/docs/modules/ROOT/partials/java/connection/Database.adoc
+++ b/docs/modules/ROOT/partials/java/connection/Database.adoc
@@ -27,6 +27,40 @@ Deletes this database.
 database.delete()
 ----
 
+[#_Database_exportFile_java_lang_String_java_lang_String]
+==== exportFile
+
+[source,java]
+----
+void exportFile​(java.lang.String schemaFilePath,
+                java.lang.String dataFilePath)
+         throws TypeDBDriverException
+----
+
+Export a database into a schema definition and a data files saved to the disk. This is a blocking operation and may take a significant amount of time depending on the database size. 
+
+
+[caption=""]
+.Input parameters
+[cols=",,"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `schemaFilePath` a| The path to the schema definition file to be created a| `java.lang.String`
+a| `dataFilePath` a| The path to the data file to be created a| `java.lang.String`
+|===
+
+[caption=""]
+.Returns
+`void`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+database.exportFile("schema.typeql", "data.typedb")
+----
+
 [#_Database_name_]
 ==== name
 

--- a/docs/modules/ROOT/partials/java/connection/Database.adoc
+++ b/docs/modules/ROOT/partials/java/connection/Database.adoc
@@ -27,14 +27,14 @@ Deletes this database.
 database.delete()
 ----
 
-[#_Database_exportFile_java_lang_String_java_lang_String]
-==== exportFile
+[#_Database_exportToFile_java_lang_String_java_lang_String]
+==== exportToFile
 
 [source,java]
 ----
-void exportFile​(java.lang.String schemaFilePath,
-                java.lang.String dataFilePath)
-         throws TypeDBDriverException
+void exportToFile​(java.lang.String schemaFilePath,
+                  java.lang.String dataFilePath)
+           throws TypeDBDriverException
 ----
 
 Export a database into a schema definition and a data files saved to the disk. This is a blocking operation and may take a significant amount of time depending on the database size. 
@@ -58,7 +58,7 @@ a| `dataFilePath` a| The path to the data file to be created a| `java.lang.Strin
 .Code examples
 [source,java]
 ----
-database.exportFile("schema.typeql", "data.typedb")
+database.exportToFile("schema.typeql", "data.typedb")
 ----
 
 [#_Database_name_]

--- a/docs/modules/ROOT/partials/java/connection/DatabaseManager.adoc
+++ b/docs/modules/ROOT/partials/java/connection/DatabaseManager.adoc
@@ -16,7 +16,7 @@ java.util.List<Database> all()
                       throws TypeDBDriverException
 ----
 
-Retrieves all databases present on the TypeDB server 
+Retrieves all databases present on the TypeDB server. 
 
 
 [caption=""]
@@ -40,7 +40,7 @@ boolean contains​(java.lang.String name)
           throws TypeDBDriverException
 ----
 
-Checks if a database with the given name exists 
+Checks if a database with the given name exists. 
 
 
 [caption=""]
@@ -72,7 +72,7 @@ void create​(java.lang.String name)
      throws TypeDBDriverException
 ----
 
-Create a database with the given name 
+Create a database with the given name. 
 
 
 [caption=""]
@@ -126,6 +126,42 @@ a| `name` a| The name of the database to retrieve a| `java.lang.String`
 [source,java]
 ----
 driver.databases().get(name)
+----
+
+[#_DatabaseManager_importFile_java_lang_String_java_lang_String_java_lang_String]
+==== importFile
+
+[source,java]
+----
+void importFile​(java.lang.String name,
+                java.lang.String schema,
+                java.lang.String dataFilePath)
+         throws TypeDBDriverException
+----
+
+Create a database with the given name based on previously exported another database's data loaded from a file. This is a blocking operation and may take a significant amount of time depending on the database size. 
+
+
+[caption=""]
+.Input parameters
+[cols=",,"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `name` a| The name of the database to be created a| `java.lang.String`
+a| `schema` a| The schema definition query string for the database a| `java.lang.String`
+a| `dataFilePath` a| The exported database file path to import the data from a| `java.lang.String`
+|===
+
+[caption=""]
+.Returns
+`void`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+driver.databases().importFile(name, schema, "data.typedb")
 ----
 
 // end::methods[]

--- a/docs/modules/ROOT/partials/java/connection/DatabaseManager.adoc
+++ b/docs/modules/ROOT/partials/java/connection/DatabaseManager.adoc
@@ -128,15 +128,15 @@ a| `name` a| The name of the database to retrieve a| `java.lang.String`
 driver.databases().get(name)
 ----
 
-[#_DatabaseManager_importFile_java_lang_String_java_lang_String_java_lang_String]
-==== importFile
+[#_DatabaseManager_importFromFile_java_lang_String_java_lang_String_java_lang_String]
+==== importFromFile
 
 [source,java]
 ----
-void importFile​(java.lang.String name,
-                java.lang.String schema,
-                java.lang.String dataFilePath)
-         throws TypeDBDriverException
+void importFromFile​(java.lang.String name,
+                    java.lang.String schema,
+                    java.lang.String dataFilePath)
+             throws TypeDBDriverException
 ----
 
 Create a database with the given name based on previously exported another database's data loaded from a file. This is a blocking operation and may take a significant amount of time depending on the database size. 
@@ -161,7 +161,7 @@ a| `dataFilePath` a| The exported database file path to import the data from a| 
 .Code examples
 [source,java]
 ----
-driver.databases().importFile(name, schema, "data.typedb")
+driver.databases().importFromFile(name, schema, "data.typedb")
 ----
 
 // end::methods[]

--- a/docs/modules/ROOT/partials/java/transaction/QueryOptions.adoc
+++ b/docs/modules/ROOT/partials/java/transaction/QueryOptions.adoc
@@ -82,5 +82,59 @@ a| `includeInstanceTypes` a| Whether to include instance types in ConceptRow ans
 options.includeInstanceTypes(includeInstanceTypes);
 ----
 
+[#_QueryOptions_prefetchSize_]
+==== prefetchSize
+
+[source,java]
+----
+@CheckReturnValue
+public java.util.Optional<java.lang.Integer> prefetchSize()
+----
+
+Returns the value set for the prefetch size in this ``QueryOptions`` object. If set, specifies the number of extra query responses sent before the client side has to re-request more responses. Increasing this may increase performance for queries with a huge number of answers, as it can reduce the number of network round-trips at the cost of more resources on the server side. 
+
+
+[caption=""]
+.Returns
+`public java.util.Optional<java.lang.Integer>`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+options.prefetchSize();
+----
+
+[#_QueryOptions_prefetchSize_int]
+==== prefetchSize
+
+[source,java]
+----
+public QueryOptions prefetchSize​(int prefetchSize)
+----
+
+Explicitly set the prefetch size. If set, specifies the number of extra query responses sent before the client side has to re-request more responses. Increasing this may increase performance for queries with a huge number of answers, as it can reduce the number of network round-trips at the cost of more resources on the server side. Minimal value: 1. 
+
+
+[caption=""]
+.Input parameters
+[cols=",,"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `prefetchSize` a| Whether to include instance types in ConceptRow answers. a| `int`
+|===
+
+[caption=""]
+.Returns
+`public QueryOptions`
+
+[caption=""]
+.Code examples
+[source,java]
+----
+options.prefetchSize(prefetchSize);
+----
+
 // end::methods[]
 

--- a/docs/modules/ROOT/partials/python/connection/Database.adoc
+++ b/docs/modules/ROOT/partials/python/connection/Database.adoc
@@ -34,12 +34,12 @@ Deletes this database.
 database.delete()
 ----
 
-[#_Database_export_file_schema_file_path_str_data_file_path_str]
-==== export_file
+[#_Database_export_to_file_schema_file_path_str_data_file_path_str]
+==== export_to_file
 
 [source,python]
 ----
-export_file(schema_file_path: str, data_file_path: str) -> None
+export_to_file(schema_file_path: str, data_file_path: str) -> None
 ----
 
 Export a database into a schema definition and a data files saved to the disk. This is a blocking operation and may take a significant amount of time depending on the database size.
@@ -62,7 +62,7 @@ a| `data_file_path` a| The path to the data file to be created a| `str` a|
 .Code examples
 [source,python]
 ----
-database.export_file("schema.typeql", "data.typedb")
+database.export_to_file("schema.typeql", "data.typedb")
 ----
 
 [#_Database_schema_]

--- a/docs/modules/ROOT/partials/python/connection/Database.adoc
+++ b/docs/modules/ROOT/partials/python/connection/Database.adoc
@@ -34,6 +34,37 @@ Deletes this database.
 database.delete()
 ----
 
+[#_Database_export_file_schema_file_path_str_data_file_path_str]
+==== export_file
+
+[source,python]
+----
+export_file(schema_file_path: str, data_file_path: str) -> None
+----
+
+Export a database into a schema definition and a data files saved to the disk. This is a blocking operation and may take a significant amount of time depending on the database size.
+
+[caption=""]
+.Input parameters
+[cols=",,,"]
+[options="header"]
+|===
+|Name |Description |Type |Default Value
+a| `schema_file_path` a| The path to the schema definition file to be created a| `str` a| 
+a| `data_file_path` a| The path to the data file to be created a| `str` a| 
+|===
+
+[caption=""]
+.Returns
+`None`
+
+[caption=""]
+.Code examples
+[source,python]
+----
+database.export_file("schema.typeql", "data.typedb")
+----
+
 [#_Database_schema_]
 ==== schema
 

--- a/docs/modules/ROOT/partials/python/connection/DatabaseManager.adoc
+++ b/docs/modules/ROOT/partials/python/connection/DatabaseManager.adoc
@@ -115,12 +115,12 @@ a| `name` a| The name of the database to retrieve a| `str` a|
 driver.databases.get(name)
 ----
 
-[#_DatabaseManager_import_file_name_str_schema_str_data_file_path_str]
-==== import_file
+[#_DatabaseManager_import_from_file_name_str_schema_str_data_file_path_str]
+==== import_from_file
 
 [source,python]
 ----
-import_file(name: str, schema: str, data_file_path: str) -> None
+import_from_file(name: str, schema: str, data_file_path: str) -> None
 ----
 
 Create a database with the given name based on previously exported another database’s data loaded from a file. This is a blocking operation and may take a significant amount of time depending on the database size.
@@ -144,7 +144,7 @@ a| `data_file_path` a| The exported database file path to import the data from a
 .Code examples
 [source,python]
 ----
-driver.databases.import_file(name, schema, "data.typedb")
+driver.databases.import_from_file(name, schema, "data.typedb")
 ----
 
 // end::methods[]

--- a/docs/modules/ROOT/partials/python/connection/DatabaseManager.adoc
+++ b/docs/modules/ROOT/partials/python/connection/DatabaseManager.adoc
@@ -12,7 +12,7 @@ Provides access to all database management methods.
 all() -> List[Database]
 ----
 
-Retrieves all databases present on the TypeDB server
+Retrieves all databases present on the TypeDB server.
 
 [caption=""]
 .Returns
@@ -33,7 +33,7 @@ driver.databases.all()
 contains(name: str) -> bool
 ----
 
-Checks if a database with the given name exists
+Checks if a database with the given name exists.
 
 [caption=""]
 .Input parameters
@@ -63,7 +63,7 @@ driver.databases.contains(name)
 create(name: str) -> None
 ----
 
-Create a database with the given name
+Create a database with the given name.
 
 [caption=""]
 .Input parameters
@@ -113,6 +113,38 @@ a| `name` a| The name of the database to retrieve a| `str` a|
 [source,python]
 ----
 driver.databases.get(name)
+----
+
+[#_DatabaseManager_import_file_name_str_schema_str_data_file_path_str]
+==== import_file
+
+[source,python]
+----
+import_file(name: str, schema: str, data_file_path: str) -> None
+----
+
+Create a database with the given name based on previously exported another database’s data loaded from a file. This is a blocking operation and may take a significant amount of time depending on the database size.
+
+[caption=""]
+.Input parameters
+[cols=",,,"]
+[options="header"]
+|===
+|Name |Description |Type |Default Value
+a| `name` a| The name of the database to be created a| `str` a| 
+a| `schema` a| The schema definition query string for the database a| `str` a| 
+a| `data_file_path` a| The exported database file path to import the data from a| `str` a| 
+|===
+
+[caption=""]
+.Returns
+`None`
+
+[caption=""]
+.Code examples
+[source,python]
+----
+driver.databases.import_file(name, schema, "data.typedb")
 ----
 
 // end::methods[]

--- a/docs/modules/ROOT/partials/python/transaction/QueryOptions.adoc
+++ b/docs/modules/ROOT/partials/python/transaction/QueryOptions.adoc
@@ -10,7 +10,7 @@ Options could be specified either as constructor arguments or using properties a
 [source,python]
 ----
 query_options = QueryOptions(include_instance_types=True)
-query_options.include_instance_types = False
+query_options.prefetch_size = 10
 ----
 
 [caption=""]
@@ -21,6 +21,7 @@ query_options.include_instance_types = False
 |===
 |Name |Type |Description
 a| `include_instance_types` a| `bool \| None` a| If set, specifies if types should be included in instance structs returned in ConceptRow answers. This option allows reducing the amount of unnecessary data transmitted.
+a| `prefetch_size` a| `int \| None` a| If set, specifies the number of extra query responses sent before the client side has to re-request more responses. Increasing this may increase performance for queries with a huge number of answers, as it can reduce the number of network round-trips at the cost of more resources on the server side. Minimal value: 1.
 |===
 // end::properties[]
 

--- a/docs/modules/ROOT/partials/rust/connection/Database.adoc
+++ b/docs/modules/ROOT/partials/rust/connection/Database.adoc
@@ -68,8 +68,8 @@ database.delete();
 --
 ====
 
-[#_struct_Database_export_file_schema_file_path_impl_AsRef_Path_data_file_path_impl_AsRef_Path_]
-==== export_file
+[#_struct_Database_export_to_file_schema_file_path_impl_AsRef_Path_data_file_path_impl_AsRef_Path_]
+==== export_to_file
 
 [tabs]
 ====
@@ -78,7 +78,7 @@ async::
 --
 [source,rust]
 ----
-pub async fn export_file(
+pub async fn export_to_file(
     &self,
     schema_file_path: impl AsRef<Path>,
     data_file_path: impl AsRef<Path>,
@@ -92,7 +92,7 @@ sync::
 --
 [source,rust]
 ----
-pub fn export_file(
+pub fn export_to_file(
     &self,
     schema_file_path: impl AsRef<Path>,
     data_file_path: impl AsRef<Path>,
@@ -130,7 +130,7 @@ async::
 --
 [source,rust]
 ----
-database.export_file(schema_path, data_path).await;
+database.export_to_file(schema_path, data_path).await;
 ----
 
 --
@@ -140,7 +140,7 @@ sync::
 --
 [source,rust]
 ----
-database.export_file(schema_path, data_path);
+database.export_to_file(schema_path, data_path);
 ----
 
 --

--- a/docs/modules/ROOT/partials/rust/connection/Database.adoc
+++ b/docs/modules/ROOT/partials/rust/connection/Database.adoc
@@ -68,6 +68,84 @@ database.delete();
 --
 ====
 
+[#_struct_Database_export_file_schema_file_path_impl_AsRef_Path_data_file_path_impl_AsRef_Path_]
+==== export_file
+
+[tabs]
+====
+async::
++
+--
+[source,rust]
+----
+pub async fn export_file(
+    &self,
+    schema_file_path: impl AsRef<Path>,
+    data_file_path: impl AsRef<Path>,
+) -> Result
+----
+
+--
+
+sync::
++
+--
+[source,rust]
+----
+pub fn export_file(
+    &self,
+    schema_file_path: impl AsRef<Path>,
+    data_file_path: impl AsRef<Path>,
+) -> Result
+----
+
+--
+====
+
+Export a database into a schema definition and a data files saved to the disk. This is a blocking operation and may take a significant amount of time depending on the database size.
+
+[caption=""]
+.Input parameters
+[cols=",,"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `schema_file_path` a|  — The path to the schema definition file to be created a| `impl AsRef<Path>`
+a| `data_file_path` a|  — The path to the data file to be created a| `impl AsRef<Path>`
+|===
+
+[caption=""]
+.Returns
+[source,rust]
+----
+Result
+----
+
+[caption=""]
+.Code examples
+[tabs]
+====
+async::
++
+--
+[source,rust]
+----
+database.export_file(schema_path, data_path).await;
+----
+
+--
+
+sync::
++
+--
+[source,rust]
+----
+database.export_file(schema_path, data_path);
+----
+
+--
+====
+
 [#_struct_Database_name_]
 ==== name
 

--- a/docs/modules/ROOT/partials/rust/connection/DatabaseManager.adoc
+++ b/docs/modules/ROOT/partials/rust/connection/DatabaseManager.adoc
@@ -275,5 +275,86 @@ driver.databases().get(name);
 --
 ====
 
+[#_struct_DatabaseManager_import_file_name_impl_Into_String_schema_impl_Into_String_data_file_path_impl_AsRef_Path_]
+==== import_file
+
+[tabs]
+====
+async::
++
+--
+[source,rust]
+----
+pub async fn import_file(
+    &self,
+    name: impl Into<String>,
+    schema: impl Into<String>,
+    data_file_path: impl AsRef<Path>,
+) -> Result
+----
+
+--
+
+sync::
++
+--
+[source,rust]
+----
+pub fn import_file(
+    &self,
+    name: impl Into<String>,
+    schema: impl Into<String>,
+    data_file_path: impl AsRef<Path>,
+) -> Result
+----
+
+--
+====
+
+Create a database with the given name based on previously exported another database’s data loaded from a file. This is a blocking operation and may take a significant amount of time depending on the database size.
+
+[caption=""]
+.Input parameters
+[cols=",,"]
+[options="header"]
+|===
+|Name |Description |Type
+a| `name` a|  — The name of the database to be created a| `impl Into<String>`
+a| `schema` a|  — The schema definition query string for the database a| `impl Into<String>`
+a| `data_file_path` a|  — The exported database file to import the data from a| `impl AsRef<Path>`
+|===
+
+[caption=""]
+.Returns
+[source,rust]
+----
+Result
+----
+
+[caption=""]
+.Code examples
+[tabs]
+====
+async::
++
+--
+[source,rust]
+----
+driver.databases().import_file(name, schema, data_path).await;
+----
+
+--
+
+sync::
++
+--
+[source,rust]
+----
+driver.databases().import_file(name, schema, data_path);
+----
+
+--
+====
+
 // end::methods[]
 

--- a/docs/modules/ROOT/partials/rust/connection/DatabaseManager.adoc
+++ b/docs/modules/ROOT/partials/rust/connection/DatabaseManager.adoc
@@ -275,8 +275,8 @@ driver.databases().get(name);
 --
 ====
 
-[#_struct_DatabaseManager_import_file_name_impl_Into_String_schema_impl_Into_String_data_file_path_impl_AsRef_Path_]
-==== import_file
+[#_struct_DatabaseManager_import_from_file_name_impl_Into_String_schema_impl_Into_String_data_file_path_impl_AsRef_Path_]
+==== import_from_file
 
 [tabs]
 ====
@@ -285,7 +285,7 @@ async::
 --
 [source,rust]
 ----
-pub async fn import_file(
+pub async fn import_from_file(
     &self,
     name: impl Into<String>,
     schema: impl Into<String>,
@@ -300,7 +300,7 @@ sync::
 --
 [source,rust]
 ----
-pub fn import_file(
+pub fn import_from_file(
     &self,
     name: impl Into<String>,
     schema: impl Into<String>,
@@ -340,7 +340,7 @@ async::
 --
 [source,rust]
 ----
-driver.databases().import_file(name, schema, data_path).await;
+driver.databases().import_from_file(name, schema, data_path).await;
 ----
 
 --
@@ -350,7 +350,7 @@ sync::
 --
 [source,rust]
 ----
-driver.databases().import_file(name, schema, data_path);
+driver.databases().import_from_file(name, schema, data_path);
 ----
 
 --

--- a/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
@@ -13,6 +13,10 @@ a| `BrokenPipe`
 a| `ClusterAllNodesFailed`
 a| `ClusterReplicaNotPrimary`
 a| `ConnectionFailed`
+a| `DatabaseExportChannelIsClosed`
+a| `DatabaseExportStreamNoResponse`
+a| `DatabaseImportChannelIsClosed`
+a| `DatabaseImportStreamUnexpectedResponse`
 a| `DatabaseNotFound`
 a| `EncryptionSettingsMismatch`
 a| `InvalidResponseField`

--- a/docs/modules/ROOT/partials/rust/errors/Error.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/Error.adoc
@@ -13,6 +13,7 @@ Represents errors encountered during operation.
 a| `Concept(ConceptError)`
 a| `Connection(ConnectionError)`
 a| `Internal(InternalError)`
+a| `Migration(MigrationError)`
 a| `Other(String)`
 a| `Server(ServerError)`
 |===

--- a/docs/modules/ROOT/partials/rust/errors/MigrationError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/MigrationError.adoc
@@ -1,0 +1,18 @@
+[#_enum_MigrationError]
+=== MigrationError
+
+[caption=""]
+.Enum variants
+// tag::enum_constants[]
+[cols=""]
+[options="header"]
+|===
+|Variant
+a| `CannotCreateExportFile`
+a| `CannotDecodeImportedConcept`
+a| `CannotDecodeImportedConceptLength`
+a| `CannotEncodeExportedConcept`
+a| `CannotOpenImportFile`
+|===
+// end::enum_constants[]
+

--- a/docs/modules/ROOT/partials/rust/errors/MigrationError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/MigrationError.adoc
@@ -10,7 +10,7 @@
 |Variant
 a| `CannotCreateExportFile`
 a| `CannotDecodeImportedConcept`
-a| `CannotDecodeImportedConceptLenh`
+a| `CannotDecodeImportedConceptLength`
 a| `CannotEncodeExportedConcept`
 a| `CannotOpenImportFile`
 |===

--- a/docs/modules/ROOT/partials/rust/errors/MigrationError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/MigrationError.adoc
@@ -10,7 +10,7 @@
 |Variant
 a| `CannotCreateExportFile`
 a| `CannotDecodeImportedConcept`
-a| `CannotDecodeImportedConceptLength`
+a| `CannotDecodeImportedConceptLenh`
 a| `CannotEncodeExportedConcept`
 a| `CannotOpenImportFile`
 |===

--- a/docs/modules/ROOT/partials/rust/errors/MigrationError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/MigrationError.adoc
@@ -12,6 +12,7 @@ a| `CannotCreateExportFile`
 a| `CannotDecodeImportedConcept`
 a| `CannotDecodeImportedConceptLength`
 a| `CannotEncodeExportedConcept`
+a| `CannotExportToTheSameFile`
 a| `CannotOpenImportFile`
 |===
 // end::enum_constants[]

--- a/docs/modules/ROOT/partials/rust/transaction/QueryOptions.adoc
+++ b/docs/modules/ROOT/partials/rust/transaction/QueryOptions.adoc
@@ -18,6 +18,7 @@ TypeDB query options. ``QueryOptions`` object can be used to override the defaul
 |===
 |Name |Type |Description
 a| `include_instance_types` a| `Option<bool>` a| If set, specifies if types should be included in instance structs returned in ConceptRow answers. This option allows reducing the amount of unnecessary data transmitted.
+a| `prefetch_size` a| `Option<u64>` a| If set, specifies the number of extra query responses sent before the client side has to re-request more responses. Increasing this may increase performance for queries with a huge number of answers, as it can reduce the number of network round-trips at the cost of more resources on the server side. Minimal value: 1.
 |===
 // end::properties[]
 
@@ -31,6 +32,23 @@ pub fn include_instance_types(self, include_instance_types: bool) -> Self
 ----
 
 If set, specifies if types should be included in instance structs returned in ConceptRow answers. This option allows reducing the amount of unnecessary data transmitted.
+
+[caption=""]
+.Returns
+[source,rust]
+----
+Self
+----
+
+[#_struct_QueryOptions_prefetch_size_]
+==== prefetch_size
+
+[source,rust]
+----
+pub fn prefetch_size(self, prefetch_size: u64) -> Self
+----
+
+If set, specifies the number of extra query responses sent before the client side has to re-request more responses. Increasing this may increase performance for queries with a huge number of answers, as it can reduce the number of network round-trips at the cost of more resources on the server side.
 
 [caption=""]
 .Returns

--- a/java/api/TransactionOptions.java
+++ b/java/api/TransactionOptions.java
@@ -21,12 +21,10 @@ package com.typedb.driver.api;
 
 import com.typedb.driver.common.NativeObject;
 import com.typedb.driver.common.Validator;
-import com.typedb.driver.common.exception.TypeDBDriverException;
 
 import javax.annotation.CheckReturnValue;
 import java.util.Optional;
 
-import static com.typedb.driver.common.exception.ErrorMessage.Driver.POSITIVE_VALUE_REQUIRED;
 import static com.typedb.driver.jni.typedb_driver.transaction_options_get_schema_lock_acquire_timeout_millis;
 import static com.typedb.driver.jni.typedb_driver.transaction_options_get_transaction_timeout_millis;
 import static com.typedb.driver.jni.typedb_driver.transaction_options_has_schema_lock_acquire_timeout_millis;

--- a/java/api/database/Database.java
+++ b/java/api/database/Database.java
@@ -59,13 +59,13 @@ public interface Database {
      *
      * <h3>Examples</h3>
      * <pre>
-     * database.exportFile("schema.typeql", "data.typedb")
+     * database.exportToFile("schema.typeql", "data.typedb")
      * </pre>
      *
      * @param schemaFilePath The path to the schema definition file to be created
      * @param dataFilePath   The path to the data file to be created
      */
-    void exportFile(String schemaFilePath, String dataFilePath) throws TypeDBDriverException;
+    void exportToFile(String schemaFilePath, String dataFilePath) throws TypeDBDriverException;
 
     /**
      * Deletes this database.

--- a/java/api/database/Database.java
+++ b/java/api/database/Database.java
@@ -54,6 +54,20 @@ public interface Database {
     String typeSchema() throws TypeDBDriverException;
 
     /**
+     * Export a database into a schema definition and a data files saved to the disk.
+     * This is a blocking operation and may take a significant amount of time depending on the database size.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * database.exportFile("schema.typeql", "data.typedb")
+     * </pre>
+     *
+     * @param schemaFilePath The path to the schema definition file to be created
+     * @param dataFilePath   The path to the data file to be created
+     */
+    void exportFile(String schemaFilePath, String dataFilePath) throws TypeDBDriverException;
+
+    /**
      * Deletes this database.
      *
      * <h3>Examples</h3>

--- a/java/api/database/DatabaseManager.java
+++ b/java/api/database/DatabaseManager.java
@@ -73,14 +73,14 @@ public interface DatabaseManager {
      *
      * <h3>Examples</h3>
      * <pre>
-     * driver.databases().importFile(name, schema, "data.typedb")
+     * driver.databases().importFromFile(name, schema, "data.typedb")
      * </pre>
      *
      * @param name         The name of the database to be created
      * @param schema       The schema definition query string for the database
      * @param dataFilePath The exported database file path to import the data from
      */
-    void importFile(String name, String schema, String dataFilePath) throws TypeDBDriverException;
+    void importFromFile(String name, String schema, String dataFilePath) throws TypeDBDriverException;
 
     /**
      * Retrieves all databases present on the TypeDB server.

--- a/java/api/database/DatabaseManager.java
+++ b/java/api/database/DatabaseManager.java
@@ -43,7 +43,7 @@ public interface DatabaseManager {
     Database get(String name) throws TypeDBDriverException;
 
     /**
-     * Checks if a database with the given name exists
+     * Checks if a database with the given name exists.
      *
      * <h3>Examples</h3>
      * <pre>
@@ -56,7 +56,7 @@ public interface DatabaseManager {
     boolean contains(String name) throws TypeDBDriverException;
 
     /**
-     * Create a database with the given name
+     * Create a database with the given name.
      *
      * <h3>Examples</h3>
      * <pre>
@@ -65,11 +65,25 @@ public interface DatabaseManager {
      *
      * @param name The name of the database to be created
      */
-    // TODO: Return type should be 'Database' but right now that would require 2 server calls in Cluster
     void create(String name) throws TypeDBDriverException;
 
     /**
-     * Retrieves all databases present on the TypeDB server
+     * Create a database with the given name based on previously exported another database's data loaded from a file.
+     * This is a blocking operation and may take a significant amount of time depending on the database size.
+     *
+     * <h3>Examples</h3>
+     * <pre>
+     * driver.databases().importFile(name, schema, "data.typedb")
+     * </pre>
+     *
+     * @param name         The name of the database to be created
+     * @param schema       The schema definition query string for the database
+     * @param dataFilePath The exported database file path to import the data from
+     */
+    void importFile(String name, String schema, String dataFilePath) throws TypeDBDriverException;
+
+    /**
+     * Retrieves all databases present on the TypeDB server.
      *
      * <h3>Examples</h3>
      * <pre>

--- a/java/connection/DatabaseImpl.java
+++ b/java/connection/DatabaseImpl.java
@@ -26,7 +26,7 @@ import com.typedb.driver.common.exception.TypeDBDriverException;
 
 import static com.typedb.driver.common.exception.ErrorMessage.Driver.DATABASE_DELETED;
 import static com.typedb.driver.jni.typedb_driver.database_delete;
-import static com.typedb.driver.jni.typedb_driver.database_export_file;
+import static com.typedb.driver.jni.typedb_driver.database_export_to_file;
 import static com.typedb.driver.jni.typedb_driver.database_get_name;
 import static com.typedb.driver.jni.typedb_driver.database_schema;
 import static com.typedb.driver.jni.typedb_driver.database_type_schema;
@@ -63,11 +63,11 @@ public class DatabaseImpl extends NativeObject<com.typedb.driver.jni.Database> i
     }
 
     @Override
-    public void exportFile(String schemaFilePath, String dataFilePath) throws TypeDBDriverException {
+    public void exportToFile(String schemaFilePath, String dataFilePath) throws TypeDBDriverException {
         Validator.requireNonNull(schemaFilePath, "schemaFilePath");
         Validator.requireNonNull(dataFilePath, "dataFilePath");
         try {
-            database_export_file(nativeObject, schemaFilePath, dataFilePath);
+            database_export_to_file(nativeObject, schemaFilePath, dataFilePath);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/java/connection/DatabaseImpl.java
+++ b/java/connection/DatabaseImpl.java
@@ -21,10 +21,12 @@ package com.typedb.driver.connection;
 
 import com.typedb.driver.api.database.Database;
 import com.typedb.driver.common.NativeObject;
+import com.typedb.driver.common.Validator;
 import com.typedb.driver.common.exception.TypeDBDriverException;
 
 import static com.typedb.driver.common.exception.ErrorMessage.Driver.DATABASE_DELETED;
 import static com.typedb.driver.jni.typedb_driver.database_delete;
+import static com.typedb.driver.jni.typedb_driver.database_export_file;
 import static com.typedb.driver.jni.typedb_driver.database_get_name;
 import static com.typedb.driver.jni.typedb_driver.database_schema;
 import static com.typedb.driver.jni.typedb_driver.database_type_schema;
@@ -55,6 +57,17 @@ public class DatabaseImpl extends NativeObject<com.typedb.driver.jni.Database> i
         if (!nativeObject.isOwned()) throw new TypeDBDriverException(DATABASE_DELETED);
         try {
             return database_type_schema(nativeObject);
+        } catch (com.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
+    }
+
+    @Override
+    public void exportFile(String schemaFilePath, String dataFilePath) throws TypeDBDriverException {
+        Validator.requireNonNull(schemaFilePath, "schemaFilePath");
+        Validator.requireNonNull(dataFilePath, "dataFilePath");
+        try {
+            database_export_file(nativeObject, schemaFilePath, dataFilePath);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/java/connection/DatabaseManagerImpl.java
+++ b/java/connection/DatabaseManagerImpl.java
@@ -31,6 +31,7 @@ import static com.typedb.driver.jni.typedb_driver.databases_all;
 import static com.typedb.driver.jni.typedb_driver.databases_contains;
 import static com.typedb.driver.jni.typedb_driver.databases_create;
 import static com.typedb.driver.jni.typedb_driver.databases_get;
+import static com.typedb.driver.jni.typedb_driver.databases_import_file;
 import static java.util.stream.Collectors.toList;
 
 public class DatabaseManagerImpl implements DatabaseManager {
@@ -65,6 +66,18 @@ public class DatabaseManagerImpl implements DatabaseManager {
         Validator.requireNonNull(name, "name");
         try {
             databases_create(nativeDriver, name);
+        } catch (com.typedb.driver.jni.Error e) {
+            throw new TypeDBDriverException(e);
+        }
+    }
+
+    @Override
+    public void importFile(String name, String schema, String dataFilePath) throws TypeDBDriverException {
+        Validator.requireNonNull(name, "name");
+        Validator.requireNonNull(schema, "schema");
+        Validator.requireNonNull(dataFilePath, "dataFilePath");
+        try {
+            databases_import_file(nativeDriver, name, schema, dataFilePath);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/java/connection/DatabaseManagerImpl.java
+++ b/java/connection/DatabaseManagerImpl.java
@@ -31,7 +31,7 @@ import static com.typedb.driver.jni.typedb_driver.databases_all;
 import static com.typedb.driver.jni.typedb_driver.databases_contains;
 import static com.typedb.driver.jni.typedb_driver.databases_create;
 import static com.typedb.driver.jni.typedb_driver.databases_get;
-import static com.typedb.driver.jni.typedb_driver.databases_import_file;
+import static com.typedb.driver.jni.typedb_driver.databases_import_from_file;
 import static java.util.stream.Collectors.toList;
 
 public class DatabaseManagerImpl implements DatabaseManager {
@@ -72,12 +72,12 @@ public class DatabaseManagerImpl implements DatabaseManager {
     }
 
     @Override
-    public void importFile(String name, String schema, String dataFilePath) throws TypeDBDriverException {
+    public void importFromFile(String name, String schema, String dataFilePath) throws TypeDBDriverException {
         Validator.requireNonNull(name, "name");
         Validator.requireNonNull(schema, "schema");
         Validator.requireNonNull(dataFilePath, "dataFilePath");
         try {
-            databases_import_file(nativeDriver, name, schema, dataFilePath);
+            databases_import_from_file(nativeDriver, name, schema, dataFilePath);
         } catch (com.typedb.driver.jni.Error e) {
             throw new TypeDBDriverException(e);
         }

--- a/java/test/behaviour/config/Parameters.java
+++ b/java/test/behaviour/config/Parameters.java
@@ -153,6 +153,16 @@ public class Parameters {
         return null;
     }
 
+    @ParameterType("exists|does not exist")
+    public ExistsOrDoesnt exists_or_doesnt(String value) {
+        if (value.equals("exists")) {
+            return ExistsOrDoesnt.DOES;
+        } else if (value.equals("does not exist")) {
+            return ExistsOrDoesnt.DOES_NOT;
+        }
+        return null;
+    }
+
     @ParameterType("| by index of variable")
     public IsByVarIndex by_index_of_var(String value) {
         if (value.equals(" by index of variable")) {
@@ -318,6 +328,25 @@ public class Parameters {
         private final boolean does;
 
         ContainsOrDoesnt(boolean is) {
+            this.does = is;
+        }
+
+        public boolean toBoolean() {
+            return does;
+        }
+
+        public void check(boolean toCheck) {
+            assertEquals(does, toCheck);
+        }
+    }
+
+    public enum ExistsOrDoesnt {
+        DOES(true),
+        DOES_NOT(false);
+
+        private final boolean does;
+
+        ExistsOrDoesnt(boolean is) {
             this.does = is;
         }
 

--- a/java/test/behaviour/connection/BUILD
+++ b/java/test/behaviour/connection/BUILD
@@ -26,7 +26,9 @@ java_library(
         # Package dependencies
         "//java:driver-java",
         "//java/api",
+        "//java/common",
         "//java/test/behaviour/config:parameters",
+        "//java/test/behaviour/util:util",
 
         # External dependencies from Maven
         "@maven//:junit_junit",

--- a/java/test/behaviour/connection/ConnectionStepsBase.java
+++ b/java/test/behaviour/connection/ConnectionStepsBase.java
@@ -25,7 +25,6 @@ import com.typedb.driver.api.DriverOptions;
 import com.typedb.driver.api.QueryOptions;
 import com.typedb.driver.api.Transaction;
 import com.typedb.driver.api.TransactionOptions;
-import com.typedb.driver.common.exception.TypeDBDriverException;
 import com.typedb.driver.test.behaviour.config.Parameters;
 import com.typedb.driver.test.behaviour.util.Util;
 
@@ -41,7 +40,6 @@ import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 import static com.typedb.driver.test.behaviour.util.Util.createTempDir;
-import static com.typedb.driver.test.behaviour.util.Util.deleteDir;
 import static org.junit.Assert.assertEquals;
 
 public abstract class ConnectionStepsBase {

--- a/java/test/behaviour/connection/database/BUILD
+++ b/java/test/behaviour/connection/database/BUILD
@@ -32,6 +32,7 @@ java_library(
         "//java/common:common",
         "//java/test/behaviour/config:parameters",
         "//java/test/behaviour/connection:steps-base",
+        "//java/test/behaviour/util:util",
 
         # External Maven Dependencies
         "@maven//:junit_junit",

--- a/java/test/behaviour/connection/database/DatabaseSteps.java
+++ b/java/test/behaviour/connection/database/DatabaseSteps.java
@@ -73,7 +73,7 @@ public class DatabaseSteps {
 
     public void importDatabase(String name, String schema, String dataFile, Parameters.MayError mayError) {
         Path dataPath = fullPath(dataFile);
-        mayError.check(() -> driver.databases().importFile(name, schema, dataPath.toString()));
+        mayError.check(() -> driver.databases().importFromFile(name, schema, dataPath.toString()));
     }
 
     @When("connection create database: {non_semicolon}{may_error}")
@@ -212,6 +212,6 @@ public class DatabaseSteps {
     public void connection_get_database_export_to_schema_file_data_file(String name, String schemaFile, String dataFile, Parameters.MayError mayError) {
         Path schemaPath = fullPath(schemaFile);
         Path dataPath = fullPath(dataFile);
-        mayError.check(() -> driver.databases().get(name).exportFile(schemaPath.toString(), dataPath.toString()));
+        mayError.check(() -> driver.databases().get(name).exportToFile(schemaPath.toString(), dataPath.toString()));
     }
 }

--- a/java/test/behaviour/connection/database/DatabaseSteps.java
+++ b/java/test/behaviour/connection/database/DatabaseSteps.java
@@ -33,7 +33,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static com.typedb.driver.common.collection.Collections.list;
-import static com.typedb.driver.common.collection.Collections.set;
 import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.THREAD_POOL_SIZE;
 import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.backgroundDriver;
 import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.driver;

--- a/java/test/behaviour/driver/concept/BUILD
+++ b/java/test/behaviour/driver/concept/BUILD
@@ -15,37 +15,37 @@
 # specific language governing permissions and limitations
 # under the License.
 
-package(default_visibility = ["//java/test/behaviour:__subpackages__"])
-
+package(default_visibility = ["//visibility:__subpackages__"])
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("//java/test/behaviour:rules.bzl", "typedb_behaviour_java_test")
 
-java_library(
-    name = "util",
-    srcs = ["Util.java"],
-    visibility = ["//visibility:public"],
-    deps = [
-        # Package dependencies
-        "//java/api",
-        "//java/common",
-
-        # External Maven Dependencies
-        "@maven//:junit_junit",
+typedb_behaviour_java_test(
+    name = "test",
+    srcs = [
+        "ConceptTest.java",
     ],
-)
-
-java_library(
-    name = "steps",
-    srcs = ["UtilSteps.java"],
+    test_class = "com.typedb.driver.test.behaviour.driver.concept.ConceptTest",
+    data = [
+        "@typedb_behaviour//driver:concept.feature",
+    ],
+    connection_steps_community = "//java/test/behaviour/connection:steps-community",
+    connection_steps_cluster = "//java/test/behaviour/connection:steps-cluster",
+    steps = [
+        "//java/test/behaviour/query:steps",
+        "//java/test/behaviour/util:steps",
+    ],
     deps = [
-        # Package dependencies
-        "//java/test/behaviour/connection:steps-base",
+        # Internal Package Dependencies
+        "//java/test/behaviour:behaviour",
+
+        # External dependencies from Maven
+        "@maven//:io_cucumber_cucumber_junit",
+    ],
+    runtime_deps = [
         "//java/test/behaviour/config:parameters",
-        ":util",
-
-        # External Maven Dependencies
-        "@maven//:io_cucumber_cucumber_java",
-        "@maven//:junit_junit",
     ],
+    size = "enormous",
+    visibility = ["//visibility:public"],
 )
 
 checkstyle_test(

--- a/java/test/behaviour/driver/concept/ConceptTest.java
+++ b/java/test/behaviour/driver/concept/ConceptTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.typedb.driver.test.behaviour.driver.concept;
+
+import com.typedb.driver.test.behaviour.BehaviourTest;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "com.typedb.driver.test.behaviour",
+        features = "external/typedb_behaviour/driver/concept.feature",
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
+)
+public class ConceptTest extends BehaviourTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test DefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-community' to test against typedb (TypeDB Community Edition)
+    //    b) Use '//<this>/<package>/<name>:test-cluster' to test against typedb-cluster (TypeDB Cloud / Enterprise)
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=com.typedb.driver.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run TypeDB)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/java/test/behaviour/driver/connection/BUILD
+++ b/java/test/behaviour/driver/connection/BUILD
@@ -22,11 +22,11 @@ load("//java/test/behaviour:rules.bzl", "typedb_behaviour_java_test")
 typedb_behaviour_java_test(
     name = "test",
     srcs = [
-        "DriverTest.java",
+        "ConnectionTest.java",
     ],
-    test_class = "com.typedb.driver.test.behaviour.driver.driver.DriverTest",
+    test_class = "com.typedb.driver.test.behaviour.driver.connection.ConnectionTest",
     data = [
-        "@typedb_behaviour//driver:driver.feature",
+        "@typedb_behaviour//driver:connection.feature",
     ],
     connection_steps_community = "//java/test/behaviour/connection:steps-community",
     connection_steps_cluster = "//java/test/behaviour/connection:steps-cluster",

--- a/java/test/behaviour/driver/connection/ConnectionTest.java
+++ b/java/test/behaviour/driver/connection/ConnectionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.typedb.driver.test.behaviour.driver.connection;
+
+import com.typedb.driver.test.behaviour.BehaviourTest;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "com.typedb.driver.test.behaviour",
+        features = "external/typedb_behaviour/driver/connection.feature",
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
+)
+public class ConnectionTest extends BehaviourTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test DefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-community' to test against typedb (TypeDB Community Edition)
+    //    b) Use '//<this>/<package>/<name>:test-cluster' to test against typedb-cluster (TypeDB Cloud / Enterprise)
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=com.typedb.driver.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run TypeDB)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/java/test/behaviour/driver/migration/BUILD
+++ b/java/test/behaviour/driver/migration/BUILD
@@ -15,37 +15,37 @@
 # specific language governing permissions and limitations
 # under the License.
 
-package(default_visibility = ["//java/test/behaviour:__subpackages__"])
-
+package(default_visibility = ["//visibility:__subpackages__"])
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("//java/test/behaviour:rules.bzl", "typedb_behaviour_java_test")
 
-java_library(
-    name = "util",
-    srcs = ["Util.java"],
-    visibility = ["//visibility:public"],
-    deps = [
-        # Package dependencies
-        "//java/api",
-        "//java/common",
-
-        # External Maven Dependencies
-        "@maven//:junit_junit",
+typedb_behaviour_java_test(
+    name = "test",
+    srcs = [
+        "MigrationTest.java",
     ],
-)
-
-java_library(
-    name = "steps",
-    srcs = ["UtilSteps.java"],
+    test_class = "com.typedb.driver.test.behaviour.driver.migration.MigrationTest",
+    data = [
+        "@typedb_behaviour//driver:migration.feature",
+    ],
+    connection_steps_community = "//java/test/behaviour/connection:steps-community",
+    connection_steps_cluster = "//java/test/behaviour/connection:steps-cluster",
+    steps = [
+        "//java/test/behaviour/query:steps",
+        "//java/test/behaviour/util:steps",
+    ],
     deps = [
-        # Package dependencies
-        "//java/test/behaviour/connection:steps-base",
+        # Internal Package Dependencies
+        "//java/test/behaviour:behaviour",
+
+        # External dependencies from Maven
+        "@maven//:io_cucumber_cucumber_junit",
+    ],
+    runtime_deps = [
         "//java/test/behaviour/config:parameters",
-        ":util",
-
-        # External Maven Dependencies
-        "@maven//:io_cucumber_cucumber_java",
-        "@maven//:junit_junit",
     ],
+    size = "enormous",
+    visibility = ["//visibility:public"],
 )
 
 checkstyle_test(

--- a/java/test/behaviour/driver/migration/MigrationTest.java
+++ b/java/test/behaviour/driver/migration/MigrationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.typedb.driver.test.behaviour.driver.migration;
+
+import com.typedb.driver.test.behaviour.BehaviourTest;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "com.typedb.driver.test.behaviour",
+        features = "external/typedb_behaviour/driver/migration.feature",
+        tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
+)
+public class MigrationTest extends BehaviourTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test DefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-community' to test against typedb (TypeDB Community Edition)
+    //    b) Use '//<this>/<package>/<name>:test-cluster' to test against typedb-cluster (TypeDB Cloud / Enterprise)
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=com.typedb.driver.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run TypeDB)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/java/test/behaviour/driver/query/BUILD
+++ b/java/test/behaviour/driver/query/BUILD
@@ -15,37 +15,38 @@
 # specific language governing permissions and limitations
 # under the License.
 
-package(default_visibility = ["//java/test/behaviour:__subpackages__"])
+package(default_visibility = ["//java/test/behaviour/query/language:__subpackages__"])
 
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("//java/test/behaviour:rules.bzl", "typedb_behaviour_java_test")
 
-java_library(
-    name = "util",
-    srcs = ["Util.java"],
-    visibility = ["//visibility:public"],
-    deps = [
-        # Package dependencies
-        "//java/api",
-        "//java/common",
-
-        # External Maven Dependencies
-        "@maven//:junit_junit",
+typedb_behaviour_java_test(
+    name = "test",
+    srcs = [
+        "QueryTest.java",
     ],
-)
-
-java_library(
-    name = "steps",
-    srcs = ["UtilSteps.java"],
+    test_class = "com.typedb.driver.test.behaviour.driver.query.QueryTest",
+    data = [
+        "@typedb_behaviour//driver:query.feature",
+    ],
+    connection_steps_community = "//java/test/behaviour/connection:steps-community",
+    connection_steps_cluster = "//java/test/behaviour/connection:steps-cluster",
+    steps = [
+        "//java/test/behaviour/query:steps",
+        "//java/test/behaviour/util:steps",
+    ],
     deps = [
-        # Package dependencies
-        "//java/test/behaviour/connection:steps-base",
+        # Internal Package Dependencies
+        "//java/test/behaviour:behaviour",
+
+        # External dependencies from Maven
+        "@maven//:io_cucumber_cucumber_junit",
+    ],
+    runtime_deps = [
         "//java/test/behaviour/config:parameters",
-        ":util",
-
-        # External Maven Dependencies
-        "@maven//:io_cucumber_cucumber_java",
-        "@maven//:junit_junit",
     ],
+    size = "enormous",
+    visibility = ["//visibility:public"],
 )
 
 checkstyle_test(

--- a/java/test/behaviour/driver/query/QueryTest.java
+++ b/java/test/behaviour/driver/query/QueryTest.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package com.typedb.driver.test.behaviour.driver.driver;
+package com.typedb.driver.test.behaviour.driver.query;
 
 import com.typedb.driver.test.behaviour.BehaviourTest;
 import io.cucumber.junit.Cucumber;
@@ -29,10 +29,10 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "com.typedb.driver.test.behaviour",
-        features = "external/typedb_behaviour/driver/driver.feature",
+        features = "external/typedb_behaviour/driver/query.feature",
         tags = "not @ignore and not @ignore-typedb-driver and not @ignore-typedb-driver-java"
 )
-public class DriverTest extends BehaviourTest {
+public class QueryTest extends BehaviourTest {
     // ATTENTION:
     // When you click RUN from within this class through Intellij IDE, it will fail.
     // You can fix it by doing:

--- a/java/test/behaviour/util/Util.java
+++ b/java/test/behaviour/util/Util.java
@@ -138,7 +138,7 @@ public class Util {
         }
     }
 
-    public static boolean isEmpty(Path path) {
+    public static boolean isFileEmpty(Path path) {
         try {
             return Files.size(path) == 0;
         } catch (IOException e) {
@@ -146,7 +146,7 @@ public class Util {
         }
     }
 
-    // Otherwise, function bodies are passed with an excessive tabulation from docstrings...
+    // Can be useful for docstrings read with excessive tabulation compared to other languages
     public static String removeTwoSpacesInTabulation(String input) {
         return input.lines()
                 .map(line -> line.startsWith("  ") ? line.substring(2) : line)

--- a/java/test/behaviour/util/Util.java
+++ b/java/test/behaviour/util/Util.java
@@ -21,10 +21,16 @@ package com.typedb.driver.test.behaviour.util;
 
 import com.typedb.driver.api.answer.JSON;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import static com.typedb.driver.common.util.Double.equalsApproximate;
 import static org.junit.Assert.assertTrue;
@@ -89,5 +95,62 @@ public class Util {
         } else {
             return lhs.equals(rhs);
         }
+    }
+
+    public static Path createTempDir() {
+        try {
+            return Files.createTempDirectory("temp-" + UUID.randomUUID());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create temp directory", e);
+        }
+    }
+
+    public static void deleteDir(Path dir) {
+        if (!Files.exists(dir)) return;
+
+        try (var paths = Files.walk(dir)) {
+            paths.sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException("Failed to delete: " + path, e);
+                        }
+                    });
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to delete directory: " + dir, e);
+        }
+    }
+
+    public static void writeFile(Path path, String content) {
+        try {
+            Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write to file: " + path, e);
+        }
+    }
+
+    public static String readFileToString(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read file: " + path, e);
+        }
+    }
+
+    public static boolean isEmpty(Path path) {
+        try {
+            return Files.size(path) == 0;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to check file size: " + path, e);
+        }
+    }
+
+    // Otherwise, function bodies are passed with an excessive tabulation from docstrings...
+    public static String removeTwoSpacesInTabulation(String input) {
+        return input.lines()
+                .map(line -> line.startsWith("  ") ? line.substring(2) : line)
+                .reduce((a, b) -> a + "\n" + b)
+                .orElse("");
     }
 }

--- a/java/test/behaviour/util/UtilSteps.java
+++ b/java/test/behaviour/util/UtilSteps.java
@@ -27,12 +27,8 @@ import java.nio.file.Files;
 import java.util.TimeZone;
 
 import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.fullPath;
-import static com.typedb.driver.test.behaviour.util.Util.isEmpty;
-import static com.typedb.driver.test.behaviour.util.Util.readFileToString;
+import static com.typedb.driver.test.behaviour.util.Util.isFileEmpty;
 import static com.typedb.driver.test.behaviour.util.Util.writeFile;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class UtilSteps {
 
@@ -53,7 +49,7 @@ public class UtilSteps {
 
     @Then("file\\({word}) {is_or_not} empty")
     public void file_is_empty(String name, Parameters.IsOrNot isOrNot) {
-        isOrNot.check(isEmpty(fullPath(name)));
+        isOrNot.check(isFileEmpty(fullPath(name)));
     }
 
     @When("file\\({word}) write:")

--- a/java/test/behaviour/util/UtilSteps.java
+++ b/java/test/behaviour/util/UtilSteps.java
@@ -19,10 +19,20 @@
 
 package com.typedb.driver.test.behaviour.util;
 
+import com.typedb.driver.test.behaviour.config.Parameters;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
+import java.nio.file.Files;
 import java.util.TimeZone;
+
+import static com.typedb.driver.test.behaviour.connection.ConnectionStepsBase.fullPath;
+import static com.typedb.driver.test.behaviour.util.Util.isEmpty;
+import static com.typedb.driver.test.behaviour.util.Util.readFileToString;
+import static com.typedb.driver.test.behaviour.util.Util.writeFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class UtilSteps {
 
@@ -34,5 +44,20 @@ public class UtilSteps {
     @Then("wait {integer} seconds")
     public void wait_seconds(int seconds) throws InterruptedException {
         Thread.sleep(seconds * 1000L);
+    }
+
+    @Then("file\\({word}) {exists_or_doesnt}")
+    public void file_exists(String name, Parameters.ExistsOrDoesnt existsOrDoesnt) {
+        existsOrDoesnt.check(Files.exists(fullPath(name)));
+    }
+
+    @Then("file\\({word}) {is_or_not} empty")
+    public void file_is_empty(String name, Parameters.IsOrNot isOrNot) {
+        isOrNot.check(isEmpty(fullPath(name)));
+    }
+
+    @When("file\\({word}) write:")
+    public void file_write(String name, String text) {
+        writeFile(fullPath(name), text.strip());
     }
 }

--- a/python/tests/behaviour/background/environment_base.py
+++ b/python/tests/behaviour/background/environment_base.py
@@ -15,19 +15,25 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import tempfile
+import uuid
+from pathlib import Path
+
 from behave.model_core import Status
 from tests.behaviour.context import Context
+from tests.behaviour.util.util import delete_dir
 from typedb.driver import *
 
 
 def before_all(context: Context):
     context.THREAD_POOL_SIZE = 32
-    context.init_transaction_options_if_needed_fn = lambda: init_transaction_options_if_needed(context)
-    context.init_query_options_if_needed_fn = lambda: init_query_options_if_needed(context)
+    context.init_transaction_options_if_needed_fn = lambda: _init_transaction_options_if_needed(context)
+    context.init_query_options_if_needed_fn = lambda: _init_query_options_if_needed(context)
 
 
 def before_scenario(context: Context):
     # setup context state
+    context.temp_dir = None
     context.background_driver = None
     context.transactions = []
     context.transactions_parallel = []
@@ -38,42 +44,56 @@ def before_scenario(context: Context):
     context.concurrent_answers = None
     context.unwrapped_concurrent_answers = None
     # setup context functions
+    context.full_path = lambda file_name: _full_path(context, file_name)
     context.tx = lambda: next(iter(context.transactions), None)
-    context.clear_answers = lambda: _clear_answers_impl(context)
-    context.clear_concurrent_answers = lambda: _clear_concurrent_answers_impl(context)
+    context.clear_answers = lambda: _clear_answers(context)
+    context.clear_concurrent_answers = lambda: _clear_concurrent_answers(context)
     context.transaction_options = None
     context.query_options = None
-
-
-def _clear_answers_impl(context: Context):
-    context.answers = None
-    context.unwrapped_answer = None
-    context.collected_answer = None
-
-
-def _clear_concurrent_answers_impl(context: Context):
-    context.concurrent_answers = None
-    context.unwrapped_concurrent_answers = None
 
 
 def after_scenario(context: Context, scenario):
     if scenario.status == Status.skipped:
         return
+    if context.temp_dir:
+        delete_dir(context.temp_dir)
     if context.driver.is_open():
         context.driver.close()
     if context.background_driver and context.background_driver.is_open():
         context.background_driver.close()
 
 
-def init_transaction_options_if_needed(context: Context):
+def after_all(_: Context):
+    pass
+
+
+def _clear_answers(context: Context):
+    context.answers = None
+    context.unwrapped_answer = None
+    context.collected_answer = None
+
+
+def _clear_concurrent_answers(context: Context):
+    context.concurrent_answers = None
+    context.unwrapped_concurrent_answers = None
+
+
+def _full_path(context: Context, file_name: str) -> Path:
+    return _get_temp_dir(context) / file_name
+
+
+def _init_transaction_options_if_needed(context: Context):
     if not context.transaction_options:
         context.transaction_options = TransactionOptions()
 
 
-def init_query_options_if_needed(context: Context):
+def _init_query_options_if_needed(context: Context):
     if not context.query_options:
         context.query_options = QueryOptions()
 
 
-def after_all(_: Context):
-    pass
+def _get_temp_dir(context: Context) -> Path:
+    if context.temp_dir is None:
+        context.temp_dir = Path(tempfile.gettempdir()) / f"temp-{uuid.uuid4()}"
+        context.temp_dir.mkdir(parents=True, exist_ok=True)
+    return context.temp_dir

--- a/python/tests/behaviour/config/parameters.py
+++ b/python/tests/behaviour/config/parameters.py
@@ -257,7 +257,7 @@ def parse_may_error(value: str) -> MayError:
     else:
         match = re.match(r'; fails with a message containing: "(?P<message>.*)"', value)
         if match:
-            return MayError(True, match.group("message"))
+            return MayError(True, re.escape(match.group("message")))
         else:
             raise ValueError(f"Unrecognised MayError: {value}")
 
@@ -289,6 +289,19 @@ def parse_contains_or_doesnt(value: str) -> bool:
 
 
 register_type(ContainsOrDoesnt=parse_contains_or_doesnt)
+
+
+@parse.with_pattern("exists|does not exist")
+def parse_exists_or_doesnt(value: str) -> bool:
+    if value == "exists":
+        return True
+    elif value == "does not exist":
+        return False
+    else:
+        raise ValueError(f"Unrecognised ExistsOrDoesnt: {value}")
+
+
+register_type(ExistsOrDoesnt=parse_exists_or_doesnt)
 
 
 def is_or_not_reason(is_or_not: bool, real, expected) -> str:

--- a/python/tests/behaviour/connection/database/database_steps.py
+++ b/python/tests/behaviour/connection/database/database_steps.py
@@ -59,7 +59,7 @@ def create_temporary_database_with_schema(context: Context, schema_query: str) -
 
 
 def import_database(context: Context, name: str, schema: str, data_file: str, may_error: MayError):
-    may_error.check(lambda: context.driver.databases.import_file(name, schema, str(context.full_path(data_file))))
+    may_error.check(lambda: context.driver.databases.import_from_file(name, schema, str(context.full_path(data_file))))
 
 
 @step("connection create database: {name:NonSemicolon}{may_error:MayError}")
@@ -200,6 +200,6 @@ def import_from_data_file_and_schema(context: Context, name: str, data_file: str
 @step(
     "connection get database({name:NonSemicolon}) export to schema file({schema_file:NonSemicolon}), data file({data_file:NonSemicolon}){may_error:MayError}")
 def export_to_schema_file_data_file(context: Context, name: str, schema_file: str, data_file: str, may_error: MayError):
-    may_error.check(lambda: context.driver.databases.get(name).export_file(
+    may_error.check(lambda: context.driver.databases.get(name).export_to_file(
         str(context.full_path(schema_file)), str(context.full_path(data_file))
     ))

--- a/python/tests/behaviour/connection/database/database_steps.py
+++ b/python/tests/behaviour/connection/database/database_steps.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import random
+import uuid
 from concurrent.futures.thread import ThreadPoolExecutor
 from functools import partial
 
@@ -23,7 +23,7 @@ from behave import *
 from hamcrest import *
 from tests.behaviour.config.parameters import MayError, parse_list
 from tests.behaviour.context import Context
-from tests.behaviour.util.util import assert_collections_equal
+from tests.behaviour.util.util import read_file_to_string, remove_two_spaces_in_tabulation
 from typedb.api.connection.transaction import TransactionType
 from typedb.driver import *
 
@@ -36,6 +36,30 @@ def create_databases(driver: Driver, names: list[str]):
 def delete_databases(driver: Driver, names: list[str]):
     for name in names:
         driver.databases.get(name).delete()
+
+
+def has_databases(context: Context, names: list[str]):
+    all_database_names = [db.name for db in context.driver.databases.all()]
+    for name in names:
+        assert_that(all_database_names, has_item(name))
+
+
+def execute_and_retrieve_schema_for_comparison(context: Context, schema_query: str) -> str:
+    temp_database_name = create_temporary_database_with_schema(context, schema_query)
+    return context.driver.databases.get(temp_database_name).schema()
+
+
+def create_temporary_database_with_schema(context: Context, schema_query: str) -> str:
+    name = f"temp-{uuid.uuid4()}"
+    create_databases(context.driver, [name])
+    transaction = context.driver.transaction(name, TransactionType.SCHEMA)
+    transaction.query(schema_query).resolve()
+    transaction.commit()
+    return name
+
+
+def import_database(context: Context, name: str, schema: str, data_file: str, may_error: MayError):
+    may_error.check(lambda: context.driver.databases.import_file(name, schema, str(context.full_path(data_file))))
 
 
 @step("connection create database: {name:NonSemicolon}{may_error:MayError}")
@@ -96,12 +120,7 @@ def step_impl(context: Context, name: str, may_error: MayError):
     background.close()
 
 
-# TODO: Use "contains" instead. Cover "all" interface explicitly
-def has_databases(context: Context, names: list[str]):
-    assert_collections_equal([db.name for db in context.driver.databases.all()], names)
-
-
-@step("connection has database: {name}")
+@step("connection has database: {name:NonSemicolon}")
 def step_impl(context: Context, name: str):
     has_databases(context, [name])
 
@@ -117,7 +136,7 @@ def does_not_have_databases(context: Context, names: list[str]):
         assert_that(name, not_(is_in(databases)))
 
 
-@step("connection does not have database: {name}")
+@step("connection does not have database: {name:NonSemicolon}")
 def step_impl(context: Context, name: str):
     does_not_have_databases(context, [name])
 
@@ -127,28 +146,18 @@ def step_impl(context: Context):
     does_not_have_databases(context, names=parse_list(context))
 
 
-def create_temporary_database_with_schema(context: Context, schema_query: str) -> str:
-    name = "temp-" + str(random.randint(0, 100000))
-    create_databases(context.driver, [name])
-    transaction = context.driver.transaction(name, TransactionType.SCHEMA)
-    transaction.query(schema_query).resolve()
-    transaction.commit()
-    return name
-
-
-@step("connection get database({name}) has schema")
+@step("connection get database({name:NonSemicolon}) has schema")
 def step_impl(context: Context, name: str):
     expected_schema = context.text.strip()
     if expected_schema:
-        temp_database_name = create_temporary_database_with_schema(context, expected_schema)
-        expected_schema_retrieved = context.driver.databases.get(temp_database_name).schema()
+        expected_schema_retrieved = execute_and_retrieve_schema_for_comparison(context, expected_schema)
     else:
         expected_schema_retrieved = ""
     real_schema = context.driver.databases.get(name).schema()
     assert_that(real_schema, is_(expected_schema_retrieved))
 
 
-@step("connection get database({name}) has type schema")
+@step("connection get database({name:NonSemicolon}) has type schema")
 def step_impl(context: Context, name: str):
     expected_type_schema = context.text.strip()
     if expected_type_schema:
@@ -158,3 +167,39 @@ def step_impl(context: Context, name: str):
         expected_type_schema_retrieved = ""
     real_type_schema = context.driver.databases.get(name).type_schema()
     assert_that(real_type_schema, is_(expected_type_schema_retrieved))
+
+
+@step("file({file_name:NonSemicolon}) has schema")
+def file_has_schema(context: Context, file_name: str):
+    file_schema = read_file_to_string(context.full_path(file_name))
+    expected_schema = context.text.strip()
+    if expected_schema:
+        expected_schema_retrieved = execute_and_retrieve_schema_for_comparison(context, remove_two_spaces_in_tabulation(
+            expected_schema))
+    else:
+        expected_schema_retrieved = ""
+    file_schema_retrieved = execute_and_retrieve_schema_for_comparison(context, file_schema)
+    assert_that(file_schema_retrieved, is_(expected_schema_retrieved))
+
+
+@step(
+    "connection import database({name:NonSemicolon}) from schema file({schema_file:NonSemicolon}), data file({data_file:NonSemicolon}){may_error:MayError}")
+def import_from_schema_file_data_file(context: Context, name: str, schema_file: str, data_file: str,
+                                      may_error: MayError):
+    schema = read_file_to_string(context.full_path(schema_file))
+    import_database(context, name, schema, data_file, may_error)
+
+
+@step(
+    "connection import database({name:NonSemicolon}) from data file({data_file:NonSemicolon}) and schema{may_error:MayError}")
+def import_from_data_file_and_schema(context: Context, name: str, data_file: str, may_error: MayError):
+    schema = remove_two_spaces_in_tabulation(context.text.strip())
+    import_database(context, name, schema, data_file, may_error)
+
+
+@step(
+    "connection get database({name:NonSemicolon}) export to schema file({schema_file:NonSemicolon}), data file({data_file:NonSemicolon}){may_error:MayError}")
+def export_to_schema_file_data_file(context: Context, name: str, schema_file: str, data_file: str, may_error: MayError):
+    may_error.check(lambda: context.driver.databases.get(name).export_file(
+        str(context.full_path(schema_file)), str(context.full_path(data_file))
+    ))

--- a/python/tests/behaviour/driver/concept/BUILD
+++ b/python/tests/behaviour/driver/concept/BUILD
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+package(default_visibility = ["//python/tests/behaviour:__subpackages__"])
+load("//python/tests/behaviour:behave_rule.bzl", "typedb_behaviour_py_test")
+load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+typedb_behaviour_py_test(
+    name = "test",
+    feats = ["@typedb_behaviour//driver:concept.feature"],
+    steps = [
+        "//python/tests/behaviour/connection:steps",
+        "//python/tests/behaviour/connection/database:steps",
+        "//python/tests/behaviour/connection/transaction:steps",
+        "//python/tests/behaviour/query:steps",
+        "//python/tests/behaviour/util:steps",
+    ],
+    deps = [
+        "//python:driver_python",
+        "//python/tests/behaviour:context",
+        "//python/tests/behaviour/util:util",
+        "//python/tests/behaviour/config:parameters",
+        "//python/tests/behaviour/background",
+    ],
+    data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
+    size = "medium",
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "apache-header",
+    size = "small",
+)

--- a/python/tests/behaviour/driver/connection/BUILD
+++ b/python/tests/behaviour/driver/connection/BUILD
@@ -21,7 +21,7 @@ load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 typedb_behaviour_py_test(
     name = "test",
-    feats = ["@typedb_behaviour//driver:driver.feature"],
+    feats = ["@typedb_behaviour//driver:connection.feature"],
     steps = [
         "//python/tests/behaviour/connection:steps",
         "//python/tests/behaviour/connection/database:steps",

--- a/python/tests/behaviour/driver/migration/BUILD
+++ b/python/tests/behaviour/driver/migration/BUILD
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+package(default_visibility = ["//python/tests/behaviour:__subpackages__"])
+load("//python/tests/behaviour:behave_rule.bzl", "typedb_behaviour_py_test")
+load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+typedb_behaviour_py_test(
+    name = "test",
+    feats = ["@typedb_behaviour//driver:migration.feature"],
+    steps = [
+        "//python/tests/behaviour/connection:steps",
+        "//python/tests/behaviour/connection/database:steps",
+        "//python/tests/behaviour/connection/transaction:steps",
+        "//python/tests/behaviour/query:steps",
+        "//python/tests/behaviour/util:steps",
+    ],
+    deps = [
+        "//python:driver_python",
+        "//python/tests/behaviour:context",
+        "//python/tests/behaviour/util:util",
+        "//python/tests/behaviour/config:parameters",
+        "//python/tests/behaviour/background",
+    ],
+    data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
+    size = "medium",
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "apache-header",
+    size = "small",
+)

--- a/python/tests/behaviour/driver/query/BUILD
+++ b/python/tests/behaviour/driver/query/BUILD
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+package(default_visibility = ["//python/tests/behaviour:__subpackages__"])
+load("//python/tests/behaviour:behave_rule.bzl", "typedb_behaviour_py_test")
+load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+typedb_behaviour_py_test(
+    name = "test",
+    feats = ["@typedb_behaviour//driver:query.feature"],
+    steps = [
+        "//python/tests/behaviour/connection:steps",
+        "//python/tests/behaviour/connection/database:steps",
+        "//python/tests/behaviour/connection/transaction:steps",
+        "//python/tests/behaviour/query:steps",
+        "//python/tests/behaviour/util:steps",
+    ],
+    deps = [
+        "//python:driver_python",
+        "//python/tests/behaviour:context",
+        "//python/tests/behaviour/util:util",
+        "//python/tests/behaviour/config:parameters",
+        "//python/tests/behaviour/background",
+    ],
+    data = ["//python:native-driver-binary-link", "//python:native-driver-wrapper-link"],
+    size = "medium",
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "apache-header",
+    size = "small",
+)

--- a/python/tests/behaviour/util/util.py
+++ b/python/tests/behaviour/util/util.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import shutil
 from collections import Counter
+from pathlib import Path
 
 from hamcrest import *
 
@@ -54,3 +56,25 @@ def list_contains_json(json_list: list, json: dict) -> bool:
         if json_matches(json_from_list, json):
             return True
     return False
+
+
+def write_file(path: Path, content: str):
+    path.write_text(content, encoding="utf-8")
+
+
+def read_file_to_string(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def is_file_empty(path: Path) -> bool:
+    return path.stat().st_size == 0
+
+
+def delete_dir(path: Path):
+    if path.exists():
+        shutil.rmtree(path)
+
+
+# Can be useful for docstrings read with excessive tabulation compared to other languages
+def remove_two_spaces_in_tabulation(input: str) -> str:
+    return "\n".join(line[2:] if line.startswith("  ") else line for line in input.splitlines())

--- a/python/tests/behaviour/util/util_steps.py
+++ b/python/tests/behaviour/util/util_steps.py
@@ -20,7 +20,9 @@ import time
 from time import sleep
 
 from behave import *
+from hamcrest import *
 from tests.behaviour.context import Context
+from tests.behaviour.util.util import write_file, is_file_empty
 
 
 @step("set time-zone: {time_zone_name}")
@@ -32,3 +34,18 @@ def step_impl(context: Context, time_zone_name: str):
 @step("wait {seconds} seconds")
 def step_impl(context: Context, seconds: str):
     sleep(float(seconds))
+
+
+@step("file({name:NonSemicolon}) {exists_or_doesnt:ExistsOrDoesnt}")
+def file_exists(context, name: str, exists_or_doesnt: bool):
+    assert_that(context.full_path(name).exists(), is_(exists_or_doesnt))
+
+
+@step("file({name:NonSemicolon}) {is_or_not:IsOrNot} empty")
+def file_is_empty(context, name: str, is_or_not: bool):
+    assert_that(is_file_empty(context.full_path(name)), is_(is_or_not))
+
+
+@step("file({name:NonSemicolon}) write")
+def file_write(context, name: str):
+    write_file(context.full_path(name), context.text.strip())

--- a/python/typedb/api/connection/database.py
+++ b/python/typedb/api/connection/database.py
@@ -60,6 +60,23 @@ class Database(ABC):
         """
         pass
 
+    def export_file(self, schema_file_path: str, data_file_path: str) -> None:
+        """
+        Export a database into a schema definition and a data files saved to the disk.
+        This is a blocking operation and may take a significant amount of time depending on the database size.
+
+        :param schema_file_path: The path to the schema definition file to be created
+        :param data_file_path: The path to the data file to be created
+        :return:
+
+        Examples:
+        ---------
+        ::
+
+            database.export_file("schema.typeql", "data.typedb")
+        """
+        pass
+
     @abstractmethod
     def delete(self) -> None:
         """
@@ -204,7 +221,7 @@ class DatabaseManager(ABC):
     @abstractmethod
     def contains(self, name: str) -> bool:
         """
-        Checks if a database with the given name exists
+        Checks if a database with the given name exists.
 
         :param name: The database name to be checked
         :return:
@@ -220,7 +237,7 @@ class DatabaseManager(ABC):
     @abstractmethod
     def create(self, name: str) -> None:
         """
-        Create a database with the given name
+        Create a database with the given name.
 
         :param name: The name of the database to be created
         :return:
@@ -234,9 +251,28 @@ class DatabaseManager(ABC):
         pass
 
     @abstractmethod
+    def import_file(self, name: str, schema: str, data_file_path: str) -> None:
+        """
+        Create a database with the given name based on previously exported another database's data loaded from a file.
+        This is a blocking operation and may take a significant amount of time depending on the database size.
+
+        :param name: The name of the database to be created
+        :param schema: The schema definition query string for the database
+        :param data_file_path: The exported database file path to import the data from
+        :return:
+
+        Examples:
+        ---------
+        ::
+
+            driver.databases.import_file(name, schema, "data.typedb")
+        """
+        pass
+
+    @abstractmethod
     def all(self) -> List[Database]:
         """
-        Retrieves all databases present on the TypeDB server
+        Retrieves all databases present on the TypeDB server.
 
         :return:
 

--- a/python/typedb/api/connection/database.py
+++ b/python/typedb/api/connection/database.py
@@ -60,7 +60,7 @@ class Database(ABC):
         """
         pass
 
-    def export_file(self, schema_file_path: str, data_file_path: str) -> None:
+    def export_to_file(self, schema_file_path: str, data_file_path: str) -> None:
         """
         Export a database into a schema definition and a data files saved to the disk.
         This is a blocking operation and may take a significant amount of time depending on the database size.
@@ -73,7 +73,7 @@ class Database(ABC):
         ---------
         ::
 
-            database.export_file("schema.typeql", "data.typedb")
+            database.export_to_file("schema.typeql", "data.typedb")
         """
         pass
 
@@ -251,7 +251,7 @@ class DatabaseManager(ABC):
         pass
 
     @abstractmethod
-    def import_file(self, name: str, schema: str, data_file_path: str) -> None:
+    def import_from_file(self, name: str, schema: str, data_file_path: str) -> None:
         """
         Create a database with the given name based on previously exported another database's data loaded from a file.
         This is a blocking operation and may take a significant amount of time depending on the database size.
@@ -265,7 +265,7 @@ class DatabaseManager(ABC):
         ---------
         ::
 
-            driver.databases.import_file(name, schema, "data.typedb")
+            driver.databases.import_from_file(name, schema, "data.typedb")
         """
         pass
 

--- a/python/typedb/api/connection/transaction_options.py
+++ b/python/typedb/api/connection/transaction_options.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE, POSITIVE_VALUE_REQUIRED
+from typedb.common.exception import TypeDBDriverException, ILLEGAL_STATE
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.common.validation import require_positive
 from typedb.native_driver_wrapper import transaction_options_new, \

--- a/python/typedb/connection/database.py
+++ b/python/typedb/connection/database.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 from typedb.api.connection.database import Database
 from typedb.common.exception import TypeDBDriverException, DATABASE_DELETED, NULL_NATIVE_OBJECT
 from typedb.common.native_wrapper import NativeWrapper
+from typedb.common.validation import require_non_null
 from typedb.native_driver_wrapper import database_get_name, database_schema, database_delete, database_type_schema, \
-    Database as NativeDatabase, \
+    database_export_file, Database as NativeDatabase, \
     TypeDBDriverExceptionNative
 
 
@@ -52,6 +53,14 @@ class _Database(Database, NativeWrapper[NativeDatabase]):
     def type_schema(self) -> str:
         try:
             return database_type_schema(self.native_object)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e) from None
+
+    def export_file(self, schema_file_path: str, data_file_path: str) -> None:
+        require_non_null(schema_file_path, "schema_file_path")
+        require_non_null(data_file_path, "data_file_path")
+        try:
+            return database_export_file(self.native_object, schema_file_path, data_file_path)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 

--- a/python/typedb/connection/database.py
+++ b/python/typedb/connection/database.py
@@ -22,7 +22,7 @@ from typedb.common.exception import TypeDBDriverException, DATABASE_DELETED, NUL
 from typedb.common.native_wrapper import NativeWrapper
 from typedb.common.validation import require_non_null
 from typedb.native_driver_wrapper import database_get_name, database_schema, database_delete, database_type_schema, \
-    database_export_file, Database as NativeDatabase, \
+    database_export_to_file, Database as NativeDatabase, \
     TypeDBDriverExceptionNative
 
 
@@ -56,11 +56,11 @@ class _Database(Database, NativeWrapper[NativeDatabase]):
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 
-    def export_file(self, schema_file_path: str, data_file_path: str) -> None:
+    def export_to_file(self, schema_file_path: str, data_file_path: str) -> None:
         require_non_null(schema_file_path, "schema_file_path")
         require_non_null(data_file_path, "data_file_path")
         try:
-            return database_export_file(self.native_object, schema_file_path, data_file_path)
+            return database_export_to_file(self.native_object, schema_file_path, data_file_path)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 

--- a/python/typedb/connection/database_manager.py
+++ b/python/typedb/connection/database_manager.py
@@ -24,8 +24,8 @@ from typedb.common.exception import TypeDBDriverException
 from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.validation import require_non_null
 from typedb.connection.database import _Database
-from typedb.native_driver_wrapper import databases_contains, databases_create, databases_get, \
-    databases_all, database_iterator_next, TypeDBDriverExceptionNative
+from typedb.native_driver_wrapper import databases_all, databases_contains, databases_create, databases_get, \
+    databases_import_file, database_iterator_next, TypeDBDriverExceptionNative
 
 if TYPE_CHECKING:
     from typedb.native_driver_wrapper import TypeDBDriver as NativeDriver
@@ -54,6 +54,15 @@ class _DatabaseManager(DatabaseManager):
         require_non_null(name, "name")
         try:
             databases_create(self.native_driver, name)
+        except TypeDBDriverExceptionNative as e:
+            raise TypeDBDriverException.of(e) from None
+
+    def import_file(self, name: str, schema: str, data_file_path: str) -> None:
+        require_non_null(name, "name")
+        require_non_null(schema, "schema")
+        require_non_null(data_file_path, "data_file_path")
+        try:
+            databases_import_file(self.native_driver, name, schema, data_file_path)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 

--- a/python/typedb/connection/database_manager.py
+++ b/python/typedb/connection/database_manager.py
@@ -25,7 +25,7 @@ from typedb.common.iterator_wrapper import IteratorWrapper
 from typedb.common.validation import require_non_null
 from typedb.connection.database import _Database
 from typedb.native_driver_wrapper import databases_all, databases_contains, databases_create, databases_get, \
-    databases_import_file, database_iterator_next, TypeDBDriverExceptionNative
+    databases_import_from_file, database_iterator_next, TypeDBDriverExceptionNative
 
 if TYPE_CHECKING:
     from typedb.native_driver_wrapper import TypeDBDriver as NativeDriver
@@ -57,12 +57,12 @@ class _DatabaseManager(DatabaseManager):
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 
-    def import_file(self, name: str, schema: str, data_file_path: str) -> None:
+    def import_from_file(self, name: str, schema: str, data_file_path: str) -> None:
         require_non_null(name, "name")
         require_non_null(schema, "schema")
         require_non_null(data_file_path, "data_file_path")
         try:
-            databases_import_file(self.native_driver, name, schema, data_file_path)
+            databases_import_from_file(self.native_driver, name, schema, data_file_path)
         except TypeDBDriverExceptionNative as e:
             raise TypeDBDriverException.of(e) from None
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,7 +60,7 @@
 
 	[dependencies.typedb-protocol]
 		features = []
-		rev = "9ef738d2e0f5d9ebb57d1281a66b38267c430c15"
+		rev = "7ec14787622df5809b3ef86138eb331762a34083"
 		git = "https://github.com/typedb/typedb-protocol"
 		default-features = false
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,7 +60,7 @@
 
 	[dependencies.typedb-protocol]
 		features = []
-		rev = "7ec14787622df5809b3ef86138eb331762a34083"
+		rev = "4520ca7f461cfca8f007403fdd09bdb9a66ed428"
 		git = "https://github.com/typedb/typedb-protocol"
 		default-features = false
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,8 +60,8 @@
 
 	[dependencies.typedb-protocol]
 		features = []
+		rev = "9ef738d2e0f5d9ebb57d1281a66b38267c430c15"
 		git = "https://github.com/typedb/typedb-protocol"
-		tag = "3.2.0"
 		default-features = false
 
 	[dependencies.log]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,7 +60,7 @@
 
 	[dependencies.typedb-protocol]
 		features = []
-		rev = "4520ca7f461cfca8f007403fdd09bdb9a66ed428"
+		rev = "8c9dae847b4d816d02727541bd9db9828b038ad9"
 		git = "https://github.com/typedb/typedb-protocol"
 		default-features = false
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,12 +55,12 @@
 
 	[dependencies.tokio]
 		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.44.2"
+		version = "1.45.0"
 		default-features = false
 
 	[dependencies.typedb-protocol]
 		features = []
-		rev = "1480387a62e48b64b34d5d8626211c3d139e0465"
+		rev = "59ad51a9e9dcde8e5ac47015be7956f9b2b27fef"
 		git = "https://github.com/typedb/typedb-protocol"
 		default-features = false
 
@@ -121,7 +121,7 @@
 
 	[dependencies.chrono]
 		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.40"
+		version = "0.4.41"
 		default-features = false
 
 	[dependencies.crossbeam]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,7 +60,7 @@
 
 	[dependencies.typedb-protocol]
 		features = []
-		rev = "8c9dae847b4d816d02727541bd9db9828b038ad9"
+		rev = "1480387a62e48b64b34d5d8626211c3d139e0465"
 		git = "https://github.com/typedb/typedb-protocol"
 		default-features = false
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -60,7 +60,7 @@
 
 	[dependencies.typedb-protocol]
 		features = []
-		rev = "59ad51a9e9dcde8e5ac47015be7956f9b2b27fef"
+		rev = "f6528beec33d6e3c31cb5dafc30e8f0f097c3f82"
 		git = "https://github.com/typedb/typedb-protocol"
 		default-features = false
 
@@ -142,10 +142,22 @@
 	name = "test_transaction"
 
 [[test]]
-	path = "tests/behaviour/driver/driver.rs"
-	name = "test_driver"
+	path = "tests/behaviour/driver/connection.rs"
+	name = "test_connection"
+
+[[test]]
+	path = "tests/behaviour/driver/query.rs"
+	name = "test_query"
+
+[[test]]
+	path = "tests/behaviour/driver/concept.rs"
+	name = "test_concept"
 
 [[test]]
 	path = "tests/behaviour/driver/user.rs"
 	name = "test_user"
+
+[[test]]
+	path = "tests/behaviour/driver/migration.rs"
+	name = "test_migration"
 

--- a/rust/docs_structure.bzl
+++ b/rust/docs_structure.bzl
@@ -48,6 +48,7 @@ dir_mapping = {
     "ConceptError.adoc": "errors",
     "ConnectionError.adoc": "errors",
     "InternalError.adoc": "errors",
+    "MigrationError.adoc": "errors",
     "ServerError.adoc": "errors",
     "DurationParseError.adoc": "errors",
     "RelationType.adoc": "schema",

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -184,6 +184,10 @@ error_messages! { ConceptError
         1: "Cannot get concept from a concept row by variable '{variable}'.",
     UnavailableRowIndex { index: usize } =
         2: "Cannot get concept from a concept row by index '{index}'.",
+    CannotDecodeImportedConcept =
+        3: "Cannot decode a concept from the provided import file. Make sure to pass a correct database file produced by a TypeDB export operation.",
+    CannotEncodeExportedConcept =
+        4: "Cannot encode a concept for export. It's either a version compatibility error or a bug."
 }
 
 error_messages! { InternalError

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -176,6 +176,12 @@ error_messages! { ConnectionError
         28: "Unexpected kind in message received from server: {kind}. This is either a version compatibility issue or a bug.",
     UnexpectedConnectionClose =
         29: "Connection closed unexpectedly.",
+    DatabaseImportChannelIsClosed =
+        30: "The database import channel is closed and no further operation is allowed.",
+    DatabaseExportChannelIsClosed =
+        31: "The database export channel is closed and no further operation is allowed.",
+    DatabaseExportStreamNoResponse =
+        32: "Didn't receive any server responses for the database export command.",
 }
 
 error_messages! { ConceptError
@@ -184,6 +190,14 @@ error_messages! { ConceptError
         1: "Cannot get concept from a concept row by variable '{variable}'.",
     UnavailableRowIndex { index: usize } =
         2: "Cannot get concept from a concept row by index '{index}'.",
+}
+
+error_messages! { MigrationError
+    code: "MGT", type: "Migration Error",
+    CannotOpenImportFile { path: String, reason: String } =
+        1: "Cannot open import file '{path}': {reason}",
+    CannotCreateExportFile { path: String, reason: String } =
+        2: "Cannot create export file '{path}': {reason}",
     CannotDecodeImportedConcept =
         3: "Cannot decode a concept from the provided import file. Make sure to pass a correct database file produced by a TypeDB export operation.",
     CannotEncodeExportedConcept =
@@ -253,6 +267,7 @@ impl fmt::Debug for ServerError {
 pub enum Error {
     Connection(ConnectionError),
     Concept(ConceptError),
+    Migration(MigrationError),
     Internal(InternalError),
     Server(ServerError),
     Other(String),
@@ -263,6 +278,7 @@ impl Error {
         match self {
             Self::Connection(error) => error.format_code(),
             Self::Concept(error) => error.format_code(),
+            Self::Migration(error) => error.format_code(),
             Self::Internal(error) => error.format_code(),
             Self::Server(error) => error.format_code().to_owned(),
             Self::Other(_error) => String::new(),
@@ -273,6 +289,7 @@ impl Error {
         match self {
             Self::Connection(error) => error.message(),
             Self::Concept(error) => error.message(),
+            Self::Migration(error) => error.message(),
             Self::Internal(error) => error.message(),
             Self::Server(error) => error.message(),
             Self::Other(error) => error.clone(),
@@ -314,6 +331,7 @@ impl fmt::Display for Error {
         match self {
             Self::Connection(error) => write!(f, "{error}"),
             Self::Concept(error) => write!(f, "{error}"),
+            Self::Migration(error) => write!(f, "{error}"),
             Self::Internal(error) => write!(f, "{error}"),
             Self::Server(error) => write!(f, "{error}"),
             Self::Other(message) => write!(f, "{message}"),
@@ -326,6 +344,7 @@ impl StdError for Error {
         match self {
             Self::Connection(error) => Some(error),
             Self::Concept(error) => Some(error),
+            Self::Migration(error) => Some(error),
             Self::Internal(error) => Some(error),
             Self::Server(_) => None,
             Self::Other(_) => None,

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -178,10 +178,12 @@ error_messages! { ConnectionError
         29: "Connection closed unexpectedly.",
     DatabaseImportChannelIsClosed =
         30: "The database import channel is closed and no further operation is allowed.",
+    DatabaseImportStreamUnexpectedResponse =
+        31: "The database import stream received an unexpected response in the process. It is either a version compatibility issue or a bug.",
     DatabaseExportChannelIsClosed =
-        31: "The database export channel is closed and no further operation is allowed.",
+        32: "The database export channel is closed and no further operation is allowed.",
     DatabaseExportStreamNoResponse =
-        32: "Didn't receive any server responses for the database export command.",
+        33: "Didn't receive any server responses for the database export command.",
 }
 
 error_messages! { ConceptError

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -200,12 +200,14 @@ error_messages! { MigrationError
         1: "Cannot open import file '{path}': {reason}",
     CannotCreateExportFile { path: String, reason: String } =
         2: "Cannot create export file '{path}': {reason}",
+    CannotExportToTheSameFile =
+        3: "Cannot export both schema and data to the same file.",
     CannotDecodeImportedConcept =
-        3: "Cannot decode a concept from the provided import file. Make sure to pass a correct database file produced by a TypeDB export operation.",
+        4: "Cannot decode a concept from the provided import file. Make sure to pass a correct database file produced by a TypeDB export operation.",
     CannotDecodeImportedConceptLength =
-        4: "Cannot decode a concept length from the provided import file. Make sure to pass a correct database file produced by a TypeDB export operation.",
+        5: "Cannot decode a concept length from the provided import file. Make sure to pass a correct database file produced by a TypeDB export operation.",
     CannotEncodeExportedConcept =
-        5: "Cannot encode a concept for export. It's either a version compatibility error or a bug."
+        6: "Cannot encode a concept for export. It's either a version compatibility error or a bug."
 }
 
 error_messages! { InternalError

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -200,8 +200,10 @@ error_messages! { MigrationError
         2: "Cannot create export file '{path}': {reason}",
     CannotDecodeImportedConcept =
         3: "Cannot decode a concept from the provided import file. Make sure to pass a correct database file produced by a TypeDB export operation.",
+    CannotDecodeImportedConceptLength =
+        4: "Cannot decode a concept length from the provided import file. Make sure to pass a correct database file produced by a TypeDB export operation.",
     CannotEncodeExportedConcept =
-        4: "Cannot encode a concept for export. It's either a version compatibility error or a bug."
+        5: "Cannot encode a concept for export. It's either a version compatibility error or a bug."
 }
 
 error_messages! { InternalError

--- a/rust/src/connection/database/export_stream.rs
+++ b/rust/src/connection/database/export_stream.rs
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use std::fmt;
+
+#[cfg(not(feature = "sync"))]
+use futures::{stream, StreamExt};
+
+use crate::{
+    common::{stream::Stream, Promise, Result},
+    connection::{message::DatabaseExportResponse, network::transmitter::DatabaseExportTransmitter},
+    database::migration::DatabaseExportAnswer,
+    error::ConnectionError,
+    promisify, Error,
+};
+
+pub(crate) struct DatabaseExportStream {
+    export_transmitter: DatabaseExportTransmitter,
+}
+
+impl DatabaseExportStream {
+    pub(crate) fn new(export_transmitter: DatabaseExportTransmitter) -> Self {
+        Self { export_transmitter }
+    }
+
+    pub(crate) fn listen<'a>(&'a mut self) -> impl Promise<'a, Result<DatabaseExportAnswer>> + 'a {
+        let mut stream = self.export_transmitter.stream();
+        promisify! {
+            #[cfg(feature = "sync")]
+            let response = stream.next();
+            #[cfg(not(feature = "sync"))]
+            let response: Option<Result<DatabaseExportResponse>> = stream.next().await;
+
+            let response = match response {
+                None => return Err(ConnectionError::QueryStreamNoResponse.into()),
+                Some(Err(err)) => return Err(err),
+                Some(Ok(response)) => response,
+            };
+            match response {
+                DatabaseExportResponse::Schema(schema) => Ok(DatabaseExportAnswer::Schema(schema)),
+                DatabaseExportResponse::Items(items) => Ok(DatabaseExportAnswer::Items(items)),
+                DatabaseExportResponse::Done => Ok(DatabaseExportAnswer::Done),
+                DatabaseExportResponse::Error(error) => Err(Error::Server(error)),
+            }
+        }
+    }
+}
+
+impl fmt::Debug for DatabaseExportStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DatabaseExportStream").finish()
+    }
+}

--- a/rust/src/connection/database/export_stream.rs
+++ b/rust/src/connection/database/export_stream.rs
@@ -39,7 +39,7 @@ impl DatabaseExportStream {
         Self { export_transmitter }
     }
 
-    pub(crate) fn listen<'a>(&'a mut self) -> impl Promise<'a, Result<DatabaseExportAnswer>> + 'a {
+    pub(crate) fn next<'a>(&'a mut self) -> impl Promise<'a, Result<DatabaseExportAnswer>> + 'a {
         let mut stream = self.export_transmitter.stream();
         promisify! {
             #[cfg(feature = "sync")]

--- a/rust/src/connection/database/export_stream.rs
+++ b/rust/src/connection/database/export_stream.rs
@@ -47,16 +47,14 @@ impl DatabaseExportStream {
             #[cfg(not(feature = "sync"))]
             let response: Option<Result<DatabaseExportResponse>> = stream.next().await;
 
-            let response = match response {
-                None => return Err(ConnectionError::QueryStreamNoResponse.into()),
-                Some(Err(err)) => return Err(err),
-                Some(Ok(response)) => response,
-            };
             match response {
-                DatabaseExportResponse::Schema(schema) => Ok(DatabaseExportAnswer::Schema(schema)),
-                DatabaseExportResponse::Items(items) => Ok(DatabaseExportAnswer::Items(items)),
-                DatabaseExportResponse::Done => Ok(DatabaseExportAnswer::Done),
-                DatabaseExportResponse::Error(error) => Err(Error::Server(error)),
+                None => return Err(ConnectionError::DatabaseExportStreamNoResponse.into()),
+                Some(Err(err)) => return Err(err),
+                Some(Ok(response)) => match response {
+                    DatabaseExportResponse::Schema(schema) => Ok(DatabaseExportAnswer::Schema(schema)),
+                    DatabaseExportResponse::Items(items) => Ok(DatabaseExportAnswer::Items(items)),
+                    DatabaseExportResponse::Done => Ok(DatabaseExportAnswer::Done),
+                }
             }
         }
     }

--- a/rust/src/connection/database/export_stream.rs
+++ b/rust/src/connection/database/export_stream.rs
@@ -20,14 +20,14 @@
 use std::fmt;
 
 #[cfg(not(feature = "sync"))]
-use futures::{stream, StreamExt};
+use futures::StreamExt;
 
 use crate::{
     common::{stream::Stream, Promise, Result},
     connection::{message::DatabaseExportResponse, network::transmitter::DatabaseExportTransmitter},
     database::migration::DatabaseExportAnswer,
     error::ConnectionError,
-    promisify, Error,
+    promisify,
 };
 
 pub(crate) struct DatabaseExportStream {

--- a/rust/src/connection/database/import_stream.rs
+++ b/rust/src/connection/database/import_stream.rs
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use std::{fmt, iter, pin::Pin, sync::Arc};
+
+#[cfg(not(feature = "sync"))]
+use futures::{stream, StreamExt};
+use typedb_protocol::migration;
+
+use crate::{
+    common::{stream::Stream, Promise, Result},
+    connection::{
+        message::{DatabaseImportRequest, TransactionResponse},
+        network::transmitter::DatabaseImportTransmitter,
+    },
+    promisify, resolve,
+};
+
+pub(crate) struct DatabaseImportStream {
+    import_transmitter: DatabaseImportTransmitter,
+}
+
+impl DatabaseImportStream {
+    pub(crate) fn new(import_transmitter: DatabaseImportTransmitter) -> Self {
+        Self { import_transmitter }
+    }
+
+    pub(crate) fn items(&self, items: Vec<migration::Item>) -> impl Promise<'static, Result> {
+        let promise = self.single(DatabaseImportRequest::ItemPart { items });
+        promisify! { resolve!(promise) }
+    }
+
+    pub(crate) fn done(self) -> impl Promise<'static, Result> {
+        let promise = self.single(DatabaseImportRequest::Done);
+        promisify! {
+            let _this = self; // move into the promise so the stream isn't dropped until the promise is resolved
+            resolve!(promise)
+        }
+    }
+
+    fn single(&self, req: DatabaseImportRequest) -> impl Promise<'static, Result> {
+        self.import_transmitter.single(req)
+    }
+}
+
+impl fmt::Debug for DatabaseImportStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DatabaseImportStream").finish()
+    }
+}

--- a/rust/src/connection/database/import_stream.rs
+++ b/rust/src/connection/database/import_stream.rs
@@ -38,7 +38,7 @@ impl DatabaseImportStream {
         Self { import_transmitter }
     }
 
-    pub(crate) fn items(&mut self, items: Vec<migration::Item>) -> Result {
+    pub(crate) fn send_items(&mut self, items: Vec<migration::Item>) -> Result {
         self.import_transmitter.single(DatabaseImportRequest::ItemPart { items })
     }
 

--- a/rust/src/connection/database/import_stream.rs
+++ b/rust/src/connection/database/import_stream.rs
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-use std::{fmt, iter, pin::Pin, sync::Arc};
+use std::fmt;
 
 #[cfg(not(feature = "sync"))]
 use futures::{stream, StreamExt};
@@ -45,7 +45,7 @@ impl DatabaseImportStream {
     pub(crate) fn done(mut self) -> impl Promise<'static, Result> {
         promisify! {
             self.import_transmitter.single(DatabaseImportRequest::Done)?;
-            let promise = self.import_transmitter.wait_until_done();
+            let promise = self.import_transmitter.wait_done();
             resolve!(promise)
         }
     }

--- a/rust/src/connection/database/mod.rs
+++ b/rust/src/connection/database/mod.rs
@@ -17,14 +17,5 @@
  * under the License.
  */
 
-pub(crate) use self::transaction_stream::TransactionStream;
-pub use self::{credentials::Credentials, driver_options::DriverOptions};
-
-mod credentials;
-pub(crate) mod database;
-mod driver_options;
-mod message;
-mod network;
-pub(crate) mod runtime;
-pub(crate) mod server_connection;
-pub(crate) mod transaction_stream;
+pub(crate) mod export_stream;
+pub(crate) mod import_stream;

--- a/rust/src/connection/message.rs
+++ b/rust/src/connection/message.rs
@@ -103,9 +103,6 @@ pub(super) enum Response {
     DatabaseExportStream {
         response_source: Streaming<database::export::Server>,
     },
-    DatabaseExportAnswer {
-        response_source: Streaming<database::export::Server>,
-    },
 
     TransactionStream {
         open_request_id: RequestID,

--- a/rust/src/connection/message.rs
+++ b/rust/src/connection/message.rs
@@ -84,6 +84,7 @@ pub(super) enum Response {
     },
     DatabaseImport {
         request_sink: UnboundedSender<database_manager::import::Client>,
+        response_source: Streaming<database_manager::import::Server>,
     },
     DatabaseGet {
         database: DatabaseInfo,
@@ -139,7 +140,6 @@ pub(super) enum DatabaseExportResponse {
     Schema(String),
     Items(Vec<Item>),
     Done,
-    Error(ServerError),
 }
 
 #[derive(Debug)]

--- a/rust/src/connection/network/proto/concept.rs
+++ b/rust/src/connection/network/proto/concept.rs
@@ -96,7 +96,6 @@ impl TryFromProto<ConceptProto> for Concept {
                 Attribute::try_from_proto(attribute_proto).map(Self::Attribute)
             }
 
-            // Some(concept::Concept::Value(value_proto)) => Value::try_from_proto(value_proto).map(Self::Value),
             None => Err(MissingResponseField { field: "concept" }.into()),
         }
     }

--- a/rust/src/connection/network/proto/message.rs
+++ b/rust/src/connection/network/proto/message.rs
@@ -19,8 +19,11 @@
 
 use itertools::Itertools;
 use typedb_protocol::{
-    authentication, connection, database, database_manager, query::initial_res::Res, server_manager, transaction, user,
-    user_manager, Version::Version,
+    authentication, connection, database, database_manager, migration,
+    migration::export::{initial_res, res_part::stream_signal_res_part::State, server::Server},
+    query::initial_res::Res,
+    server_manager, transaction, user, user_manager,
+    Version::Version,
 };
 use uuid::Uuid;
 
@@ -28,7 +31,10 @@ use super::{FromProto, IntoProto, TryFromProto, TryIntoProto};
 use crate::{
     answer::{concept_document::ConceptDocumentHeader, concept_row::ConceptRowHeader, QueryType},
     common::{info::DatabaseInfo, RequestID, Result},
-    connection::message::{QueryRequest, QueryResponse, Request, Response, TransactionRequest, TransactionResponse},
+    connection::message::{
+        DatabaseExportResponse, DatabaseImportRequest, QueryRequest, QueryResponse, Request, Response,
+        TransactionRequest, TransactionResponse,
+    },
     error::{ConnectionError, InternalError, ServerError},
     info::UserInfo,
     Credentials,
@@ -93,6 +99,32 @@ impl TryIntoProto<database_manager::create::Req> for Request {
     }
 }
 
+impl TryIntoProto<database_manager::import::Client> for Request {
+    fn try_into_proto(self) -> Result<database_manager::import::Client> {
+        match self {
+            Self::DatabaseImport(import_request) => Ok(database_manager::import::Client {
+                client: Some(migration::import::Client { req: Some(import_request.into_proto()) }),
+            }),
+            other => Err(InternalError::UnexpectedRequestType { request_type: format!("{other:?}") }.into()),
+        }
+    }
+}
+
+impl IntoProto<migration::import::Req> for DatabaseImportRequest {
+    fn into_proto(self) -> migration::import::Req {
+        let req = match self {
+            DatabaseImportRequest::Initial { name, schema } => {
+                migration::import::req::Req::InitialReq(migration::import::req::InitialReq { name, schema })
+            }
+            DatabaseImportRequest::ItemPart { items } => {
+                migration::import::req::Req::ItemReqPart(migration::import::req::ItemReqPart { items })
+            }
+            DatabaseImportRequest::Done {} => migration::import::req::Req::DoneReq(migration::import::req::DoneReq {}),
+        };
+        migration::import::Req { req: Some(req) }
+    }
+}
+
 impl TryIntoProto<database::delete::Req> for Request {
     fn try_into_proto(self) -> Result<database::delete::Req> {
         match self {
@@ -115,6 +147,17 @@ impl TryIntoProto<database::type_schema::Req> for Request {
     fn try_into_proto(self) -> Result<database::type_schema::Req> {
         match self {
             Self::DatabaseTypeSchema { database_name } => Ok(database::type_schema::Req { name: database_name }),
+            other => Err(InternalError::UnexpectedRequestType { request_type: format!("{other:?}") }.into()),
+        }
+    }
+}
+
+impl TryIntoProto<database::export::Req> for Request {
+    fn try_into_proto(self) -> Result<database::export::Req> {
+        match self {
+            Self::DatabaseExport { database_name } => {
+                Ok(database::export::Req { req: Some(migration::export::Req { database: database_name }) })
+            }
             other => Err(InternalError::UnexpectedRequestType { request_type: format!("{other:?}") }.into()),
         }
     }
@@ -311,6 +354,61 @@ impl FromProto<database::type_schema::Res> for Response {
     }
 }
 
+impl TryFromProto<database::export::Server> for DatabaseExportResponse {
+    fn try_from_proto(proto: database::export::Server) -> Result<Self> {
+        match proto.server {
+            Some(server) => match server.server {
+                Some(Server::InitialRes(initial_res)) => Self::try_from_proto(initial_res),
+                Some(Server::ResPart(res_part)) => Self::try_from_proto(res_part),
+                None => Err(ConnectionError::MissingResponseField { field: "server" }.into()),
+            },
+            None => Err(ConnectionError::MissingResponseField { field: "server" }.into()),
+        }
+    }
+}
+
+impl TryFromProto<migration::export::InitialRes> for DatabaseExportResponse {
+    fn try_from_proto(proto: migration::export::InitialRes) -> Result<Self> {
+        match proto.res {
+            Some(initial_res::Res::Ok(initial_res::Ok { schema })) => Ok(Self::Schema(schema)),
+            Some(initial_res::Res::Error(error)) => Ok(Self::Error(ServerError::from_proto(error))),
+            None => Err(ConnectionError::MissingResponseField { field: "res" }.into()),
+        }
+    }
+}
+
+impl TryFromProto<migration::export::ResPart> for DatabaseExportResponse {
+    fn try_from_proto(proto: migration::export::ResPart) -> Result<Self> {
+        match proto.res_part {
+            Some(migration::export::res_part::ResPart::ItemRes(
+                migration::export::res_part::MigrationItemResPart { items },
+            )) => Ok(Self::Items(items)),
+            Some(migration::export::res_part::ResPart::StreamRes(
+                migration::export::res_part::StreamSignalResPart { state },
+            )) => match state {
+                Some(state) => match state {
+                    State::Done(_) => Ok(Self::Done),
+                    State::Error(error) => Ok(Self::Error(ServerError::from_proto(error))),
+                },
+                None => Err(ConnectionError::MissingResponseField { field: "state" }.into()),
+            },
+            None => Err(ConnectionError::MissingResponseField { field: "res_part" }.into()),
+        }
+    }
+}
+
+impl FromProto<typedb_protocol::Error> for ServerError {
+    fn from_proto(proto: typedb_protocol::Error) -> Self {
+        ServerError::new(proto.error_code, proto.domain, String::new(), proto.stack_trace)
+    }
+}
+
+impl FromProto<typedb_protocol::Error> for DatabaseExportResponse {
+    fn from_proto(proto: typedb_protocol::Error) -> Self {
+        DatabaseExportResponse::Error(ServerError::from_proto(proto))
+    }
+}
+
 impl TryFromProto<transaction::Res> for TransactionResponse {
     fn try_from_proto(proto: transaction::Res) -> Result<Self> {
         match proto.res {
@@ -392,7 +490,7 @@ impl TryFromProto<typedb_protocol::query::res_part::Res> for QueryResponse {
 
 impl FromProto<typedb_protocol::Error> for QueryResponse {
     fn from_proto(proto: typedb_protocol::Error) -> Self {
-        QueryResponse::Error(ServerError::new(proto.error_code, proto.domain, String::new(), proto.stack_trace))
+        QueryResponse::Error(ServerError::from_proto(proto))
     }
 }
 

--- a/rust/src/connection/network/proto/message.rs
+++ b/rust/src/connection/network/proto/message.rs
@@ -155,7 +155,7 @@ impl TryIntoProto<database::export::Req> for Request {
     fn try_into_proto(self) -> Result<database::export::Req> {
         match self {
             Self::DatabaseExport { database_name } => {
-                Ok(database::export::Req { req: Some(migration::export::Req { database: database_name }) })
+                Ok(database::export::Req { req: Some(migration::export::Req { name: database_name }) })
             }
             other => Err(InternalError::UnexpectedRequestType { request_type: format!("{other:?}") }.into()),
         }

--- a/rust/src/connection/network/stub.rs
+++ b/rust/src/connection/network/stub.rs
@@ -153,8 +153,7 @@ impl<Channel: GRPCChannel> RPCStub<Channel> {
         req: database::export::Req,
     ) -> Result<Streaming<database::export::Server>> {
         self.call_with_auto_renew_token(|this| {
-            let req = req.clone();
-            Box::pin(async { this.grpc.database_export(req).map(|r| Ok(r?.into_inner())).await })
+            Box::pin(this.grpc.database_export(req.clone()).map(|r| Ok(r?.into_inner())))
         })
         .await
     }

--- a/rust/src/connection/network/stub.rs
+++ b/rust/src/connection/network/stub.rs
@@ -119,11 +119,10 @@ impl<Channel: GRPCChannel> RPCStub<Channel> {
 
     pub(super) async fn databases_import(
         &mut self,
-        req: migration::import::Req,
-    ) -> Result<(UnboundedSender<database_manager::import::Client>, database_manager::import::Res)> {
+        client: migration::import::Client,
+    ) -> Result<(UnboundedSender<database_manager::import::Client>, Streaming<database_manager::import::Server>)> {
         self.call_with_auto_renew_token(|this| {
-            let import_req =
-                database_manager::import::Client { client: Some(migration::import::Client { req: Some(req.clone()) }) };
+            let import_req = database_manager::import::Client { client: Some(client.clone()) };
             Box::pin(async {
                 let (sender, receiver) = unbounded_async();
                 sender.send(import_req)?;

--- a/rust/src/connection/network/transmitter/export.rs
+++ b/rust/src/connection/network/transmitter/export.rs
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use std::sync::Arc;
+
+use futures::StreamExt;
+use tokio::sync::mpsc::{unbounded_channel as unbounded_async, UnboundedReceiver, UnboundedSender};
+use tonic::Streaming;
+use typedb_protocol::database;
+
+use crate::{
+    common::{
+        stream::{NetworkStream, Stream},
+        Result,
+    },
+    connection::{message::DatabaseExportResponse, network::proto::TryFromProto, runtime::BackgroundRuntime},
+    Error,
+};
+
+pub(in crate::connection) struct DatabaseExportTransmitter {
+    stream: NetworkStream<Result<DatabaseExportResponse>>,
+    shutdown_sink: UnboundedSender<()>,
+    // runtime is alive as long as the export transmitter is alive:
+    background_runtime: Arc<BackgroundRuntime>,
+}
+
+impl DatabaseExportTransmitter {
+    pub(in crate::connection) fn new(
+        background_runtime: Arc<BackgroundRuntime>,
+        response_source: Streaming<database::export::Server>,
+    ) -> Self {
+        let (response_sender, response_receiver) = unbounded_async();
+        let (shutdown_sink, shutdown_source) = unbounded_async();
+
+        background_runtime.spawn(Self::start_workers(response_source, response_sender, shutdown_source));
+        Self { stream: NetworkStream::new(response_receiver), shutdown_sink, background_runtime }
+    }
+
+    pub(in crate::connection) fn shutdown_sink(&self) -> &UnboundedSender<()> {
+        &self.shutdown_sink
+    }
+
+    pub(in crate::connection) fn stream(&mut self) -> &mut impl Stream<Item = Result<DatabaseExportResponse>> {
+        &mut self.stream
+    }
+
+    async fn start_workers(
+        response_source: Streaming<database::export::Server>,
+        response_sender: UnboundedSender<Result<DatabaseExportResponse>>,
+        shutdown_signal: UnboundedReceiver<()>,
+    ) {
+        tokio::task::spawn_blocking({ move || Self::listen_loop(response_source, response_sender, shutdown_signal) });
+    }
+
+    async fn listen_loop(
+        mut grpc_source: Streaming<database::export::Server>,
+        response_sender: UnboundedSender<Result<DatabaseExportResponse>>,
+        mut shutdown_signal: UnboundedReceiver<()>,
+    ) {
+        loop {
+            println!("Listen loop export");
+            if let Ok(_) = shutdown_signal.try_recv() {
+                break;
+            }
+            match grpc_source.next().await {
+                Some(Ok(message)) => {
+                    response_sender.send(DatabaseExportResponse::try_from_proto(message)).unwrap()
+                    // TODO: cover
+                    // TODO: Close if error?
+                }
+                Some(Err(status)) => {
+                    response_sender.send(Err(status.into())).unwrap();
+                    break;
+                }
+                None => todo!("Unexpected NONE, cover? Replace to just close or panic?"), // TODO
+            }
+        }
+    }
+}

--- a/rust/src/connection/network/transmitter/export.rs
+++ b/rust/src/connection/network/transmitter/export.rs
@@ -81,7 +81,7 @@ impl DatabaseExportTransmitter {
                     .send(DatabaseExportResponse::try_from_proto(message))
                     .expect("Expected export channel to be open. It is a bug."),
                 Some(Err(status)) => {
-                    response_sender.send(Err(status.into())).unwrap();
+                    response_sender.send(Err(status.into())).expect("Expected export channel to be open. It is a bug.");
                     break;
                 }
                 None => break,

--- a/rust/src/connection/network/transmitter/import.rs
+++ b/rust/src/connection/network/transmitter/import.rs
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    sync::{Arc, RwLock},
+    thread::sleep,
+    time::Duration,
+};
+
+use crossbeam::{atomic::AtomicCell, channel::Sender};
+use futures::StreamExt;
+#[cfg(not(feature = "sync"))]
+use futures::TryStreamExt;
+#[cfg(feature = "sync")]
+use itertools::Itertools;
+use log::{debug, error};
+use prost::Message;
+#[cfg(not(feature = "sync"))]
+use tokio::sync::oneshot::channel as oneshot;
+use tokio::{
+    select,
+    sync::{
+        mpsc::{error::SendError, unbounded_channel as unbounded_async, UnboundedReceiver, UnboundedSender},
+        oneshot::{channel as oneshot_async, Sender as AsyncOneshotSender},
+    },
+    time::{sleep_until, Instant},
+};
+use typedb_protocol::{database_manager, migration};
+
+#[cfg(feature = "sync")]
+use super::oneshot_blocking as oneshot;
+use super::response_sink::ResponseSink;
+use crate::{
+    common::{box_promise, error::ConnectionError, Promise, Result},
+    connection::{message::DatabaseImportRequest, network::proto::IntoProto, runtime::BackgroundRuntime},
+};
+
+pub(in crate::connection) struct DatabaseImportTransmitter {
+    request_sink: UnboundedSender<(DatabaseImportRequest, Option<ResponseSink<()>>)>,
+    shutdown_sink: UnboundedSender<()>,
+    // runtime is alive as long as the import transmitter is alive:
+    background_runtime: Arc<BackgroundRuntime>,
+}
+
+impl DatabaseImportTransmitter {
+    pub(in crate::connection) fn new(
+        background_runtime: Arc<BackgroundRuntime>,
+        request_sink: UnboundedSender<database_manager::import::Client>,
+    ) -> Self {
+        let (buffer_sink, buffer_source) = unbounded_async();
+        let (shutdown_sink, shutdown_source) = unbounded_async();
+        // let (error_sink, error_source) = unbounded_async();
+
+        background_runtime.spawn(Self::start_workers(
+            buffer_source,
+            request_sink,
+            // error_sink,
+            // error_source
+            shutdown_source,
+        ));
+        Self { request_sink: buffer_sink, shutdown_sink, background_runtime }
+    }
+
+    pub(in crate::connection) fn shutdown_sink(&self) -> &UnboundedSender<()> {
+        &self.shutdown_sink
+    }
+
+    #[cfg(not(feature = "sync"))]
+    pub(in crate::connection) fn single(&self, req: DatabaseImportRequest) -> impl Promise<'static, Result<()>> {
+        let (res_sink, recv) = oneshot();
+        let send_result = self.request_sink.send((req, Some(ResponseSink::AsyncOneShot(res_sink))));
+        box_promise(async move {
+            send_result.map_err(|_| ConnectionError::DatabaseImportChannelIsClosed)?;
+            recv.await?.map(Into::into)
+        })
+    }
+
+    #[cfg(feature = "sync")]
+    pub(in crate::connection) fn single(&self, req: DatabaseImportRequest) -> impl Promise<'static, Result> {
+        let (res_sink, recv) = oneshot();
+        let send_result = self.request_sink.send((req, Some(ResponseSink::BlockingOneShot(res_sink))));
+        box_promise(move || {
+            send_result.map_err(|_| ConnectionError::DatabaseImportChannelIsClosed.into()).and_then(|_| recv.recv()?)
+        })
+    }
+
+    // TODO: how to return errors?
+    async fn start_workers(
+        queue_source: UnboundedReceiver<(DatabaseImportRequest, Option<ResponseSink<()>>)>,
+        request_sink: UnboundedSender<database_manager::import::Client>,
+        // error_sender: UnboundedSender<()>,
+        // error_signal: UnboundedReceiver<()>,
+        shutdown_signal: UnboundedReceiver<()>,
+    ) {
+        tokio::task::spawn_blocking({ move || Self::dispatch_loop(queue_source, request_sink, shutdown_signal) });
+    }
+
+    fn dispatch_loop(
+        mut request_source: UnboundedReceiver<(DatabaseImportRequest, Option<ResponseSink<()>>)>,
+        request_sink: UnboundedSender<database_manager::import::Client>,
+        mut shutdown_signal: UnboundedReceiver<()>,
+    ) {
+        const MAX_GRPC_MESSAGE_LEN: usize = 1_000_000;
+        const DISPATCH_INTERVAL: Duration = Duration::from_micros(50);
+
+        loop {
+            if let Ok(_) = shutdown_signal.try_recv() {
+                break;
+            }
+
+            if let Ok(request) = request_source.try_recv() {
+                let (request, callback) = request;
+                let client_req = database_manager::import::Client {
+                    client: Some(migration::import::Client { req: Some(request.into_proto()) }),
+                };
+                request_sink.send(client_req).expect("Expected database import request send");
+                // TODO: return error??
+                // TODO: If Done, break? Await for the Done signal? Where?
+            }
+        }
+    }
+}

--- a/rust/src/connection/network/transmitter/import.rs
+++ b/rust/src/connection/network/transmitter/import.rs
@@ -17,46 +17,31 @@
  * under the License.
  */
 
-use std::{
-    collections::HashMap,
-    future::Future,
-    pin::Pin,
-    sync::{Arc, RwLock},
-    thread::sleep,
-    time::Duration,
-};
+use std::{sync::Arc, thread::sleep, time::Duration};
 
-use crossbeam::{atomic::AtomicCell, channel::Sender};
 use futures::StreamExt;
 #[cfg(not(feature = "sync"))]
 use futures::TryStreamExt;
-#[cfg(feature = "sync")]
-use itertools::Itertools;
-use log::{debug, error};
-use prost::Message;
-#[cfg(not(feature = "sync"))]
-use tokio::sync::oneshot::channel as oneshot;
-use tokio::{
-    select,
-    sync::{
-        mpsc::{error::SendError, unbounded_channel as unbounded_async, UnboundedReceiver, UnboundedSender},
-        oneshot::{channel as oneshot_async, Sender as AsyncOneshotSender},
+use tokio::sync::{
+    mpsc::{unbounded_channel as unbounded_async, UnboundedReceiver, UnboundedSender},
+    oneshot::{
+        channel as oneshot_async,
+        error::{RecvError, TryRecvError},
+        Receiver as AsyncOneshotReceiver, Sender as AsyncOneshotSender,
     },
-    time::{sleep_until, Instant},
 };
-use typedb_protocol::{database_manager, migration};
+use tonic::Streaming;
+use typedb_protocol::database_manager;
 
-#[cfg(feature = "sync")]
-use super::oneshot_blocking as oneshot;
-use super::response_sink::ResponseSink;
 use crate::{
     common::{box_promise, error::ConnectionError, Promise, Result},
     connection::{message::DatabaseImportRequest, network::proto::IntoProto, runtime::BackgroundRuntime},
 };
 
 pub(in crate::connection) struct DatabaseImportTransmitter {
-    request_sink: UnboundedSender<(DatabaseImportRequest, Option<ResponseSink<()>>)>,
+    request_sink: UnboundedSender<DatabaseImportRequest>,
     shutdown_sink: UnboundedSender<()>,
+    result_source: AsyncOneshotReceiver<Result>,
     // runtime is alive as long as the import transmitter is alive:
     background_runtime: Arc<BackgroundRuntime>,
 }
@@ -65,57 +50,62 @@ impl DatabaseImportTransmitter {
     pub(in crate::connection) fn new(
         background_runtime: Arc<BackgroundRuntime>,
         request_sink: UnboundedSender<database_manager::import::Client>,
+        response_source: Streaming<database_manager::import::Server>,
     ) -> Self {
         let (buffer_sink, buffer_source) = unbounded_async();
         let (shutdown_sink, shutdown_source) = unbounded_async();
-        // let (error_sink, error_source) = unbounded_async();
+        let (result_sink, result_source) = oneshot_async();
 
         background_runtime.spawn(Self::start_workers(
             buffer_source,
             request_sink,
-            // error_sink,
-            // error_source
+            response_source,
+            result_sink,
+            shutdown_sink.clone(),
             shutdown_source,
         ));
-        Self { request_sink: buffer_sink, shutdown_sink, background_runtime }
+        Self { request_sink: buffer_sink, shutdown_sink, result_source, background_runtime }
     }
 
     pub(in crate::connection) fn shutdown_sink(&self) -> &UnboundedSender<()> {
         &self.shutdown_sink
     }
 
-    #[cfg(not(feature = "sync"))]
-    pub(in crate::connection) fn single(&self, req: DatabaseImportRequest) -> impl Promise<'static, Result<()>> {
-        let (res_sink, recv) = oneshot();
-        let send_result = self.request_sink.send((req, Some(ResponseSink::AsyncOneShot(res_sink))));
-        box_promise(async move {
-            send_result.map_err(|_| ConnectionError::DatabaseImportChannelIsClosed)?;
-            recv.await?.map(Into::into)
-        })
+    pub(in crate::connection) fn single(&mut self, req: DatabaseImportRequest) -> Result {
+        match self.result_source.try_recv() {
+            Ok(result) => return result,
+            Err(TryRecvError::Closed) => return Err(ConnectionError::DatabaseImportChannelIsClosed.into()),
+            Err(TryRecvError::Empty) => {}
+        }
+        let send_result = self.request_sink.send(req);
+        send_result.map_err(|_| ConnectionError::DatabaseImportChannelIsClosed.into())
     }
 
-    #[cfg(feature = "sync")]
-    pub(in crate::connection) fn single(&self, req: DatabaseImportRequest) -> impl Promise<'static, Result> {
-        let (res_sink, recv) = oneshot();
-        let send_result = self.request_sink.send((req, Some(ResponseSink::BlockingOneShot(res_sink))));
-        box_promise(move || {
-            send_result.map_err(|_| ConnectionError::DatabaseImportChannelIsClosed.into()).and_then(|_| recv.recv()?)
-        })
+    pub(in crate::connection) fn wait_until_done(mut self) -> Result {
+        loop {
+            sleep(Duration::from_millis(100)); // TODO: Config and increase it with every loop
+            match self.result_source.try_recv() {
+                Ok(result) => return result,
+                Err(TryRecvError::Closed) => return Err(ConnectionError::DatabaseImportChannelIsClosed.into()),
+                Err(TryRecvError::Empty) => {} // TODO: Fix
+            }
+        }
     }
 
-    // TODO: how to return errors?
     async fn start_workers(
-        queue_source: UnboundedReceiver<(DatabaseImportRequest, Option<ResponseSink<()>>)>,
+        queue_source: UnboundedReceiver<DatabaseImportRequest>,
         request_sink: UnboundedSender<database_manager::import::Client>,
-        // error_sender: UnboundedSender<()>,
-        // error_signal: UnboundedReceiver<()>,
+        response_source: Streaming<database_manager::import::Server>,
+        result_sink: AsyncOneshotSender<Result>,
+        shutdown_sink: UnboundedSender<()>,
         shutdown_signal: UnboundedReceiver<()>,
     ) {
         tokio::task::spawn_blocking({ move || Self::dispatch_loop(queue_source, request_sink, shutdown_signal) });
+        tokio::spawn(Self::listen(response_source, result_sink, shutdown_sink));
     }
 
     fn dispatch_loop(
-        mut request_source: UnboundedReceiver<(DatabaseImportRequest, Option<ResponseSink<()>>)>,
+        mut request_source: UnboundedReceiver<DatabaseImportRequest>,
         request_sink: UnboundedSender<database_manager::import::Client>,
         mut shutdown_signal: UnboundedReceiver<()>,
     ) {
@@ -127,15 +117,25 @@ impl DatabaseImportTransmitter {
                 break;
             }
 
+            sleep(DISPATCH_INTERVAL);
             if let Ok(request) = request_source.try_recv() {
-                let (request, callback) = request;
-                let client_req = database_manager::import::Client {
-                    client: Some(migration::import::Client { req: Some(request.into_proto()) }),
-                };
-                request_sink.send(client_req).expect("Expected database import request send");
-                // TODO: return error??
-                // TODO: If Done, break? Await for the Done signal? Where?
+                let client_req = database_manager::import::Client { client: Some(request.into_proto()) };
+                request_sink.send(client_req).ok();
             }
         }
+    }
+
+    async fn listen(
+        mut grpc_source: Streaming<database_manager::import::Server>,
+        result_sink: AsyncOneshotSender<Result>,
+        shutdown_sink: UnboundedSender<()>,
+    ) {
+        let result = match grpc_source.next().await {
+            Some(Ok(_message)) => Ok(()), // can only be Done
+            Some(Err(status)) => Err(status.into()),
+            None => Err(ConnectionError::DatabaseImportChannelIsClosed.into()),
+        };
+        result_sink.send(result).ok();
+        shutdown_sink.send(()).ok();
     }
 }

--- a/rust/src/connection/network/transmitter/import.rs
+++ b/rust/src/connection/network/transmitter/import.rs
@@ -82,14 +82,19 @@ impl DatabaseImportTransmitter {
     }
 
     pub(in crate::connection) fn wait_until_done(mut self) -> Result {
+        // TODO: Make sync/async in a smart way
         loop {
-            sleep(Duration::from_millis(100)); // TODO: Config and increase it with every loop
+            sleep(Duration::from_millis(100));
             match self.result_source.try_recv() {
                 Ok(result) => return result,
                 Err(TryRecvError::Closed) => return Err(ConnectionError::DatabaseImportChannelIsClosed.into()),
-                Err(TryRecvError::Empty) => {} // TODO: Fix
+                Err(TryRecvError::Empty) => {}
             }
         }
+        // match self.result_source.await {
+        //     Ok(result) => result,
+        //     Err(_) => Err(ConnectionError::DatabaseImportChannelIsClosed.into()),
+        // }
     }
 
     async fn start_workers(

--- a/rust/src/connection/network/transmitter/import.rs
+++ b/rust/src/connection/network/transmitter/import.rs
@@ -146,7 +146,7 @@ impl DatabaseImportTransmitter {
         shutdown_signal: UnboundedReceiver<()>,
     ) {
         tokio::task::spawn_blocking(move || Self::dispatch_loop(queue_source, request_sink, shutdown_signal));
-        tokio::spawn(Self::listen(response_source, result_sink, shutdown_sink));
+        tokio::spawn(Self::next(response_source, result_sink, shutdown_sink));
     }
 
     fn dispatch_loop(
@@ -168,7 +168,7 @@ impl DatabaseImportTransmitter {
         }
     }
 
-    async fn listen(
+    async fn next(
         mut grpc_source: Streaming<database_manager::import::Server>,
         result_sink: ResponseSink<()>,
         shutdown_sink: UnboundedSender<()>,

--- a/rust/src/connection/network/transmitter/mod.rs
+++ b/rust/src/connection/network/transmitter/mod.rs
@@ -19,8 +19,13 @@
 
 use crossbeam::channel::{bounded as bounded_blocking, Receiver as SyncReceiver, Sender as SyncSender};
 
-pub(in crate::connection) use self::{rpc::RPCTransmitter, transaction::TransactionTransmitter};
+pub(in crate::connection) use self::{
+    export::DatabaseExportTransmitter, import::DatabaseImportTransmitter, rpc::RPCTransmitter,
+    transaction::TransactionTransmitter,
+};
 
+mod export;
+mod import;
 mod response_sink;
 mod rpc;
 mod transaction;

--- a/rust/src/connection/network/transmitter/mod.rs
+++ b/rust/src/connection/network/transmitter/mod.rs
@@ -17,7 +17,9 @@
  * under the License.
  */
 
-use crossbeam::channel::{bounded as bounded_blocking, Receiver as SyncReceiver, Sender as SyncSender};
+use crossbeam::channel::{
+    bounded as bounded_blocking, Receiver as SyncReceiver, Sender as SyncSender, TryRecvError as SyncTryRecvError,
+};
 
 pub(in crate::connection) use self::{
     export::DatabaseExportTransmitter, import::DatabaseImportTransmitter, rpc::RPCTransmitter,

--- a/rust/src/connection/network/transmitter/response_sink.rs
+++ b/rust/src/connection/network/transmitter/response_sink.rs
@@ -19,7 +19,7 @@
 
 use std::{fmt, fmt::Formatter, sync::Arc};
 
-use crossbeam::channel::Sender as SyncSender;
+use crossbeam::channel::Sender as SyncOneshotSender;
 use itertools::Either;
 use log::{debug, error};
 use tokio::sync::{mpsc::UnboundedSender, oneshot::Sender as AsyncOneshotSender};
@@ -34,7 +34,7 @@ use crate::{
 pub(super) enum ResponseSink<T> {
     ImmediateOneShot(ImmediateHandler<Result<T>>),
     AsyncOneShot(AsyncOneshotSender<Result<T>>),
-    BlockingOneShot(SyncSender<Result<T>>),
+    BlockingOneShot(SyncOneshotSender<Result<T>>),
     Streamed(UnboundedSender<StreamResponse<T>>),
 }
 

--- a/rust/src/connection/network/transmitter/rpc.rs
+++ b/rust/src/connection/network/transmitter/rpc.rs
@@ -131,8 +131,8 @@ impl RPCTransmitter {
                 rpc.databases_create(request.try_into_proto()?).await.and_then(Response::try_from_proto)
             }
             Request::DatabaseImport(import_request) => {
-                let (request_sink, _res) = rpc.databases_import(import_request.into_proto()).await?;
-                Ok(Response::DatabaseImport { request_sink })
+                let (request_sink, response_source) = rpc.databases_import(import_request.into_proto()).await?;
+                Ok(Response::DatabaseImport { request_sink, response_source })
             }
 
             Request::DatabaseDelete { .. } => {

--- a/rust/src/connection/network/transmitter/transaction.rs
+++ b/rust/src/connection/network/transmitter/transaction.rs
@@ -290,6 +290,7 @@ impl TransactionTransmitter {
             }
         }
     }
+
     async fn listen_loop(
         mut grpc_source: Streaming<transaction::Server>,
         collector: ResponseCollector,

--- a/rust/src/connection/server_connection.rs
+++ b/rust/src/connection/server_connection.rs
@@ -188,7 +188,6 @@ impl ServerConnection {
                 let transmitter_shutdown_sink = transmitter.shutdown_sink().clone();
                 let import_stream = DatabaseImportStream::new(transmitter);
 
-                // TODO: Is it needed?
                 self.shutdown_senders.lock().unwrap().push(transmitter_shutdown_sink);
                 Ok(import_stream)
             }

--- a/rust/src/connection/server_connection.rs
+++ b/rust/src/connection/server_connection.rs
@@ -182,8 +182,9 @@ impl ServerConnection {
             .request(Request::DatabaseImport(DatabaseImportRequest::Initial { name: database_name, schema }))
             .await?
         {
-            Response::DatabaseImport { request_sink } => {
-                let transmitter = DatabaseImportTransmitter::new(self.background_runtime.clone(), request_sink);
+            Response::DatabaseImport { request_sink, response_source } => {
+                let transmitter =
+                    DatabaseImportTransmitter::new(self.background_runtime.clone(), request_sink, response_source);
                 let transmitter_shutdown_sink = transmitter.shutdown_sink().clone();
                 let import_stream = DatabaseImportStream::new(transmitter);
 

--- a/rust/src/connection/transaction_stream.rs
+++ b/rust/src/connection/transaction_stream.rs
@@ -95,7 +95,7 @@ impl TransactionStream {
     }
 
     pub(crate) fn commit(self: Pin<Box<Self>>) -> impl Promise<'static, Result> {
-        let promise = self.transaction_transmitter.single(TransactionRequest::Commit);
+        let promise = self.single(TransactionRequest::Commit);
         promisify! {
             let _this = self; // move into the promise so the stream isn't dropped until the promise is resolved
             require_transaction_response!(resolve!(promise), Commit)

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -22,6 +22,7 @@ use std::future::Future;
 use std::{
     collections::HashMap,
     fmt,
+    path::Path,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, RwLock,
@@ -41,6 +42,7 @@ use crate::{
         Error, Result,
     },
     connection::server_connection::ServerConnection,
+    database::migration::{read_and_print_import_file, write_export_file},
     driver::TypeDBDriver,
     error::InternalError,
     Transaction, TransactionOptions, TransactionType,
@@ -155,6 +157,25 @@ impl Database {
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn type_schema(&self) -> Result<String> {
         self.run_failsafe(|database| async move { database.type_schema().await }).await
+    }
+
+    /// Export a database into a .tql schema definition and a .typedb data file
+    ///
+    /// # Arguments
+    ///
+    /// * `schema_file_path` — The path to the .tql schema definition file to be created
+    /// * `data_file_path` — The path to the .typedb data file to be created
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    #[cfg_attr(feature = "sync", doc = "database.export(schema_path, data_path);")]
+    #[cfg_attr(not(feature = "sync"), doc = "database.export(schema_path, data_path).await;")]
+    /// ```
+    #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
+    pub async fn export(&self, schema_file_path: impl AsRef<Path>, data_file_path: impl AsRef<Path>) -> Result {
+        // write_export_file(data_file_path)?;
+        Ok(())
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -173,11 +173,11 @@ impl Database {
     /// # Examples
     ///
     /// ```rust
-    #[cfg_attr(feature = "sync", doc = "database.export_file(schema_path, data_path);")]
-    #[cfg_attr(not(feature = "sync"), doc = "database.export_file(schema_path, data_path).await;")]
+    #[cfg_attr(feature = "sync", doc = "database.export_to_file(schema_path, data_path);")]
+    #[cfg_attr(not(feature = "sync"), doc = "database.export_to_file(schema_path, data_path).await;")]
     /// ```
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub async fn export_file(&self, schema_file_path: impl AsRef<Path>, data_file_path: impl AsRef<Path>) -> Result {
+    pub async fn export_to_file(&self, schema_file_path: impl AsRef<Path>, data_file_path: impl AsRef<Path>) -> Result {
         let schema_file_path = schema_file_path.as_ref();
         let data_file_path = data_file_path.as_ref();
         if schema_file_path == data_file_path {
@@ -195,7 +195,7 @@ impl Database {
                 // File opening should be idempotent for multiple function invocations
                 let schema_file = try_open_existing_export_file(schema_file_path)?;
                 let data_file = try_open_existing_export_file(data_file_path)?;
-                database.export_file(schema_file, data_file).await
+                database.export_to_file(schema_file, data_file).await
             })
             .await;
 
@@ -446,7 +446,7 @@ impl ServerDatabase {
     }
 
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    async fn export_file(&self, mut schema_file: File, data_file: File) -> Result {
+    async fn export_to_file(&self, mut schema_file: File, data_file: File) -> Result {
         let mut export_stream = self.connection.database_export(self.name.clone()).await?;
         let mut data_writer = BufWriter::new(data_file);
 

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -180,6 +180,10 @@ impl Database {
     pub async fn export_file(&self, schema_file_path: impl AsRef<Path>, data_file_path: impl AsRef<Path>) -> Result {
         let schema_file_path = schema_file_path.as_ref();
         let data_file_path = data_file_path.as_ref();
+        if schema_file_path == data_file_path {
+            return Err(Error::Migration(MigrationError::CannotExportToTheSameFile));
+        }
+
         let _ = try_creating_export_file(schema_file_path)?;
         if let Err(err) = try_creating_export_file(data_file_path) {
             let _ = std::fs::remove_file(schema_file_path);

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -163,11 +163,12 @@ impl Database {
     }
 
     /// Export a database into a schema definition and a data files saved to the disk.
+    /// This is a blocking operation and may take a significant amount of time depending on the database size.
     ///
     /// # Arguments
     ///
-    /// * `schema_file_path` — The path to the .tql schema definition file to be created
-    /// * `data_file_path` — The path to the .typedb data file to be created
+    /// * `schema_file_path` — The path to the schema definition file to be created
+    /// * `data_file_path` — The path to the data file to be created
     ///
     /// # Examples
     ///

--- a/rust/src/database/database.rs
+++ b/rust/src/database/database.rs
@@ -45,7 +45,7 @@ use crate::{
         Error, Result,
     },
     connection::{database::export_stream::DatabaseExportStream, server_connection::ServerConnection},
-    database::migration::{try_creating_export_file, write_export_file, DatabaseExportAnswer},
+    database::migration::{try_creating_export_file, DatabaseExportAnswer},
     driver::TypeDBDriver,
     error::{InternalError, MigrationError},
     resolve, Transaction, TransactionOptions, TransactionType,

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -158,23 +158,24 @@ impl DatabaseManager {
         Ok(())
     }
 
-    /// TODO
+    /// Create a database with the given name based on previously exported another database's data
     ///
     /// # Arguments
     ///
-    /// * `import_file` — The file to import data from
     /// * `name` — The name of the database to be created
+    /// * `schema` — The schema definition query string for the database
+    /// * `data_file_path` — The exported database file to import the data from
     ///
     /// # Examples
     ///
     /// ```rust
-    #[cfg_attr(feature = "sync", doc = "driver.databases().import(name);")]
-    #[cfg_attr(not(feature = "sync"), doc = "driver.databases().import(name).await;")]
+    #[cfg_attr(feature = "sync", doc = "driver.databases().import(name, schema, path);")]
+    #[cfg_attr(not(feature = "sync"), doc = "driver.databases().import(name, schema, path).await;")]
     /// ```
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub async fn import(&self, import_file_path: impl AsRef<Path>, name: impl Into<String>) -> Result {
+    pub async fn import(&self, name: impl Into<String>, schema: String, data_file_path: impl AsRef<Path>) -> Result {
         let name = name.into();
-        read_and_print_import_file(import_file_path)?;
+        read_and_print_import_file(data_file_path)?;
         Ok(())
     }
 

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -21,21 +21,18 @@
 use std::future::Future;
 use std::{
     collections::HashMap,
+    path::Path,
     sync::{Arc, RwLock},
 };
-use std::fs::File;
-use std::io::{BufReader, Read};
-use std::path::Path;
-use prost::bytes::Bytes;
-use prost::Message;
+
 use super::Database;
 use crate::{
     common::{address::Address, error::ConnectionError, Result},
     connection::server_connection::ServerConnection,
+    database::migration::read_and_print_import_file,
     info::DatabaseInfo,
     Error,
 };
-use typedb_protocol::Item;
 
 /// Provides access to all database management methods.
 #[derive(Debug)]
@@ -177,7 +174,7 @@ impl DatabaseManager {
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
     pub async fn import(&self, import_file_path: impl AsRef<Path>, name: impl Into<String>) -> Result {
         let name = name.into();
-        Self::read_and_print_items(import_file_path)?;
+        read_and_print_import_file(import_file_path)?;
         Ok(())
     }
 
@@ -223,46 +220,5 @@ impl DatabaseManager {
             }
         }
         Err(ConnectionError::ServerConnectionFailedWithError { error: error_buffer.join("\n") })?
-    }
-
-    fn read_and_print_items(path: impl AsRef<Path>) -> Result {
-        let file = File::open(path).expect("Expcted file"); // TODO: Convert to error
-        let mut reader = BufReader::new(file);
-
-        loop {
-            // Read length prefix as varint32
-            let length = match Self::decode_varint32(&mut reader) {
-                Ok(len) => len,
-                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
-                // Err(e) => return Err(Box::new(e)),
-                Err(e) => panic!("Flkaflkawlkfawlkflk {e:?}"),
-            };
-
-            let mut buffer = vec![0u8; length as usize];
-            reader.read_exact(&mut buffer)?;
-
-            let bytes = Bytes::from(buffer);
-            let item = Item::decode_length_delimited(bytes).expect("awkfaklflk");
-
-            println!("{:#?}", item);
-        }
-        println!("END!");
-        Ok(())
-    }
-
-    fn decode_varint32<R: Read>(reader: &mut R) -> std::io::Result<u32> {
-        let mut result = 0u32;
-        let mut shift = 0;
-        for _ in 0..5 {
-            let mut byte = [0u8];
-            reader.read_exact(&mut byte)?;
-            let b = byte[0];
-            result |= ((b & 0x7F) as u32) << shift;
-            if b & 0x80 == 0 {
-                return Ok(result);
-            }
-            shift += 7;
-        }
-        Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Varint too long"))
     }
 }

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -257,6 +257,9 @@ impl DatabaseManager {
                 Err(err) => error_buffer.push(format!("- {}: {}", server_id, err)),
             }
         }
+        // TODO: With this, every operation fails with
+        // [CXN03] Connection Error: Unable to connect to TypeDB server(s), received errors: .... <stacktrace>
+        // Which is quite confusing as it's not really connected to connection.
         Err(ConnectionError::ServerConnectionFailedWithError { error: error_buffer.join("\n") })?
     }
 }

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -193,9 +193,9 @@ impl DatabaseManager {
         let schema_ref: &str = schema.as_ref();
         let data_file_path = data_file_path.as_ref();
         self.run_failsafe(name, |server_connection, name| async move {
+            let file = try_opening_import_file(data_file_path)?;
             let mut import_stream = server_connection.import_database(name, schema_ref.to_string()).await?;
 
-            let file = try_opening_import_file(data_file_path)?;
             let mut item_buffer = Vec::with_capacity(ITEM_BATCH_SIZE);
             let mut read_item_iterator = ProtoMessageIterator::<Item, _>::new(BufReader::new(file));
 

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -176,11 +176,11 @@ impl DatabaseManager {
     /// # Examples
     ///
     /// ```rust
-    #[cfg_attr(feature = "sync", doc = "driver.databases().import_file(name, schema, data_path);")]
-    #[cfg_attr(not(feature = "sync"), doc = "driver.databases().import_file(name, schema, data_path).await;")]
+    #[cfg_attr(feature = "sync", doc = "driver.databases().import_from_file(name, schema, data_path);")]
+    #[cfg_attr(not(feature = "sync"), doc = "driver.databases().import_from_file(name, schema, data_path).await;")]
     /// ```
     #[cfg_attr(feature = "sync", maybe_async::must_be_sync)]
-    pub async fn import_file(
+    pub async fn import_from_file(
         &self,
         name: impl Into<String>,
         schema: impl Into<String>,

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -211,7 +211,7 @@ impl DatabaseManager {
                 import_stream.items(item_buffer)?;
             }
 
-            resolve! { import_stream.done() }
+            resolve!(import_stream.done())
         })
         .await
     }

--- a/rust/src/database/database_manager.rs
+++ b/rust/src/database/database_manager.rs
@@ -192,6 +192,7 @@ impl DatabaseManager {
         let schema: String = schema.into();
         let schema_ref: &str = schema.as_ref();
         let data_file_path = data_file_path.as_ref();
+
         self.run_failsafe(name, |server_connection, name| async move {
             let file = try_opening_import_file(data_file_path)?;
             let mut import_stream = server_connection.import_database(name, schema_ref.to_string()).await?;

--- a/rust/src/database/migration.rs
+++ b/rust/src/database/migration.rs
@@ -27,7 +27,7 @@ use prost::{
     bytes::{Buf, Bytes},
     Message,
 };
-use typedb_protocol::MigrationItem;
+use typedb_protocol::migration;
 
 use crate::{error::ConceptError, Error, Result};
 
@@ -48,7 +48,7 @@ pub(crate) fn read_and_print_import_file(path: impl AsRef<Path>) -> Result {
     Ok(())
 }
 
-pub(crate) fn read_and_print_import_file_inner(path: impl AsRef<Path>) -> Result<Vec<MigrationItem>> {
+pub(crate) fn read_and_print_import_file_inner(path: impl AsRef<Path>) -> Result<Vec<migration::Item>> {
     let file = File::open(path)?;
     let mut reader = BufReader::new(file);
     let mut buffer = Vec::new();
@@ -58,7 +58,7 @@ pub(crate) fn read_and_print_import_file_inner(path: impl AsRef<Path>) -> Result
 
     let mut cursor = std::io::Cursor::new(buffer);
     while cursor.has_remaining() {
-        let item = MigrationItem::decode_length_delimited(&mut cursor)
+        let item = migration::Item::decode_length_delimited(&mut cursor)
             .map_err(|_| Error::Concept(ConceptError::CannotDecodeImportedConcept))?;
         println!("{:#?}", item);
         items.push(item);
@@ -67,7 +67,7 @@ pub(crate) fn read_and_print_import_file_inner(path: impl AsRef<Path>) -> Result
     Ok(items)
 }
 
-pub(crate) fn write_export_file(path: impl AsRef<Path>, items: &[MigrationItem]) -> Result {
+pub(crate) fn write_export_file(path: impl AsRef<Path>, items: &[migration::Item]) -> Result {
     let file = OpenOptions::new().write(true).create_new(true).open(path.as_ref()).map_err(|_| {
         Error::Other(format!(
             "Cannot create export file '{}' as it already exists",

--- a/rust/src/database/migration.rs
+++ b/rust/src/database/migration.rs
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{BufReader, BufWriter, Read, Write},
+    path::{Path, PathBuf},
+};
+
+use prost::{
+    bytes::{Buf, Bytes},
+    Message,
+};
+use typedb_protocol::MigrationItem;
+
+use crate::{error::ConceptError, Error, Result};
+
+pub(crate) fn read_and_print_import_file(path: impl AsRef<Path>) -> Result {
+    let items = read_and_print_import_file_inner(path.as_ref())?;
+
+    // Temporary: test reverse-import
+    let temp_path = temp_path_from(path)?;
+    write_export_file(&temp_path, &items)?;
+    let reimport_items = read_and_print_import_file_inner(&temp_path)?;
+
+    if items == reimport_items {
+        println!("All is good!");
+    } else {
+        println!("ITEMS AND REIMPORT ITEMS ARE DIFFERENT: '{items:?}' VS '{reimport_items:?}'");
+    }
+
+    Ok(())
+}
+
+pub(crate) fn read_and_print_import_file_inner(path: impl AsRef<Path>) -> Result<Vec<MigrationItem>> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let mut buffer = Vec::new();
+    reader.read_to_end(&mut buffer)?;
+
+    let mut items = Vec::new();
+
+    let mut cursor = std::io::Cursor::new(buffer);
+    while cursor.has_remaining() {
+        let item = MigrationItem::decode_length_delimited(&mut cursor)
+            .map_err(|_| Error::Concept(ConceptError::CannotDecodeImportedConcept))?;
+        println!("{:#?}", item);
+        items.push(item);
+    }
+
+    Ok(items)
+}
+
+pub(crate) fn write_export_file(path: impl AsRef<Path>, items: &[MigrationItem]) -> Result {
+    let file = OpenOptions::new().write(true).create_new(true).open(path.as_ref()).map_err(|_| {
+        Error::Other(format!(
+            "Cannot create export file '{}' as it already exists",
+            path.as_ref().to_str().unwrap_or("")
+        ))
+    })?;
+    let mut writer = BufWriter::new(file);
+
+    for item in items {
+        let mut buf = Vec::new();
+        item.encode_length_delimited(&mut buf)
+            .map_err(|_| Error::Concept(ConceptError::CannotEncodeExportedConcept))?;
+        writer.write_all(&buf)?;
+    }
+
+    writer.flush()?;
+    Ok(())
+}
+
+fn temp_path_from(path: impl AsRef<Path>) -> Result<PathBuf> {
+    let path = path.as_ref();
+
+    let mut temp_path = match path.file_name() {
+        Some(name) => {
+            let mut name_os = name.to_os_string();
+            name_os.push(".temp");
+            path.with_file_name(name_os)
+        }
+        None => {
+            // Fallback: if there's no file name (e.g. just a directory), append ".temp"
+            let mut path_buf = path.to_path_buf();
+            path_buf.set_extension("temp");
+            path_buf
+        }
+    };
+
+    std::fs::remove_file(&temp_path)?;
+    Ok(temp_path)
+}

--- a/rust/src/database/migration.rs
+++ b/rust/src/database/migration.rs
@@ -116,15 +116,15 @@ impl<M: Message + Default, R: BufRead> Iterator for ProtoMessageIterator<M, R> {
     }
 }
 
-pub(crate) fn try_creating_export_file(path: impl AsRef<Path>) -> Result<File> {
-    try_opening_export_file(path, true)
+pub(crate) fn try_create_export_file(path: impl AsRef<Path>) -> Result<File> {
+    try_open_export_file(path, true)
 }
 
-pub(crate) fn try_opening_existing_export_file(path: impl AsRef<Path>) -> Result<File> {
-    try_opening_export_file(path, false)
+pub(crate) fn try_open_existing_export_file(path: impl AsRef<Path>) -> Result<File> {
+    try_open_export_file(path, false)
 }
 
-fn try_opening_export_file(path: impl AsRef<Path>, is_new: bool) -> Result<File> {
+fn try_open_export_file(path: impl AsRef<Path>, is_new: bool) -> Result<File> {
     OpenOptions::new().write(true).create_new(is_new).open(path.as_ref()).map_err(|source| {
         Error::Migration(MigrationError::CannotCreateExportFile {
             path: path.as_ref().to_str().unwrap_or("").to_string(),
@@ -133,7 +133,7 @@ fn try_opening_export_file(path: impl AsRef<Path>, is_new: bool) -> Result<File>
     })
 }
 
-pub(crate) fn try_opening_import_file(path: impl AsRef<Path>) -> Result<File> {
+pub(crate) fn try_open_import_file(path: impl AsRef<Path>) -> Result<File> {
     File::open(path.as_ref()).map_err(|source| {
         Error::Migration(MigrationError::CannotOpenImportFile {
             path: path.as_ref().to_str().unwrap_or("").to_string(),

--- a/rust/src/database/migration.rs
+++ b/rust/src/database/migration.rs
@@ -114,21 +114,6 @@ impl<M: Message + Default, R: BufRead> Iterator for ProtoMessageIterator<M, R> {
     }
 }
 
-pub(crate) fn write_export_file(path: impl AsRef<Path>, items: &[MigrationItemProto]) -> Result {
-    let file = try_creating_export_file(path)?;
-    let mut writer = BufWriter::new(file);
-
-    for item in items {
-        let mut buf = Vec::new();
-        item.encode_length_delimited(&mut buf)
-            .map_err(|_| Error::Migration(MigrationError::CannotEncodeExportedConcept))?;
-        writer.write_all(&buf)?;
-    }
-
-    writer.flush()?;
-    Ok(())
-}
-
 pub(crate) fn try_creating_export_file(path: impl AsRef<Path>) -> Result<File> {
     OpenOptions::new().write(true).create_new(true).open(path.as_ref()).map_err(|source| {
         Error::Migration(MigrationError::CannotCreateExportFile {

--- a/rust/src/database/migration.rs
+++ b/rust/src/database/migration.rs
@@ -23,18 +23,13 @@ use std::{
     fs::{File, OpenOptions},
     io::{BufRead, BufWriter, Read, Write},
     marker::PhantomData,
-    path::{Path},
+    path::Path,
 };
 
-use prost::{
-    Message,
-};
+use prost::Message;
 use typedb_protocol::migration::Item as MigrationItemProto;
 
-use crate::{
-    error::{MigrationError},
-    Error, Result,
-};
+use crate::{error::MigrationError, Error, Result};
 
 #[derive(Debug)]
 pub(crate) enum DatabaseExportAnswer {

--- a/rust/src/database/mod.rs
+++ b/rust/src/database/mod.rs
@@ -21,3 +21,4 @@ pub use self::{database::Database, database_manager::DatabaseManager};
 
 mod database;
 mod database_manager;
+mod migration;

--- a/rust/src/database/mod.rs
+++ b/rust/src/database/mod.rs
@@ -21,4 +21,4 @@ pub use self::{database::Database, database_manager::DatabaseManager};
 
 mod database;
 mod database_manager;
-mod migration;
+pub(crate) mod migration;

--- a/rust/tests/BUILD
+++ b/rust/tests/BUILD
@@ -26,7 +26,11 @@ rustfmt_test(
         "//rust/tests/behaviour/steps:steps",
         "//rust/tests/behaviour/connection:test_database",
         "//rust/tests/behaviour/connection:test_transaction",
-        "//rust/tests/behaviour/driver:test_driver",
+        "//rust/tests/behaviour/driver:test_concept",
+        "//rust/tests/behaviour/driver:test_connection",
+        "//rust/tests/behaviour/driver:test_migration",
+        "//rust/tests/behaviour/driver:test_query",
+        "//rust/tests/behaviour/driver:test_user",
 
         "//rust/tests/integration:test_example",
     ],

--- a/rust/tests/behaviour/driver/BUILD
+++ b/rust/tests/behaviour/driver/BUILD
@@ -21,9 +21,27 @@ load("//rust/tests/behaviour:rules.bzl", "rust_behaviour_test")
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 rust_behaviour_test(
-    name = "test_driver",
-    srcs = ["driver.rs"],
-    data = ["@typedb_behaviour//driver:driver.feature"],
+    name = "test_concept",
+    srcs = ["concept.rs"],
+    data = ["@typedb_behaviour//driver:concept.feature"],
+)
+
+rust_behaviour_test(
+    name = "test_connection",
+    srcs = ["connection.rs"],
+    data = ["@typedb_behaviour//driver:connection.feature"],
+)
+
+rust_behaviour_test(
+    name = "test_migration",
+    srcs = ["migration.rs"],
+    data = ["@typedb_behaviour//driver:migration.feature"],
+)
+
+rust_behaviour_test(
+    name = "test_query",
+    srcs = ["query.rs"],
+    data = ["@typedb_behaviour//driver:query.feature"],
 )
 
 rust_behaviour_test(

--- a/rust/tests/behaviour/driver/concept.rs
+++ b/rust/tests/behaviour/driver/concept.rs
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use config::is_cluster;
+use serial_test::serial;
+use steps::Context;
+
+#[tokio::test]
+#[serial]
+async fn test() {
+    // Bazel specific path: when running the test in bazel, the external data from
+    // @typedb_behaviour is stored in a directory that is a sibling to
+    // the working directory.
+    #[cfg(feature = "bazel")]
+    let path = "../typedb_behaviour/driver/concept.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "../../typedb-behaviour/driver/concept.feature";
+
+    assert!(Context::test(path, is_cluster()).await);
+}

--- a/rust/tests/behaviour/driver/connection.rs
+++ b/rust/tests/behaviour/driver/connection.rs
@@ -28,10 +28,10 @@ async fn test() {
     // @typedb_behaviour is stored in a directory that is a sibling to
     // the working directory.
     #[cfg(feature = "bazel")]
-    let path = "../typedb_behaviour/driver/driver.feature";
+    let path = "../typedb_behaviour/driver/connection.feature";
 
     #[cfg(not(feature = "bazel"))]
-    let path = "../../typedb-behaviour/driver/driver.feature";
+    let path = "../../typedb-behaviour/driver/connection.feature";
 
     assert!(Context::test(path, is_cluster()).await);
 }

--- a/rust/tests/behaviour/driver/migration.rs
+++ b/rust/tests/behaviour/driver/migration.rs
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use config::is_cluster;
+use serial_test::serial;
+use steps::Context;
+
+#[tokio::test]
+#[serial]
+async fn test() {
+    // Bazel specific path: when running the test in bazel, the external data from
+    // @typedb_behaviour is stored in a directory that is a sibling to
+    // the working directory.
+    #[cfg(feature = "bazel")]
+    let path = "../typedb_behaviour/driver/migration.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "../../typedb-behaviour/driver/migration.feature";
+
+    assert!(Context::test(path, is_cluster()).await);
+}

--- a/rust/tests/behaviour/driver/query.rs
+++ b/rust/tests/behaviour/driver/query.rs
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use config::is_cluster;
+use serial_test::serial;
+use steps::Context;
+
+#[tokio::test]
+#[serial]
+async fn test() {
+    // Bazel specific path: when running the test in bazel, the external data from
+    // @typedb_behaviour is stored in a directory that is a sibling to
+    // the working directory.
+    #[cfg(feature = "bazel")]
+    let path = "../typedb_behaviour/driver/query.feature";
+
+    #[cfg(not(feature = "bazel"))]
+    let path = "../../typedb-behaviour/driver/query.feature";
+
+    assert!(Context::test(path, is_cluster()).await);
+}

--- a/rust/tests/behaviour/steps/Cargo.toml
+++ b/rust/tests/behaviour/steps/Cargo.toml
@@ -16,7 +16,7 @@ features = {}
 
 	[dependencies.tokio]
 		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.44.2"
+		version = "1.45.0"
 		default-features = false
 
 	[dependencies.smol]
@@ -56,7 +56,7 @@ features = {}
 
 	[dependencies.chrono]
 		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.40"
+		version = "0.4.41"
 		default-features = false
 
 	[dependencies.uuid]

--- a/rust/tests/behaviour/steps/connection/database.rs
+++ b/rust/tests/behaviour/steps/connection/database.rs
@@ -51,7 +51,7 @@ async fn database_type_schema(driver: &TypeDBDriver, name: &str) -> String {
 }
 
 async fn has_database(driver: &TypeDBDriver, name: &str) -> bool {
-    driver.databases().contains(name.clone()).await.unwrap()
+    driver.databases().contains(name).await.unwrap()
 }
 
 #[apply(generic_step)]

--- a/rust/tests/behaviour/steps/connection/database.rs
+++ b/rust/tests/behaviour/steps/connection/database.rs
@@ -83,7 +83,7 @@ async fn import_database(
 ) {
     let data_file_path = context.get_full_file_path(&data_file_name);
     let databases = context.driver.as_ref().unwrap().databases();
-    may_error.check(databases.import_file(name, schema, data_file_path).await);
+    may_error.check(databases.import_from_file(name, schema, data_file_path).await);
 }
 
 #[apply(generic_step)]
@@ -241,7 +241,7 @@ async fn connection_get_database_export_to_schema_file_data_file(
     let database = context.driver.as_ref().unwrap().databases().get(name).await.expect("Expected database");
     let schema_file_path = context.get_full_file_path(&schema_file_name);
     let data_file_path = context.get_full_file_path(&data_file_name);
-    may_error.check(database.export_file(schema_file_path, data_file_path).await);
+    may_error.check(database.export_to_file(schema_file_path, data_file_path).await);
 }
 
 #[apply(generic_step)]

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -139,7 +139,6 @@ impl Context {
     const DEFAULT_ADDRESS: &'static str = "127.0.0.1:1729";
     // TODO when multiple nodes are available: "127.0.0.1:11729", "127.0.0.1:21729", "127.0.0.1:31729"
     const DEFAULT_CLUSTER_ADDRESSES: [&'static str; 1] = ["127.0.0.1:1729"];
-    const DEFAULT_DATABASE: &'static str = "test";
     const ADMIN_USERNAME: &'static str = "admin";
     const ADMIN_PASSWORD: &'static str = "password";
     const STEP_REATTEMPT_SLEEP: Duration = Duration::from_millis(250);

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -42,7 +42,10 @@ use typedb_driver::{
     TypeDBDriver,
 };
 
-use crate::params::QueryAnswerType;
+use crate::{
+    params::QueryAnswerType,
+    util::{create_temp_dir, TempDir},
+};
 
 mod connection;
 mod params;
@@ -516,8 +519,6 @@ macro_rules! in_background {
     };
 }
 pub(crate) use in_background;
-
-use crate::util::{create_temp_dir, TempDir};
 
 // Most of the drivers are error-driven, while the Rust driver returns Option::None in many cases instead.
 // These "fake" errors allow us to emulate error messages for generalised driver BDDs,

--- a/rust/tests/behaviour/steps/lib.rs
+++ b/rust/tests/behaviour/steps/lib.rs
@@ -242,14 +242,12 @@ impl Context {
     }
 
     pub async fn cleanup_users(&mut self) {
+        let users = self.driver.as_ref().expect("Expected driver").users();
         try_join_all(
-            self.driver
-                .as_ref()
-                .unwrap()
-                .users()
+            users
                 .all()
                 .await
-                .unwrap()
+                .expect("Expected all users")
                 .into_iter()
                 .filter(|user| user.name != Context::ADMIN_USERNAME)
                 .map(|user| user.delete()),
@@ -257,8 +255,14 @@ impl Context {
         .await
         .expect("Expected users cleanup");
 
-        // TODO: Return
-        // self.driver.as_ref().unwrap().users().set_password(Context::ADMIN_USERNAME, Context::ADMIN_PASSWORD).await.unwrap();
+        users
+            .get(Context::ADMIN_USERNAME)
+            .await
+            .expect("Expected admin user get")
+            .expect("Expected admin user")
+            .update_password(Context::ADMIN_PASSWORD)
+            .await
+            .expect("Expected password update");
     }
 
     pub async fn cleanup_answers(&mut self) {

--- a/rust/tests/behaviour/steps/params.rs
+++ b/rust/tests/behaviour/steps/params.rs
@@ -456,7 +456,7 @@ impl ExistsOrDoesnt {
     pub fn check_bool(&self, contains: bool, message: &str) {
         match self {
             ExistsOrDoesnt::Exists => assert!(contains, "Expected to exist, not found: {message}"),
-            ExistsOrDoesnt::DoesNotExist => assert!(!contains, "Expected not to exist, but not found: {message}"),
+            ExistsOrDoesnt::DoesNotExist => assert!(!contains, "Expected not to exist, but found: {message}"),
         }
     }
 }

--- a/rust/tests/behaviour/steps/params.rs
+++ b/rust/tests/behaviour/steps/params.rs
@@ -430,6 +430,49 @@ impl FromStr for ContainsOrDoesnt {
 }
 
 #[derive(Debug, Parameter)]
+#[param(name = "exists_or_doesnt", regex = "(exists|does not exist)")]
+pub(crate) enum ExistsOrDoesnt {
+    Exists,
+    DoesNotExist,
+}
+
+impl ExistsOrDoesnt {
+    pub fn check<T: fmt::Debug>(&self, scrutinee: &Option<T>, message: &str) {
+        match (self, scrutinee) {
+            (Self::Exists, Some(_)) | (Self::DoesNotExist, None) => (),
+            (Self::Exists, None) => panic!("Expected to exist, not found: {message}"),
+            (Self::DoesNotExist, Some(value)) => panic!("Expected not to exist, {value:?} is found: {message}"),
+        }
+    }
+
+    pub fn check_result<T: fmt::Debug, E>(&self, scrutinee: &Result<T, E>, message: &str) {
+        let option = match scrutinee {
+            Ok(result) => Some(result),
+            Err(_) => None,
+        };
+        self.check(&option, message)
+    }
+
+    pub fn check_bool(&self, contains: bool, message: &str) {
+        match self {
+            ExistsOrDoesnt::Exists => assert!(contains, "Expected to exist, not found: {message}"),
+            ExistsOrDoesnt::DoesNotExist => assert!(!contains, "Expected not to exist, but not found: {message}"),
+        }
+    }
+}
+
+impl FromStr for ExistsOrDoesnt {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "exists" => Self::Exists,
+            "does not exist" => Self::DoesNotExist,
+            invalid => return Err(format!("Invalid `ExistsOrDoesnt`: {invalid}")),
+        })
+    }
+}
+
+#[derive(Debug, Parameter)]
 #[param(name = "is_by_var_index", regex = "(| by index of variable)")]
 pub(crate) enum IsByVarIndex {
     Is,

--- a/rust/tests/behaviour/steps/util.rs
+++ b/rust/tests/behaviour/steps/util.rs
@@ -210,26 +210,16 @@ async fn file_exists(context: &mut Context, file_name: String, exists_or_doesnt:
 }
 
 #[apply(generic_step)]
-#[step(expr = r"file\({word}\) is empty")]
-async fn file_is_empty(context: &mut Context, file_name: String) {
-    let expected = params::Boolean::True;
+#[step(expr = r"file\({word}\) {is_or_not} empty")]
+async fn file_is_empty(context: &mut Context, file_name: String, is_or_not: params::IsOrNot) {
     let path = context.get_full_file_path(&file_name);
-    check_boolean!(expected, read_file(path).is_empty());
-}
-
-#[apply(generic_step)]
-#[step(expr = r"file\({word}\) is not empty")]
-async fn file_is_not_empty(context: &mut Context, file_name: String) {
-    let expected = params::Boolean::False;
-    let path = context.get_full_file_path(&file_name);
-    check_boolean!(expected, read_file(path).is_empty());
+    is_or_not.check(read_file(path).is_empty());
 }
 
 #[apply(generic_step)]
 #[step(expr = r"file\({word}\) write:")]
 async fn file_write(context: &mut Context, file_name: String, step: &Step) {
     let data = step.docstring.as_ref().unwrap().trim().to_string();
-    let expected = params::Boolean::True;
     let path = context.get_full_file_path(&file_name);
     write_file(path, data.as_bytes());
 }


### PR DESCRIPTION
## Usage and product changes
Introduce interfaces to export databases into schema definition and data files and to import databases using these files. Database import supports files exported from both TypeDB 2.x and TypeDB 3.x.

Both operations are blocking and may take a significant amount of time to execute for large databases. Use parallel connections to continue operating with the server and its other databases.

Usage examples in Rust:
```rust
// export
let db = driver.databases().get(db_name).await.unwrap();
db.export_to_file(schema_file_path, data_file_path).await.unwrap();

// import
let schema = read_to_string(schema_file_path).unwrap();
driver.databases().import_from_file(db_name2, schema, data_file_path).await.unwrap();
```

Usage examples in Python:
```py
# export
database = driver.databases.get(db_name)
database.export_to_file(schema_file_path, data_file_path)

# import
with open(schema_file_path, 'r', encoding='utf-8') as f:
    schema = f.read()
driver.databases.import_from_file(db_name2, schema, data_file_path)
```

Usage examples in Java:
```java
// export
Database database = driver.databases().get(dbName);
database.exportToFile(schemaFilePath, dataFilePath);

// import
String schema = Files.readString(Path.of(schemaFilePath));
driver.databases().importFromFile(dbName2, schema, dataFilePath);
```

## Implementation
Implemented the updated [protocol](https://github.com/typedb/typedb-protocol/pull/224).

As both operations work with streaming, the implementation is similar to transactions. The behavior is split into the file processing logic and networking (specialized for sync and async modes). The exposed interfaces present only the file-based versions, but additional interfaces for direct work with streams can be presented in future updates.

In Rust, paths are accepted as Rust `Path`s. In other languages working through C interfaces, it's pure strings for C layer transmission.

### Database export 
Implemented through the `database` interface and accepts two target files for export. Does not require a specific format of naming (so it's necessarily `.typeql` or `.typedb`. If any of the target files already exist, an error is returned.

The export operation consists of these steps:
* prepare the output files
* open a unidirectional GRPC stream from the server to the client
* "block" on server response listening until an error or a "done" is received (blocking is implemented through a loop which resolves a `listen` promise presented by the network layer)
* if there is a schema message, write it to the schema file and flush it right away
* if there is a data items message, encode the items and write them to the data file 
* in case of an error, the output files are deleted (we own them as we create them at the beginning)

The network layer is basically just a task listening for the GRPC stream and transmitting the converted messages to the processing loop.

### Database import
Implemented through the `database_manager` interface and accepts a database name, a schema definition query string (can be read from the exported file), and an exported data file. No naming requirements as well. 

The import operation consists of these steps:
* open the input file
* open a bidirectional GRPC stream between the server and the client, send the initial request with the database's name and schema
* eagerly start reading and decoding data items from the input file one by one, storing up to 250 items in the buffer (this number can be easily changed)
* once the buffer is full, attempt items sending operation: this operation will check a potential early error signal from the server and then send the batch, returning to processing the rest of the file
* once the file is read, send a "done" message and block until the server responds with either an error or its "done" message

The network layer consists of a blocking task for client-side requests and a listening task waiting for a one-shot signal from the server (either an error or a "done" message). Errors can be received at any time of processing, while "done" is expected only after a client-side "done" request. When a response is received, either an async or a sync sink receives this message, which should be checked before any client-side network operations to ensure proper interruption. 