### PR TITLE
Handle "Unexpected response type for remote procedure call: Close" on query stream opening

### DIFF
--- a/rust/src/connection/transaction_stream.rs
+++ b/rust/src/connection/transaction_stream.rs
@@ -166,7 +166,7 @@ impl TransactionStream {
     fn query_stream(&self, req: QueryRequest) -> Result<impl Stream<Item = Result<QueryResponse>>> {
         Ok(self.stream(TransactionRequest::Query(req))?.map(|response| match response {
             Ok(TransactionResponse::Query(res)) => Ok(res),
-            Ok(TransactionResponse::Close) => Err(ConnectionError::QueryStreamNoResponse.into()),
+            Ok(TransactionResponse::Close) => Err(ConnectionError::TransactionIsClosed.into()),
             Ok(other) => Err(InternalError::UnexpectedResponseType { response_type: format!("{other:?}") }.into()),
             Err(err) => Err(err),
         }))

--- a/rust/src/connection/transaction_stream.rs
+++ b/rust/src/connection/transaction_stream.rs
@@ -166,6 +166,7 @@ impl TransactionStream {
     fn query_stream(&self, req: QueryRequest) -> Result<impl Stream<Item = Result<QueryResponse>>> {
         Ok(self.stream(TransactionRequest::Query(req))?.map(|response| match response {
             Ok(TransactionResponse::Query(res)) => Ok(res),
+            Ok(TransactionResponse::Close) => Err(ConnectionError::QueryStreamNoResponse.into()),
             Ok(other) => Err(InternalError::UnexpectedResponseType { response_type: format!("{other:?}") }.into()),
             Err(err) => Err(err),
         }))


### PR DESCRIPTION
## Usage and product changes
Fix a rare `InternalError` returned by mistake when a client sends a query request while the transaction is being closed. Now, an expected "The transaction is closed and no further operation is allowed." error is returned instead.

## Implementation
We [faced](https://discord.com/channels/665254494820368395/1301180015173435454/1379414371402256454) this error when running a huge number of queries against a server that eventually went to sleep. Presumably, this state led to the GRPC stream interruption, and it "gracefully" stopped without errors. However, the driver's code did not expect that it could happen right after the stream opening request, while it should be considered a normal situation.

The source code where `Close` responses are generated:
```
    async fn listen_loop(
        mut grpc_source: Streaming<transaction::Server>,
        collector: ResponseCollector,
        shutdown_sink: UnboundedSender<()>,
    ) {
        loop {
            match grpc_source.next().await {
                Some(Ok(message)) => collector.collect(message).await,
                Some(Err(status)) => break collector.close_with_error(status.into()).await,
                None => break collector.close().await, // <---- here, the stream has ended
            }
        }
        shutdown_sink.send(()).ok();
    }

async fn close(self) {
  self.is_open.store(false);
  let mut listeners = std::mem::take(&mut *self.callbacks.write().unwrap());
  for (_, listener) in listeners.drain() {
      listener.finish(Ok(TransactionResponse::Close)); // <--- here, the only `Close` response is sent
  }
  // ....
}
```