### PR TITLE
Rename docs antora module

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,2 +1,2 @@
-name: api-ref
+name: external-typedb-driver
 version: 3.x

--- a/docs/modules/ROOT/partials/c/api-reference.adoc
+++ b/docs/modules/ROOT/partials/c/api-reference.adoc
@@ -2,85 +2,85 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}@api-ref::partial$c/connection/connection.adoc[]
+include::{page-version}::partial$c/connection/connection.adoc[]
 
-include::{page-version}@api-ref::partial$c/connection/credentials.adoc[]
+include::{page-version}::partial$c/connection/credentials.adoc[]
 
-include::{page-version}@api-ref::partial$c/connection/database.adoc[]
+include::{page-version}::partial$c/connection/database.adoc[]
 
-include::{page-version}@api-ref::partial$c/connection/replica.adoc[]
+include::{page-version}::partial$c/connection/replica.adoc[]
 
-include::{page-version}@api-ref::partial$c/connection/user.adoc[]
+include::{page-version}::partial$c/connection/user.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-version}@api-ref::partial$c/session/session.adoc[]
+include::{page-version}::partial$c/session/session.adoc[]
 
-include::{page-version}@api-ref::partial$c/session/options.adoc[]
+include::{page-version}::partial$c/session/options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}@api-ref::partial$c/transaction/transaction.adoc[]
+include::{page-version}::partial$c/transaction/transaction.adoc[]
 
-include::{page-version}@api-ref::partial$c/transaction/query.adoc[]
+include::{page-version}::partial$c/transaction/query.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}@api-ref::partial$c/answer/conceptmap.adoc[]
+include::{page-version}::partial$c/answer/conceptmap.adoc[]
 
-include::{page-version}@api-ref::partial$c/answer/valuegroup.adoc[]
+include::{page-version}::partial$c/answer/valuegroup.adoc[]
 
-include::{page-version}@api-ref::partial$c/answer/primitives.adoc[]
+include::{page-version}::partial$c/answer/primitives.adoc[]
 
-include::{page-version}@api-ref::partial$c/answer/explanation.adoc[]
+include::{page-version}::partial$c/answer/explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}@api-ref::partial$c/concept/concept.adoc[]
+include::{page-version}::partial$c/concept/concept.adoc[]
 
-include::{page-version}@api-ref::partial$c/concept/thing.adoc[]
+include::{page-version}::partial$c/concept/thing.adoc[]
 
-include::{page-version}@api-ref::partial$c/concept/entity.adoc[]
+include::{page-version}::partial$c/concept/entity.adoc[]
 
-include::{page-version}@api-ref::partial$c/concept/attribute.adoc[]
+include::{page-version}::partial$c/concept/attribute.adoc[]
 
-include::{page-version}@api-ref::partial$c/concept/relation.adoc[]
+include::{page-version}::partial$c/concept/relation.adoc[]
 
-include::{page-version}@api-ref::partial$c/concept/roleplayer.adoc[]
+include::{page-version}::partial$c/concept/roleplayer.adoc[]
 
-include::{page-version}@api-ref::partial$c/concept/value.adoc[]
+include::{page-version}::partial$c/concept/value.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}@api-ref::partial$c/schema/entitytype.adoc[]
+include::{page-version}::partial$c/schema/entitytype.adoc[]
 
-include::{page-version}@api-ref::partial$c/schema/attributetype.adoc[]
+include::{page-version}::partial$c/schema/attributetype.adoc[]
 
-include::{page-version}@api-ref::partial$c/schema/relationtype.adoc[]
+include::{page-version}::partial$c/schema/relationtype.adoc[]
 
-include::{page-version}@api-ref::partial$c/schema/roletype.adoc[]
+include::{page-version}::partial$c/schema/roletype.adoc[]
 
-include::{page-version}@api-ref::partial$c/schema/annotation.adoc[]
+include::{page-version}::partial$c/schema/annotation.adoc[]
 
-include::{page-version}@api-ref::partial$c/schema/transitivity.adoc[]
+include::{page-version}::partial$c/schema/transitivity.adoc[]
 
-include::{page-version}@api-ref::partial$c/schema/valuetype.adoc[]
+include::{page-version}::partial$c/schema/valuetype.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-version}@api-ref::partial$c/logic/logic.adoc[]
+include::{page-version}::partial$c/logic/logic.adoc[]
 
-include::{page-version}@api-ref::partial$c/logic/rule.adoc[]
+include::{page-version}::partial$c/logic/rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}@api-ref::partial$c/errors/error.adoc[]
+include::{page-version}::partial$c/errors/error.adoc[]
 
-include::{page-version}@api-ref::partial$c/errors/schemaexception.adoc[]
+include::{page-version}::partial$c/errors/schemaexception.adoc[]

--- a/docs/modules/ROOT/partials/c/api-reference.adoc
+++ b/docs/modules/ROOT/partials/c/api-reference.adoc
@@ -2,85 +2,85 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}::partial$c/connection/connection.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/connection/connection.adoc[]
 
-include::{page-version}::partial$c/connection/credentials.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/connection/credentials.adoc[]
 
-include::{page-version}::partial$c/connection/database.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/connection/database.adoc[]
 
-include::{page-version}::partial$c/connection/replica.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/connection/replica.adoc[]
 
-include::{page-version}::partial$c/connection/user.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/connection/user.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-version}::partial$c/session/session.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/session/session.adoc[]
 
-include::{page-version}::partial$c/session/options.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/session/options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}::partial$c/transaction/transaction.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/transaction/transaction.adoc[]
 
-include::{page-version}::partial$c/transaction/query.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/transaction/query.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}::partial$c/answer/conceptmap.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/answer/conceptmap.adoc[]
 
-include::{page-version}::partial$c/answer/valuegroup.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/answer/valuegroup.adoc[]
 
-include::{page-version}::partial$c/answer/primitives.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/answer/primitives.adoc[]
 
-include::{page-version}::partial$c/answer/explanation.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/answer/explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}::partial$c/concept/concept.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/concept/concept.adoc[]
 
-include::{page-version}::partial$c/concept/thing.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/concept/thing.adoc[]
 
-include::{page-version}::partial$c/concept/entity.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/concept/entity.adoc[]
 
-include::{page-version}::partial$c/concept/attribute.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/concept/attribute.adoc[]
 
-include::{page-version}::partial$c/concept/relation.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/concept/relation.adoc[]
 
-include::{page-version}::partial$c/concept/roleplayer.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/concept/roleplayer.adoc[]
 
-include::{page-version}::partial$c/concept/value.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/concept/value.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}::partial$c/schema/entitytype.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/schema/entitytype.adoc[]
 
-include::{page-version}::partial$c/schema/attributetype.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/schema/attributetype.adoc[]
 
-include::{page-version}::partial$c/schema/relationtype.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/schema/relationtype.adoc[]
 
-include::{page-version}::partial$c/schema/roletype.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/schema/roletype.adoc[]
 
-include::{page-version}::partial$c/schema/annotation.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/schema/annotation.adoc[]
 
-include::{page-version}::partial$c/schema/transitivity.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/schema/transitivity.adoc[]
 
-include::{page-version}::partial$c/schema/valuetype.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/schema/valuetype.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-version}::partial$c/logic/logic.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/logic/logic.adoc[]
 
-include::{page-version}::partial$c/logic/rule.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/logic/rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}::partial$c/errors/error.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/errors/error.adoc[]
 
-include::{page-version}::partial$c/errors/schemaexception.adoc[]
+include::{page-version}@external-typedb-driver::partial$c/errors/schemaexception.adoc[]

--- a/docs/modules/ROOT/partials/cpp/api-reference.adoc
+++ b/docs/modules/ROOT/partials/cpp/api-reference.adoc
@@ -2,122 +2,122 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}@api-ref::partial$cpp/connection/Driver.adoc[]
+include::{page-version}::partial$cpp/connection/Driver.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/connection/Credential.adoc[]
+include::{page-version}::partial$cpp/connection/Credential.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/connection/DatabaseManager.adoc[]
+include::{page-version}::partial$cpp/connection/DatabaseManager.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/connection/Database.adoc[]
+include::{page-version}::partial$cpp/connection/Database.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/connection/ReplicaInfo.adoc[]
+include::{page-version}::partial$cpp/connection/ReplicaInfo.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/connection/UserManager.adoc[]
+include::{page-version}::partial$cpp/connection/UserManager.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/connection/User.adoc[]
+include::{page-version}::partial$cpp/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-version}@api-ref::partial$cpp/session/Session.adoc[]
+include::{page-version}::partial$cpp/session/Session.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/session/SessionType.adoc[]
+include::{page-version}::partial$cpp/session/SessionType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/session/Options.adoc[]
+include::{page-version}::partial$cpp/session/Options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}@api-ref::partial$cpp/transaction/Transaction.adoc[]
+include::{page-version}::partial$cpp/transaction/Transaction.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/transaction/TransactionType.adoc[]
+include::{page-version}::partial$cpp/transaction/TransactionType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/transaction/QueryManager.adoc[]
+include::{page-version}::partial$cpp/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}@api-ref::partial$cpp/answer/ConceptMapGroup.adoc[]
+include::{page-version}::partial$cpp/answer/ConceptMapGroup.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/ConceptMap.adoc[]
+include::{page-version}::partial$cpp/answer/ConceptMap.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/ValueGroup.adoc[]
+include::{page-version}::partial$cpp/answer/ValueGroup.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/JSON.adoc[]
+include::{page-version}::partial$cpp/answer/JSON.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/JSONType.adoc[]
+include::{page-version}::partial$cpp/answer/JSONType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/OwnerAttributePair.adoc[]
+include::{page-version}::partial$cpp/answer/OwnerAttributePair.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/Explainables.adoc[]
+include::{page-version}::partial$cpp/answer/Explainables.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/Explainable.adoc[]
+include::{page-version}::partial$cpp/answer/Explainable.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/Explanation.adoc[]
+include::{page-version}::partial$cpp/answer/Explanation.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/Future.adoc[]
+include::{page-version}::partial$cpp/answer/Future.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/Iterable.adoc[]
+include::{page-version}::partial$cpp/answer/Iterable.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/Iterator.adoc[]
+include::{page-version}::partial$cpp/answer/Iterator.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/answer/typedefs.adoc[]
+include::{page-version}::partial$cpp/answer/typedefs.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}@api-ref::partial$cpp/concept/ConceptManager.adoc[]
+include::{page-version}::partial$cpp/concept/ConceptManager.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/concept/Concept.adoc[]
+include::{page-version}::partial$cpp/concept/Concept.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/concept/ConceptType.adoc[]
+include::{page-version}::partial$cpp/concept/ConceptType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/concept/Transitivity.adoc[]
+include::{page-version}::partial$cpp/concept/Transitivity.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}@api-ref::partial$cpp/schema/Type.adoc[]
+include::{page-version}::partial$cpp/schema/Type.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/schema/ThingType.adoc[]
+include::{page-version}::partial$cpp/schema/ThingType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/schema/EntityType.adoc[]
+include::{page-version}::partial$cpp/schema/EntityType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/schema/RelationType.adoc[]
+include::{page-version}::partial$cpp/schema/RelationType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/schema/RoleType.adoc[]
+include::{page-version}::partial$cpp/schema/RoleType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/schema/AttributeType.adoc[]
+include::{page-version}::partial$cpp/schema/AttributeType.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/schema/Annotation.adoc[]
+include::{page-version}::partial$cpp/schema/Annotation.adoc[]
 
-//include::{page-version}@api-ref::partial$cpp/schema/Transitivity.adoc[]
+//include::{page-version}::partial$cpp/schema/Transitivity.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/schema/ValueType.adoc[]
+include::{page-version}::partial$cpp/schema/ValueType.adoc[]
 
-//include::{page-version}@api-ref::partial$cpp/schema/ScopedLabel.adoc[]
+//include::{page-version}::partial$cpp/schema/ScopedLabel.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}@api-ref::partial$cpp/data/Thing.adoc[]
+include::{page-version}::partial$cpp/data/Thing.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/data/Entity.adoc[]
+include::{page-version}::partial$cpp/data/Entity.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/data/Relation.adoc[]
+include::{page-version}::partial$cpp/data/Relation.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/data/Attribute.adoc[]
+include::{page-version}::partial$cpp/data/Attribute.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/data/Value.adoc[]
+include::{page-version}::partial$cpp/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-version}@api-ref::partial$cpp/logic/LogicManager.adoc[]
+include::{page-version}::partial$cpp/logic/LogicManager.adoc[]
 
-include::{page-version}@api-ref::partial$cpp/logic/Rule.adoc[]
+include::{page-version}::partial$cpp/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}@api-ref::partial$cpp/errors/DriverException.adoc[]
+include::{page-version}::partial$cpp/errors/DriverException.adoc[]

--- a/docs/modules/ROOT/partials/cpp/api-reference.adoc
+++ b/docs/modules/ROOT/partials/cpp/api-reference.adoc
@@ -2,122 +2,122 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}::partial$cpp/connection/Driver.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/connection/Driver.adoc[]
 
-include::{page-version}::partial$cpp/connection/Credential.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/connection/Credential.adoc[]
 
-include::{page-version}::partial$cpp/connection/DatabaseManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/connection/DatabaseManager.adoc[]
 
-include::{page-version}::partial$cpp/connection/Database.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/connection/Database.adoc[]
 
-include::{page-version}::partial$cpp/connection/ReplicaInfo.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/connection/ReplicaInfo.adoc[]
 
-include::{page-version}::partial$cpp/connection/UserManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/connection/UserManager.adoc[]
 
-include::{page-version}::partial$cpp/connection/User.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-version}::partial$cpp/session/Session.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/session/Session.adoc[]
 
-include::{page-version}::partial$cpp/session/SessionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/session/SessionType.adoc[]
 
-include::{page-version}::partial$cpp/session/Options.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/session/Options.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}::partial$cpp/transaction/Transaction.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/transaction/Transaction.adoc[]
 
-include::{page-version}::partial$cpp/transaction/TransactionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/transaction/TransactionType.adoc[]
 
-include::{page-version}::partial$cpp/transaction/QueryManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}::partial$cpp/answer/ConceptMapGroup.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/ConceptMapGroup.adoc[]
 
-include::{page-version}::partial$cpp/answer/ConceptMap.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/ConceptMap.adoc[]
 
-include::{page-version}::partial$cpp/answer/ValueGroup.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/ValueGroup.adoc[]
 
-include::{page-version}::partial$cpp/answer/JSON.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/JSON.adoc[]
 
-include::{page-version}::partial$cpp/answer/JSONType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/JSONType.adoc[]
 
-include::{page-version}::partial$cpp/answer/OwnerAttributePair.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/OwnerAttributePair.adoc[]
 
-include::{page-version}::partial$cpp/answer/Explainables.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/Explainables.adoc[]
 
-include::{page-version}::partial$cpp/answer/Explainable.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/Explainable.adoc[]
 
-include::{page-version}::partial$cpp/answer/Explanation.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/Explanation.adoc[]
 
-include::{page-version}::partial$cpp/answer/Future.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/Future.adoc[]
 
-include::{page-version}::partial$cpp/answer/Iterable.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/Iterable.adoc[]
 
-include::{page-version}::partial$cpp/answer/Iterator.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/Iterator.adoc[]
 
-include::{page-version}::partial$cpp/answer/typedefs.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/answer/typedefs.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}::partial$cpp/concept/ConceptManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/concept/ConceptManager.adoc[]
 
-include::{page-version}::partial$cpp/concept/Concept.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/concept/Concept.adoc[]
 
-include::{page-version}::partial$cpp/concept/ConceptType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/concept/ConceptType.adoc[]
 
-include::{page-version}::partial$cpp/concept/Transitivity.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/concept/Transitivity.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}::partial$cpp/schema/Type.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/schema/Type.adoc[]
 
-include::{page-version}::partial$cpp/schema/ThingType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/schema/ThingType.adoc[]
 
-include::{page-version}::partial$cpp/schema/EntityType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/schema/EntityType.adoc[]
 
-include::{page-version}::partial$cpp/schema/RelationType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/schema/RelationType.adoc[]
 
-include::{page-version}::partial$cpp/schema/RoleType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/schema/RoleType.adoc[]
 
-include::{page-version}::partial$cpp/schema/AttributeType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/schema/AttributeType.adoc[]
 
-include::{page-version}::partial$cpp/schema/Annotation.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/schema/Annotation.adoc[]
 
-//include::{page-version}::partial$cpp/schema/Transitivity.adoc[]
+//include::{page-version}@external-typedb-driver::partial$cpp/schema/Transitivity.adoc[]
 
-include::{page-version}::partial$cpp/schema/ValueType.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/schema/ValueType.adoc[]
 
-//include::{page-version}::partial$cpp/schema/ScopedLabel.adoc[]
+//include::{page-version}@external-typedb-driver::partial$cpp/schema/ScopedLabel.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}::partial$cpp/data/Thing.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/data/Thing.adoc[]
 
-include::{page-version}::partial$cpp/data/Entity.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/data/Entity.adoc[]
 
-include::{page-version}::partial$cpp/data/Relation.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/data/Relation.adoc[]
 
-include::{page-version}::partial$cpp/data/Attribute.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/data/Attribute.adoc[]
 
-include::{page-version}::partial$cpp/data/Value.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-version}::partial$cpp/logic/LogicManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/logic/LogicManager.adoc[]
 
-include::{page-version}::partial$cpp/logic/Rule.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}::partial$cpp/errors/DriverException.adoc[]
+include::{page-version}@external-typedb-driver::partial$cpp/errors/DriverException.adoc[]

--- a/docs/modules/ROOT/partials/csharp/api-reference.adoc
+++ b/docs/modules/ROOT/partials/csharp/api-reference.adoc
@@ -2,116 +2,116 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}::partial$csharp/connection/Drivers.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/connection/Drivers.adoc[]
 
-include::{page-version}::partial$csharp/connection/ITypeDBDriver.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/connection/ITypeDBDriver.adoc[]
 
-include::{page-version}::partial$csharp/connection/TypeDBCredential.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/connection/TypeDBCredential.adoc[]
 
-include::{page-version}::partial$csharp/connection/IDatabaseManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/connection/IDatabaseManager.adoc[]
 
-include::{page-version}::partial$csharp/connection/IDatabase.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/connection/IDatabase.adoc[]
 
-include::{page-version}::partial$csharp/connection/IReplica.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/connection/IReplica.adoc[]
 
-include::{page-version}::partial$csharp/connection/IUserManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/connection/IUserManager.adoc[]
 
-include::{page-version}::partial$csharp/connection/IUser.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/connection/IUser.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-version}::partial$csharp/session/ITypeDBSession.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/session/ITypeDBSession.adoc[]
 
-include::{page-version}::partial$csharp/session/SessionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/session/SessionType.adoc[]
 
-include::{page-version}::partial$csharp/session/TypeDBOptions.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/session/TypeDBOptions.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}::partial$csharp/transaction/ITypeDBTransaction.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/transaction/ITypeDBTransaction.adoc[]
 
-include::{page-version}::partial$csharp/transaction/TransactionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/transaction/TransactionType.adoc[]
 
-include::{page-version}::partial$csharp/transaction/IQueryManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/transaction/IQueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}::partial$csharp/answer/IConceptMap.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/answer/IConceptMap.adoc[]
 
-include::{page-version}::partial$csharp/answer/IConceptMapGroup.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/answer/IConceptMapGroup.adoc[]
 
-include::{page-version}::partial$csharp/answer/IValueGroup.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/answer/IValueGroup.adoc[]
 
-// include::{page-version}::partial$csharp/answer/JSON.adoc[]
+// include::{page-version}@external-typedb-driver::partial$csharp/answer/JSON.adoc[]
 
-// include::{page-version}::partial$csharp/answer/JSONType.adoc[]
+// include::{page-version}@external-typedb-driver::partial$csharp/answer/JSONType.adoc[]
 
-include::{page-version}::partial$csharp/answer/IExplainables.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/answer/IExplainables.adoc[]
 
-include::{page-version}::partial$csharp/answer/IExplainable.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/answer/IExplainable.adoc[]
 
-include::{page-version}::partial$csharp/answer/IExplanation.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/answer/IExplanation.adoc[]
 
-include::{page-version}::partial$csharp/answer/Promise__T__.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/answer/Promise__T__.adoc[]
 
-include::{page-version}::partial$csharp/answer/VoidPromise.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/answer/VoidPromise.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}::partial$csharp/concept/IConceptManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/concept/IConceptManager.adoc[]
 
-include::{page-version}::partial$csharp/concept/IConcept.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/concept/IConcept.adoc[]
 
-include::{page-version}::partial$csharp/concept/Transitivity.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/concept/Transitivity.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}::partial$csharp/schema/IType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/schema/IType.adoc[]
 
-include::{page-version}::partial$csharp/schema/IThingType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/schema/IThingType.adoc[]
 
-include::{page-version}::partial$csharp/schema/IEntityType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/schema/IEntityType.adoc[]
 
-include::{page-version}::partial$csharp/schema/IRelationType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/schema/IRelationType.adoc[]
 
-include::{page-version}::partial$csharp/schema/IRoleType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/schema/IRoleType.adoc[]
 
-include::{page-version}::partial$csharp/schema/IAttributeType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/schema/IAttributeType.adoc[]
 
-include::{page-version}::partial$csharp/schema/Annotation.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/schema/Annotation.adoc[]
 
-include::{page-version}::partial$csharp/schema/Label.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/schema/Label.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}::partial$csharp/data/IThing.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/data/IThing.adoc[]
 
-include::{page-version}::partial$csharp/data/IEntity.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/data/IEntity.adoc[]
 
-include::{page-version}::partial$csharp/data/IRelation.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/data/IRelation.adoc[]
 
-include::{page-version}::partial$csharp/data/IAttribute.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/data/IAttribute.adoc[]
 
-include::{page-version}::partial$csharp/data/IValue.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/data/IValue.adoc[]
 
-include::{page-version}::partial$csharp/data/ValueType.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/data/ValueType.adoc[]
 
-include::{page-version}::partial$csharp/data/ValueTypeExtensions.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/data/ValueTypeExtensions.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-version}::partial$csharp/logic/ILogicManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/logic/ILogicManager.adoc[]
 
-include::{page-version}::partial$csharp/logic/IRule.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/logic/IRule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}::partial$csharp/errors/TypeDBDriverException.adoc[]
+include::{page-version}@external-typedb-driver::partial$csharp/errors/TypeDBDriverException.adoc[]

--- a/docs/modules/ROOT/partials/csharp/api-reference.adoc
+++ b/docs/modules/ROOT/partials/csharp/api-reference.adoc
@@ -2,116 +2,116 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}@api-ref::partial$csharp/connection/Drivers.adoc[]
+include::{page-version}::partial$csharp/connection/Drivers.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/connection/ITypeDBDriver.adoc[]
+include::{page-version}::partial$csharp/connection/ITypeDBDriver.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/connection/TypeDBCredential.adoc[]
+include::{page-version}::partial$csharp/connection/TypeDBCredential.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/connection/IDatabaseManager.adoc[]
+include::{page-version}::partial$csharp/connection/IDatabaseManager.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/connection/IDatabase.adoc[]
+include::{page-version}::partial$csharp/connection/IDatabase.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/connection/IReplica.adoc[]
+include::{page-version}::partial$csharp/connection/IReplica.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/connection/IUserManager.adoc[]
+include::{page-version}::partial$csharp/connection/IUserManager.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/connection/IUser.adoc[]
+include::{page-version}::partial$csharp/connection/IUser.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-version}@api-ref::partial$csharp/session/ITypeDBSession.adoc[]
+include::{page-version}::partial$csharp/session/ITypeDBSession.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/session/SessionType.adoc[]
+include::{page-version}::partial$csharp/session/SessionType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/session/TypeDBOptions.adoc[]
+include::{page-version}::partial$csharp/session/TypeDBOptions.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}@api-ref::partial$csharp/transaction/ITypeDBTransaction.adoc[]
+include::{page-version}::partial$csharp/transaction/ITypeDBTransaction.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/transaction/TransactionType.adoc[]
+include::{page-version}::partial$csharp/transaction/TransactionType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/transaction/IQueryManager.adoc[]
+include::{page-version}::partial$csharp/transaction/IQueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}@api-ref::partial$csharp/answer/IConceptMap.adoc[]
+include::{page-version}::partial$csharp/answer/IConceptMap.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/answer/IConceptMapGroup.adoc[]
+include::{page-version}::partial$csharp/answer/IConceptMapGroup.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/answer/IValueGroup.adoc[]
+include::{page-version}::partial$csharp/answer/IValueGroup.adoc[]
 
-// include::{page-version}@api-ref::partial$csharp/answer/JSON.adoc[]
+// include::{page-version}::partial$csharp/answer/JSON.adoc[]
 
-// include::{page-version}@api-ref::partial$csharp/answer/JSONType.adoc[]
+// include::{page-version}::partial$csharp/answer/JSONType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/answer/IExplainables.adoc[]
+include::{page-version}::partial$csharp/answer/IExplainables.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/answer/IExplainable.adoc[]
+include::{page-version}::partial$csharp/answer/IExplainable.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/answer/IExplanation.adoc[]
+include::{page-version}::partial$csharp/answer/IExplanation.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/answer/Promise__T__.adoc[]
+include::{page-version}::partial$csharp/answer/Promise__T__.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/answer/VoidPromise.adoc[]
+include::{page-version}::partial$csharp/answer/VoidPromise.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}@api-ref::partial$csharp/concept/IConceptManager.adoc[]
+include::{page-version}::partial$csharp/concept/IConceptManager.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/concept/IConcept.adoc[]
+include::{page-version}::partial$csharp/concept/IConcept.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/concept/Transitivity.adoc[]
+include::{page-version}::partial$csharp/concept/Transitivity.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}@api-ref::partial$csharp/schema/IType.adoc[]
+include::{page-version}::partial$csharp/schema/IType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/schema/IThingType.adoc[]
+include::{page-version}::partial$csharp/schema/IThingType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/schema/IEntityType.adoc[]
+include::{page-version}::partial$csharp/schema/IEntityType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/schema/IRelationType.adoc[]
+include::{page-version}::partial$csharp/schema/IRelationType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/schema/IRoleType.adoc[]
+include::{page-version}::partial$csharp/schema/IRoleType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/schema/IAttributeType.adoc[]
+include::{page-version}::partial$csharp/schema/IAttributeType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/schema/Annotation.adoc[]
+include::{page-version}::partial$csharp/schema/Annotation.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/schema/Label.adoc[]
+include::{page-version}::partial$csharp/schema/Label.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}@api-ref::partial$csharp/data/IThing.adoc[]
+include::{page-version}::partial$csharp/data/IThing.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/data/IEntity.adoc[]
+include::{page-version}::partial$csharp/data/IEntity.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/data/IRelation.adoc[]
+include::{page-version}::partial$csharp/data/IRelation.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/data/IAttribute.adoc[]
+include::{page-version}::partial$csharp/data/IAttribute.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/data/IValue.adoc[]
+include::{page-version}::partial$csharp/data/IValue.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/data/ValueType.adoc[]
+include::{page-version}::partial$csharp/data/ValueType.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/data/ValueTypeExtensions.adoc[]
+include::{page-version}::partial$csharp/data/ValueTypeExtensions.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-version}@api-ref::partial$csharp/logic/ILogicManager.adoc[]
+include::{page-version}::partial$csharp/logic/ILogicManager.adoc[]
 
-include::{page-version}@api-ref::partial$csharp/logic/IRule.adoc[]
+include::{page-version}::partial$csharp/logic/IRule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}@api-ref::partial$csharp/errors/TypeDBDriverException.adoc[]
+include::{page-version}::partial$csharp/errors/TypeDBDriverException.adoc[]

--- a/docs/modules/ROOT/partials/http-ts/api-reference.adoc
+++ b/docs/modules/ROOT/partials/http-ts/api-reference.adoc
@@ -1,104 +1,104 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}@api-ref::partial$http-ts/connection/Database.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/Database.adoc[]
 
 [#_DriverParams_header]
 === Driver Params
 
-include::{page-version}@api-ref::partial$http-ts/connection/DriverParams.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/DriverParams.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/connection/DriverParamsBasic.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/DriverParamsBasic.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/connection/DriverParamsTranslated.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/DriverParamsTranslated.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/connection/TransactionOptions.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/TransactionOptions.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/connection/TransactionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/TransactionType.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/connection/TranslatedAddress.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/TranslatedAddress.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/connection/TypeDBHttpDriver.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/TypeDBHttpDriver.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/connection/User.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/User.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/connection/connectionStaticFunctions.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/connection/connectionStaticFunctions.adoc[]
 
 [#_response_header]
 == Response
 
-include::{page-version}@api-ref::partial$http-ts/response/Answer.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/Answer.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/AnswerType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/AnswerType.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/ApiError.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/ApiError.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/ApiErrorResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/ApiErrorResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/ApiOkResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/ApiOkResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/ApiResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/ApiResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/ConceptDocumentsQueryResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/ConceptDocumentsQueryResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/ConceptRow.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/ConceptRow.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/ConceptRowAnswer.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/ConceptRowAnswer.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/ConceptRowsQueryResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/ConceptRowsQueryResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/DatabasesListResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/DatabasesListResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/Distribution.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/Distribution.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/OkQueryResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/OkQueryResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/SignInResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/SignInResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/TransactionOpenResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/TransactionOpenResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/UsersListResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/UsersListResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/VersionResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/VersionResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/response/responseStaticFunctions.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/response/responseStaticFunctions.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}@api-ref::partial$http-ts/concept/Attribute.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/Attribute.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/AttributeType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/AttributeType.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/Concept.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/Concept.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/ConceptDocument.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/ConceptDocument.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/EdgeKind.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/EdgeKind.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/Entity.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/Entity.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/EntityType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/EntityType.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/InstantiableType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/InstantiableType.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/Relation.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/Relation.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/RelationType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/RelationType.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/RoleType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/RoleType.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/ThingKind.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/ThingKind.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/Type.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/Type.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/TypeKind.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/TypeKind.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/Value.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/Value.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/ValueKind.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/ValueKind.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/concept/ValueType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/concept/ValueType.adoc[]
 
 [#_query_structure_header]
 == Query Structure
@@ -106,67 +106,67 @@ include::{page-version}@api-ref::partial$http-ts/concept/ValueType.adoc[]
 [#_QueryConstraint_header]
 === Query Constraints
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintAny.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintAny.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintIsa.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintIsa.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintIsaExact.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintIsaExact.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintHas.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintHas.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintLinks.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintLinks.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintSub.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintSub.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintSubExact.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintSubExact.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintOwns.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintOwns.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintExpression.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintExpression.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintFunction.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintFunction.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintComparison.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintComparison.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintIs.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintIs.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintIid.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintIid.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintKind.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintKind.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintValue.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintValue.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintLabel.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintLabel.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintPlays.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintPlays.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintRelates.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintRelates.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryConstraintSpan.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryConstraintSpan.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryOptions.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryOptions.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryResponse.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryResponse.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryResponseBase.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryResponseBase.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryStructure.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryStructure.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryType.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryType.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryVariableInfo.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryVariableInfo.adoc[]
 
 [#_QueryVertex_header]
 === Query Vertices
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryVertex.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryVertex.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryVertexKind.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryVertexKind.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryVertexLabel.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryVertexLabel.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryVertexValue.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryVertexValue.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/QueryVertexVariable.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/QueryVertexVariable.adoc[]
 
-include::{page-version}@api-ref::partial$http-ts/query-structure/query-structureStaticFunctions.adoc[]
+include::{page-version}@external-typedb-driver::partial$http-ts/query-structure/query-structureStaticFunctions.adoc[]

--- a/docs/modules/ROOT/partials/java/api-reference.adoc
+++ b/docs/modules/ROOT/partials/java/api-reference.adoc
@@ -2,85 +2,85 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}@api-ref::partial$java/connection/TypeDB.adoc[]
+include::{page-version}::partial$java/connection/TypeDB.adoc[]
 
-include::{page-version}@api-ref::partial$java/connection/Driver.adoc[]
+include::{page-version}::partial$java/connection/Driver.adoc[]
 
-include::{page-version}@api-ref::partial$java/connection/Credentials.adoc[]
+include::{page-version}::partial$java/connection/Credentials.adoc[]
 
-include::{page-version}@api-ref::partial$java/connection/DriverOptions.adoc[]
+include::{page-version}::partial$java/connection/DriverOptions.adoc[]
 
-include::{page-version}@api-ref::partial$java/connection/DatabaseManager.adoc[]
+include::{page-version}::partial$java/connection/DatabaseManager.adoc[]
 
-include::{page-version}@api-ref::partial$java/connection/Database.adoc[]
+include::{page-version}::partial$java/connection/Database.adoc[]
 
-include::{page-version}@api-ref::partial$java/connection/UserManager.adoc[]
+include::{page-version}::partial$java/connection/UserManager.adoc[]
 
-include::{page-version}@api-ref::partial$java/connection/User.adoc[]
+include::{page-version}::partial$java/connection/User.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}@api-ref::partial$java/transaction/Transaction.adoc[]
+include::{page-version}::partial$java/transaction/Transaction.adoc[]
 
-include::{page-version}@api-ref::partial$java/transaction/Transaction.Type.adoc[]
+include::{page-version}::partial$java/transaction/Transaction.Type.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}@api-ref::partial$java/answer/QueryAnswer.adoc[]
+include::{page-version}::partial$java/answer/QueryAnswer.adoc[]
 
-include::{page-version}@api-ref::partial$java/answer/OkQueryAnswer.adoc[]
+include::{page-version}::partial$java/answer/OkQueryAnswer.adoc[]
 
-include::{page-version}@api-ref::partial$java/answer/ConceptRowIterator.adoc[]
+include::{page-version}::partial$java/answer/ConceptRowIterator.adoc[]
 
-include::{page-version}@api-ref::partial$java/answer/ConceptRow.adoc[]
+include::{page-version}::partial$java/answer/ConceptRow.adoc[]
 
-include::{page-version}@api-ref::partial$java/answer/ConceptDocumentIterator.adoc[]
+include::{page-version}::partial$java/answer/ConceptDocumentIterator.adoc[]
 
-include::{page-version}@api-ref::partial$java/answer/JSON.adoc[]
+include::{page-version}::partial$java/answer/JSON.adoc[]
 
-include::{page-version}@api-ref::partial$java/answer/QueryType.adoc[]
+include::{page-version}::partial$java/answer/QueryType.adoc[]
 
-include::{page-version}@api-ref::partial$java/answer/Promise_T_.adoc[]
+include::{page-version}::partial$java/answer/Promise_T_.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}@api-ref::partial$java/concept/Concept.adoc[]
+include::{page-version}::partial$java/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}@api-ref::partial$java/schema/Type.adoc[]
+include::{page-version}::partial$java/schema/Type.adoc[]
 
-include::{page-version}@api-ref::partial$java/schema/EntityType.adoc[]
+include::{page-version}::partial$java/schema/EntityType.adoc[]
 
-include::{page-version}@api-ref::partial$java/schema/RelationType.adoc[]
+include::{page-version}::partial$java/schema/RelationType.adoc[]
 
-include::{page-version}@api-ref::partial$java/schema/RoleType.adoc[]
+include::{page-version}::partial$java/schema/RoleType.adoc[]
 
-include::{page-version}@api-ref::partial$java/schema/AttributeType.adoc[]
+include::{page-version}::partial$java/schema/AttributeType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}@api-ref::partial$java/data/Instance.adoc[]
+include::{page-version}::partial$java/data/Instance.adoc[]
 
-include::{page-version}@api-ref::partial$java/data/Entity.adoc[]
+include::{page-version}::partial$java/data/Entity.adoc[]
 
-include::{page-version}@api-ref::partial$java/data/Relation.adoc[]
+include::{page-version}::partial$java/data/Relation.adoc[]
 
-include::{page-version}@api-ref::partial$java/data/Attribute.adoc[]
+include::{page-version}::partial$java/data/Attribute.adoc[]
 
-include::{page-version}@api-ref::partial$java/data/Value.adoc[]
+include::{page-version}::partial$java/data/Value.adoc[]
 
 [#_value_header]
 == Value
 
-include::{page-version}@api-ref::partial$java/value/Duration.adoc[]
+include::{page-version}::partial$java/value/Duration.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}@api-ref::partial$java/errors/TypeDBDriverException.adoc[]
+include::{page-version}::partial$java/errors/TypeDBDriverException.adoc[]

--- a/docs/modules/ROOT/partials/java/api-reference.adoc
+++ b/docs/modules/ROOT/partials/java/api-reference.adoc
@@ -2,85 +2,85 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}::partial$java/connection/TypeDB.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/connection/TypeDB.adoc[]
 
-include::{page-version}::partial$java/connection/Driver.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/connection/Driver.adoc[]
 
-include::{page-version}::partial$java/connection/Credentials.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/connection/Credentials.adoc[]
 
-include::{page-version}::partial$java/connection/DriverOptions.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/connection/DriverOptions.adoc[]
 
-include::{page-version}::partial$java/connection/DatabaseManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/connection/DatabaseManager.adoc[]
 
-include::{page-version}::partial$java/connection/Database.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/connection/Database.adoc[]
 
-include::{page-version}::partial$java/connection/UserManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/connection/UserManager.adoc[]
 
-include::{page-version}::partial$java/connection/User.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/connection/User.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}::partial$java/transaction/Transaction.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/transaction/Transaction.adoc[]
 
-include::{page-version}::partial$java/transaction/Transaction.Type.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/transaction/Transaction.Type.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}::partial$java/answer/QueryAnswer.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/answer/QueryAnswer.adoc[]
 
-include::{page-version}::partial$java/answer/OkQueryAnswer.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/answer/OkQueryAnswer.adoc[]
 
-include::{page-version}::partial$java/answer/ConceptRowIterator.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/answer/ConceptRowIterator.adoc[]
 
-include::{page-version}::partial$java/answer/ConceptRow.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/answer/ConceptRow.adoc[]
 
-include::{page-version}::partial$java/answer/ConceptDocumentIterator.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/answer/ConceptDocumentIterator.adoc[]
 
-include::{page-version}::partial$java/answer/JSON.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/answer/JSON.adoc[]
 
-include::{page-version}::partial$java/answer/QueryType.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/answer/QueryType.adoc[]
 
-include::{page-version}::partial$java/answer/Promise_T_.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/answer/Promise_T_.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}::partial$java/concept/Concept.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}::partial$java/schema/Type.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/schema/Type.adoc[]
 
-include::{page-version}::partial$java/schema/EntityType.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/schema/EntityType.adoc[]
 
-include::{page-version}::partial$java/schema/RelationType.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/schema/RelationType.adoc[]
 
-include::{page-version}::partial$java/schema/RoleType.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/schema/RoleType.adoc[]
 
-include::{page-version}::partial$java/schema/AttributeType.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/schema/AttributeType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}::partial$java/data/Instance.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/data/Instance.adoc[]
 
-include::{page-version}::partial$java/data/Entity.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/data/Entity.adoc[]
 
-include::{page-version}::partial$java/data/Relation.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/data/Relation.adoc[]
 
-include::{page-version}::partial$java/data/Attribute.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/data/Attribute.adoc[]
 
-include::{page-version}::partial$java/data/Value.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/data/Value.adoc[]
 
 [#_value_header]
 == Value
 
-include::{page-version}::partial$java/value/Duration.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/value/Duration.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}::partial$java/errors/TypeDBDriverException.adoc[]
+include::{page-version}@external-typedb-driver::partial$java/errors/TypeDBDriverException.adoc[]

--- a/docs/modules/ROOT/partials/nodejs/api-reference.adoc
+++ b/docs/modules/ROOT/partials/nodejs/api-reference.adoc
@@ -2,112 +2,112 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}::partial$nodejs/connection/TypeDB.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/connection/TypeDB.adoc[]
 
-include::{page-version}::partial$nodejs/connection/TypeDBDriver.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/connection/TypeDBDriver.adoc[]
 
-include::{page-version}::partial$nodejs/connection/TypeDBCredential.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/connection/TypeDBCredential.adoc[]
 
-include::{page-version}::partial$nodejs/connection/DatabaseManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/connection/DatabaseManager.adoc[]
 
-include::{page-version}::partial$nodejs/connection/Database.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/connection/Database.adoc[]
 
-include::{page-version}::partial$nodejs/connection/Replica.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/connection/Replica.adoc[]
 
-include::{page-version}::partial$nodejs/connection/UserManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/connection/UserManager.adoc[]
 
-include::{page-version}::partial$nodejs/connection/User.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-version}::partial$nodejs/session/TypeDBSession.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/session/TypeDBSession.adoc[]
 
-include::{page-version}::partial$nodejs/session/SessionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/session/SessionType.adoc[]
 
-include::{page-version}::partial$nodejs/session/TypeDBOptions.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/session/TypeDBOptions.adoc[]
 
-include::{page-version}::partial$nodejs/session/Opts.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/session/Opts.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}::partial$nodejs/transaction/TypeDBTransaction.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/transaction/TypeDBTransaction.adoc[]
 
-include::{page-version}::partial$nodejs/transaction/TransactionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/transaction/TransactionType.adoc[]
 
-include::{page-version}::partial$nodejs/transaction/QueryManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}::partial$nodejs/answer/ConceptMapGroup.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/answer/ConceptMapGroup.adoc[]
 
-include::{page-version}::partial$nodejs/answer/ConceptMap.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/answer/ConceptMap.adoc[]
 
-include::{page-version}::partial$nodejs/answer/Stream_T_.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/answer/Stream_T_.adoc[]
 
-include::{page-version}::partial$nodejs/answer/ValueGroup.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/answer/ValueGroup.adoc[]
 
-include::{page-version}::partial$nodejs/answer/Explainables.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/answer/Explainables.adoc[]
 
-include::{page-version}::partial$nodejs/answer/Explainable.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/answer/Explainable.adoc[]
 
-include::{page-version}::partial$nodejs/answer/Explanation.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}::partial$nodejs/concept/ConceptManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/concept/ConceptManager.adoc[]
 
-include::{page-version}::partial$nodejs/concept/Concept.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}::partial$nodejs/schema/Type.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/Type.adoc[]
 
-include::{page-version}::partial$nodejs/schema/Label.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/Label.adoc[]
 
-include::{page-version}::partial$nodejs/schema/ThingType.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/ThingType.adoc[]
 
-include::{page-version}::partial$nodejs/schema/EntityType.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/EntityType.adoc[]
 
-include::{page-version}::partial$nodejs/schema/RelationType.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/RelationType.adoc[]
 
-include::{page-version}::partial$nodejs/schema/RoleType.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/RoleType.adoc[]
 
-include::{page-version}::partial$nodejs/schema/AttributeType.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/AttributeType.adoc[]
 
-include::{page-version}::partial$nodejs/schema/Annotation.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/Annotation.adoc[]
 
-include::{page-version}::partial$nodejs/schema/Transitivity.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/Transitivity.adoc[]
 
-include::{page-version}::partial$nodejs/schema/ValueType.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/schema/ValueType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}::partial$nodejs/data/Thing.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/data/Thing.adoc[]
 
-include::{page-version}::partial$nodejs/data/Entity.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/data/Entity.adoc[]
 
-include::{page-version}::partial$nodejs/data/Relation.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/data/Relation.adoc[]
 
-include::{page-version}::partial$nodejs/data/Attribute.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/data/Attribute.adoc[]
 
-include::{page-version}::partial$nodejs/data/Value.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-version}::partial$nodejs/logic/LogicManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/logic/LogicManager.adoc[]
 
-include::{page-version}::partial$nodejs/logic/Rule.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}::partial$nodejs/errors/TypeDBDriverError.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/errors/TypeDBDriverError.adoc[]
 
-include::{page-version}::partial$nodejs/errors/ErrorMessage.adoc[]
+include::{page-version}@external-typedb-driver::partial$nodejs/errors/ErrorMessage.adoc[]

--- a/docs/modules/ROOT/partials/nodejs/api-reference.adoc
+++ b/docs/modules/ROOT/partials/nodejs/api-reference.adoc
@@ -2,112 +2,112 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}@api-ref::partial$nodejs/connection/TypeDB.adoc[]
+include::{page-version}::partial$nodejs/connection/TypeDB.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/connection/TypeDBDriver.adoc[]
+include::{page-version}::partial$nodejs/connection/TypeDBDriver.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/connection/TypeDBCredential.adoc[]
+include::{page-version}::partial$nodejs/connection/TypeDBCredential.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/connection/DatabaseManager.adoc[]
+include::{page-version}::partial$nodejs/connection/DatabaseManager.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/connection/Database.adoc[]
+include::{page-version}::partial$nodejs/connection/Database.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/connection/Replica.adoc[]
+include::{page-version}::partial$nodejs/connection/Replica.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/connection/UserManager.adoc[]
+include::{page-version}::partial$nodejs/connection/UserManager.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/connection/User.adoc[]
+include::{page-version}::partial$nodejs/connection/User.adoc[]
 
 [#_session_header]
 == Session
 
-include::{page-version}@api-ref::partial$nodejs/session/TypeDBSession.adoc[]
+include::{page-version}::partial$nodejs/session/TypeDBSession.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/session/SessionType.adoc[]
+include::{page-version}::partial$nodejs/session/SessionType.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/session/TypeDBOptions.adoc[]
+include::{page-version}::partial$nodejs/session/TypeDBOptions.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/session/Opts.adoc[]
+include::{page-version}::partial$nodejs/session/Opts.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}@api-ref::partial$nodejs/transaction/TypeDBTransaction.adoc[]
+include::{page-version}::partial$nodejs/transaction/TypeDBTransaction.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/transaction/TransactionType.adoc[]
+include::{page-version}::partial$nodejs/transaction/TransactionType.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/transaction/QueryManager.adoc[]
+include::{page-version}::partial$nodejs/transaction/QueryManager.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}@api-ref::partial$nodejs/answer/ConceptMapGroup.adoc[]
+include::{page-version}::partial$nodejs/answer/ConceptMapGroup.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/answer/ConceptMap.adoc[]
+include::{page-version}::partial$nodejs/answer/ConceptMap.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/answer/Stream_T_.adoc[]
+include::{page-version}::partial$nodejs/answer/Stream_T_.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/answer/ValueGroup.adoc[]
+include::{page-version}::partial$nodejs/answer/ValueGroup.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/answer/Explainables.adoc[]
+include::{page-version}::partial$nodejs/answer/Explainables.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/answer/Explainable.adoc[]
+include::{page-version}::partial$nodejs/answer/Explainable.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/answer/Explanation.adoc[]
+include::{page-version}::partial$nodejs/answer/Explanation.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}@api-ref::partial$nodejs/concept/ConceptManager.adoc[]
+include::{page-version}::partial$nodejs/concept/ConceptManager.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/concept/Concept.adoc[]
+include::{page-version}::partial$nodejs/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}@api-ref::partial$nodejs/schema/Type.adoc[]
+include::{page-version}::partial$nodejs/schema/Type.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/Label.adoc[]
+include::{page-version}::partial$nodejs/schema/Label.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/ThingType.adoc[]
+include::{page-version}::partial$nodejs/schema/ThingType.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/EntityType.adoc[]
+include::{page-version}::partial$nodejs/schema/EntityType.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/RelationType.adoc[]
+include::{page-version}::partial$nodejs/schema/RelationType.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/RoleType.adoc[]
+include::{page-version}::partial$nodejs/schema/RoleType.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/AttributeType.adoc[]
+include::{page-version}::partial$nodejs/schema/AttributeType.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/Annotation.adoc[]
+include::{page-version}::partial$nodejs/schema/Annotation.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/Transitivity.adoc[]
+include::{page-version}::partial$nodejs/schema/Transitivity.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/schema/ValueType.adoc[]
+include::{page-version}::partial$nodejs/schema/ValueType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}@api-ref::partial$nodejs/data/Thing.adoc[]
+include::{page-version}::partial$nodejs/data/Thing.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/data/Entity.adoc[]
+include::{page-version}::partial$nodejs/data/Entity.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/data/Relation.adoc[]
+include::{page-version}::partial$nodejs/data/Relation.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/data/Attribute.adoc[]
+include::{page-version}::partial$nodejs/data/Attribute.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/data/Value.adoc[]
+include::{page-version}::partial$nodejs/data/Value.adoc[]
 
 [#_logic_header]
 == Logic
 
-include::{page-version}@api-ref::partial$nodejs/logic/LogicManager.adoc[]
+include::{page-version}::partial$nodejs/logic/LogicManager.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/logic/Rule.adoc[]
+include::{page-version}::partial$nodejs/logic/Rule.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}@api-ref::partial$nodejs/errors/TypeDBDriverError.adoc[]
+include::{page-version}::partial$nodejs/errors/TypeDBDriverError.adoc[]
 
-include::{page-version}@api-ref::partial$nodejs/errors/ErrorMessage.adoc[]
+include::{page-version}::partial$nodejs/errors/ErrorMessage.adoc[]

--- a/docs/modules/ROOT/partials/python/api-reference.adoc
+++ b/docs/modules/ROOT/partials/python/api-reference.adoc
@@ -1,85 +1,85 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}::partial$python/connection/TypeDB.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/connection/TypeDB.adoc[]
 
-include::{page-version}::partial$python/connection/Driver.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/connection/Driver.adoc[]
 
-include::{page-version}::partial$python/connection/Credentials.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/connection/Credentials.adoc[]
 
-include::{page-version}::partial$python/connection/DriverOptions.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/connection/DriverOptions.adoc[]
 
-include::{page-version}::partial$python/connection/DatabaseManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/connection/DatabaseManager.adoc[]
 
-include::{page-version}::partial$python/connection/Database.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/connection/Database.adoc[]
 
-include::{page-version}::partial$python/connection/UserManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/connection/UserManager.adoc[]
 
-include::{page-version}::partial$python/connection/User.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/connection/User.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}::partial$python/transaction/Transaction.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/transaction/Transaction.adoc[]
 
-include::{page-version}::partial$python/transaction/TransactionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/transaction/TransactionType.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}::partial$python/answer/QueryAnswer.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/answer/QueryAnswer.adoc[]
 
-include::{page-version}::partial$python/answer/OkQueryAnswer.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/answer/OkQueryAnswer.adoc[]
 
-include::{page-version}::partial$python/answer/ConceptRowIterator.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/answer/ConceptRowIterator.adoc[]
 
-include::{page-version}::partial$python/answer/ConceptRow.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/answer/ConceptRow.adoc[]
 
-include::{page-version}::partial$python/answer/ConceptDocumentIterator.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/answer/ConceptDocumentIterator.adoc[]
 
-include::{page-version}::partial$python/answer/QueryType.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/answer/QueryType.adoc[]
 
-include::{page-version}::partial$python/answer/Promise.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/answer/Promise.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}::partial$python/concept/Concept.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}::partial$python/schema/Type.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/schema/Type.adoc[]
 
-include::{page-version}::partial$python/schema/EntityType.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/schema/EntityType.adoc[]
 
-include::{page-version}::partial$python/schema/RelationType.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/schema/RelationType.adoc[]
 
-include::{page-version}::partial$python/schema/RoleType.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/schema/RoleType.adoc[]
 
-include::{page-version}::partial$python/schema/AttributeType.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/schema/AttributeType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}::partial$python/data/Instance.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/data/Instance.adoc[]
 
-include::{page-version}::partial$python/data/Entity.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/data/Entity.adoc[]
 
-include::{page-version}::partial$python/data/Relation.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/data/Relation.adoc[]
 
-include::{page-version}::partial$python/data/Attribute.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/data/Attribute.adoc[]
 
-include::{page-version}::partial$python/data/Value.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/data/Value.adoc[]
 
 [#_value_header]
 == Value
 
-include::{page-version}::partial$python/value/Datetime.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/value/Datetime.adoc[]
 
-include::{page-version}::partial$python/value/Duration.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/value/Duration.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}::partial$python/errors/TypeDBDriverException.adoc[]
+include::{page-version}@external-typedb-driver::partial$python/errors/TypeDBDriverException.adoc[]

--- a/docs/modules/ROOT/partials/python/api-reference.adoc
+++ b/docs/modules/ROOT/partials/python/api-reference.adoc
@@ -1,85 +1,85 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}@api-ref::partial$python/connection/TypeDB.adoc[]
+include::{page-version}::partial$python/connection/TypeDB.adoc[]
 
-include::{page-version}@api-ref::partial$python/connection/Driver.adoc[]
+include::{page-version}::partial$python/connection/Driver.adoc[]
 
-include::{page-version}@api-ref::partial$python/connection/Credentials.adoc[]
+include::{page-version}::partial$python/connection/Credentials.adoc[]
 
-include::{page-version}@api-ref::partial$python/connection/DriverOptions.adoc[]
+include::{page-version}::partial$python/connection/DriverOptions.adoc[]
 
-include::{page-version}@api-ref::partial$python/connection/DatabaseManager.adoc[]
+include::{page-version}::partial$python/connection/DatabaseManager.adoc[]
 
-include::{page-version}@api-ref::partial$python/connection/Database.adoc[]
+include::{page-version}::partial$python/connection/Database.adoc[]
 
-include::{page-version}@api-ref::partial$python/connection/UserManager.adoc[]
+include::{page-version}::partial$python/connection/UserManager.adoc[]
 
-include::{page-version}@api-ref::partial$python/connection/User.adoc[]
+include::{page-version}::partial$python/connection/User.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}@api-ref::partial$python/transaction/Transaction.adoc[]
+include::{page-version}::partial$python/transaction/Transaction.adoc[]
 
-include::{page-version}@api-ref::partial$python/transaction/TransactionType.adoc[]
+include::{page-version}::partial$python/transaction/TransactionType.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}@api-ref::partial$python/answer/QueryAnswer.adoc[]
+include::{page-version}::partial$python/answer/QueryAnswer.adoc[]
 
-include::{page-version}@api-ref::partial$python/answer/OkQueryAnswer.adoc[]
+include::{page-version}::partial$python/answer/OkQueryAnswer.adoc[]
 
-include::{page-version}@api-ref::partial$python/answer/ConceptRowIterator.adoc[]
+include::{page-version}::partial$python/answer/ConceptRowIterator.adoc[]
 
-include::{page-version}@api-ref::partial$python/answer/ConceptRow.adoc[]
+include::{page-version}::partial$python/answer/ConceptRow.adoc[]
 
-include::{page-version}@api-ref::partial$python/answer/ConceptDocumentIterator.adoc[]
+include::{page-version}::partial$python/answer/ConceptDocumentIterator.adoc[]
 
-include::{page-version}@api-ref::partial$python/answer/QueryType.adoc[]
+include::{page-version}::partial$python/answer/QueryType.adoc[]
 
-include::{page-version}@api-ref::partial$python/answer/Promise.adoc[]
+include::{page-version}::partial$python/answer/Promise.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}@api-ref::partial$python/concept/Concept.adoc[]
+include::{page-version}::partial$python/concept/Concept.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}@api-ref::partial$python/schema/Type.adoc[]
+include::{page-version}::partial$python/schema/Type.adoc[]
 
-include::{page-version}@api-ref::partial$python/schema/EntityType.adoc[]
+include::{page-version}::partial$python/schema/EntityType.adoc[]
 
-include::{page-version}@api-ref::partial$python/schema/RelationType.adoc[]
+include::{page-version}::partial$python/schema/RelationType.adoc[]
 
-include::{page-version}@api-ref::partial$python/schema/RoleType.adoc[]
+include::{page-version}::partial$python/schema/RoleType.adoc[]
 
-include::{page-version}@api-ref::partial$python/schema/AttributeType.adoc[]
+include::{page-version}::partial$python/schema/AttributeType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}@api-ref::partial$python/data/Instance.adoc[]
+include::{page-version}::partial$python/data/Instance.adoc[]
 
-include::{page-version}@api-ref::partial$python/data/Entity.adoc[]
+include::{page-version}::partial$python/data/Entity.adoc[]
 
-include::{page-version}@api-ref::partial$python/data/Relation.adoc[]
+include::{page-version}::partial$python/data/Relation.adoc[]
 
-include::{page-version}@api-ref::partial$python/data/Attribute.adoc[]
+include::{page-version}::partial$python/data/Attribute.adoc[]
 
-include::{page-version}@api-ref::partial$python/data/Value.adoc[]
+include::{page-version}::partial$python/data/Value.adoc[]
 
 [#_value_header]
 == Value
 
-include::{page-version}@api-ref::partial$python/value/Datetime.adoc[]
+include::{page-version}::partial$python/value/Datetime.adoc[]
 
-include::{page-version}@api-ref::partial$python/value/Duration.adoc[]
+include::{page-version}::partial$python/value/Duration.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}@api-ref::partial$python/errors/TypeDBDriverException.adoc[]
+include::{page-version}::partial$python/errors/TypeDBDriverException.adoc[]

--- a/docs/modules/ROOT/partials/rust/api-reference.adoc
+++ b/docs/modules/ROOT/partials/rust/api-reference.adoc
@@ -2,112 +2,112 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}@api-ref::partial$rust/connection/TypeDBDriver.adoc[]
+include::{page-version}::partial$rust/connection/TypeDBDriver.adoc[]
 
-include::{page-version}@api-ref::partial$rust/connection/Credentials.adoc[]
+include::{page-version}::partial$rust/connection/Credentials.adoc[]
 
-include::{page-version}@api-ref::partial$rust/connection/DriverOptions.adoc[]
+include::{page-version}::partial$rust/connection/DriverOptions.adoc[]
 
-include::{page-version}@api-ref::partial$rust/connection/DatabaseManager.adoc[]
+include::{page-version}::partial$rust/connection/DatabaseManager.adoc[]
 
-include::{page-version}@api-ref::partial$rust/connection/Database.adoc[]
+include::{page-version}::partial$rust/connection/Database.adoc[]
 
 // TODO: Enable when Replicas are introduced
-// include::{page-version}@api-ref::partial$rust/connection/ReplicaInfo.adoc[]
+// include::{page-version}::partial$rust/connection/ReplicaInfo.adoc[]
 
-include::{page-version}@api-ref::partial$rust/connection/UserManager.adoc[]
+include::{page-version}::partial$rust/connection/UserManager.adoc[]
 
-include::{page-version}@api-ref::partial$rust/connection/User.adoc[]
+include::{page-version}::partial$rust/connection/User.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}@api-ref::partial$rust/transaction/Transaction.adoc[]
+include::{page-version}::partial$rust/transaction/Transaction.adoc[]
 
-include::{page-version}@api-ref::partial$rust/transaction/TransactionType.adoc[]
+include::{page-version}::partial$rust/transaction/TransactionType.adoc[]
 
 // TODO: Enable when Options are introduced
-// include::{page-version}@api-ref::partial$rust/transaction/Options.adoc[]
+// include::{page-version}::partial$rust/transaction/Options.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}@api-ref::partial$rust/answer/QueryAnswer.adoc[]
+include::{page-version}::partial$rust/answer/QueryAnswer.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/ConceptRow.adoc[]
+include::{page-version}::partial$rust/answer/ConceptRow.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/ConceptRowHeader.adoc[]
+include::{page-version}::partial$rust/answer/ConceptRowHeader.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/ConceptDocument.adoc[]
+include::{page-version}::partial$rust/answer/ConceptDocument.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/ConceptDocumentHeader.adoc[]
+include::{page-version}::partial$rust/answer/ConceptDocumentHeader.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/JSON.adoc[]
+include::{page-version}::partial$rust/answer/JSON.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/Node.adoc[]
+include::{page-version}::partial$rust/answer/Node.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/Leaf.adoc[]
+include::{page-version}::partial$rust/answer/Leaf.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/QueryType.adoc[]
+include::{page-version}::partial$rust/answer/QueryType.adoc[]
 
-include::{page-version}@api-ref::partial$rust/answer/Trait_Promise.adoc[]
+include::{page-version}::partial$rust/answer/Trait_Promise.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}@api-ref::partial$rust/concept/Concept.adoc[]
+include::{page-version}::partial$rust/concept/Concept.adoc[]
 
-include::{page-version}@api-ref::partial$rust/concept/ConceptCategory.adoc[]
+include::{page-version}::partial$rust/concept/ConceptCategory.adoc[]
 
-include::{page-version}@api-ref::partial$rust/concept/Kind.adoc[]
+include::{page-version}::partial$rust/concept/Kind.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}@api-ref::partial$rust/schema/EntityType.adoc[]
+include::{page-version}::partial$rust/schema/EntityType.adoc[]
 
-include::{page-version}@api-ref::partial$rust/schema/RelationType.adoc[]
+include::{page-version}::partial$rust/schema/RelationType.adoc[]
 
-include::{page-version}@api-ref::partial$rust/schema/RoleType.adoc[]
+include::{page-version}::partial$rust/schema/RoleType.adoc[]
 
-include::{page-version}@api-ref::partial$rust/schema/AttributeType.adoc[]
+include::{page-version}::partial$rust/schema/AttributeType.adoc[]
 
-include::{page-version}@api-ref::partial$rust/schema/ValueType.adoc[]
+include::{page-version}::partial$rust/schema/ValueType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}@api-ref::partial$rust/data/Entity.adoc[]
+include::{page-version}::partial$rust/data/Entity.adoc[]
 
-include::{page-version}@api-ref::partial$rust/data/Relation.adoc[]
+include::{page-version}::partial$rust/data/Relation.adoc[]
 
-include::{page-version}@api-ref::partial$rust/data/Attribute.adoc[]
+include::{page-version}::partial$rust/data/Attribute.adoc[]
 
-include::{page-version}@api-ref::partial$rust/data/Value.adoc[]
+include::{page-version}::partial$rust/data/Value.adoc[]
 
 [#_value_header]
 == Value
 
-include::{page-version}@api-ref::partial$rust/value/Decimal.adoc[]
+include::{page-version}::partial$rust/value/Decimal.adoc[]
 
-include::{page-version}@api-ref::partial$rust/value/Duration.adoc[]
+include::{page-version}::partial$rust/value/Duration.adoc[]
 
-include::{page-version}@api-ref::partial$rust/value/Offset.adoc[]
+include::{page-version}::partial$rust/value/Offset.adoc[]
 
-include::{page-version}@api-ref::partial$rust/value/TimeZone.adoc[]
+include::{page-version}::partial$rust/value/TimeZone.adoc[]
 
 // TODO: Enable when Structs are introduced
-// include::{page-version}@api-ref::partial$rust/value/Struct.adoc[]
+// include::{page-version}::partial$rust/value/Struct.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}@api-ref::partial$rust/errors/Error.adoc[]
+include::{page-version}::partial$rust/errors/Error.adoc[]
 
-include::{page-version}@api-ref::partial$rust/errors/ConnectionError.adoc[]
+include::{page-version}::partial$rust/errors/ConnectionError.adoc[]
 
-include::{page-version}@api-ref::partial$rust/errors/ServerError.adoc[]
+include::{page-version}::partial$rust/errors/ServerError.adoc[]
 
-include::{page-version}@api-ref::partial$rust/errors/DurationParseError.adoc[]
+include::{page-version}::partial$rust/errors/DurationParseError.adoc[]
 
-include::{page-version}@api-ref::partial$rust/errors/InternalError.adoc[]
+include::{page-version}::partial$rust/errors/InternalError.adoc[]

--- a/docs/modules/ROOT/partials/rust/api-reference.adoc
+++ b/docs/modules/ROOT/partials/rust/api-reference.adoc
@@ -2,112 +2,112 @@
 [#_connection_header]
 == Connection
 
-include::{page-version}::partial$rust/connection/TypeDBDriver.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/connection/TypeDBDriver.adoc[]
 
-include::{page-version}::partial$rust/connection/Credentials.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/connection/Credentials.adoc[]
 
-include::{page-version}::partial$rust/connection/DriverOptions.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/connection/DriverOptions.adoc[]
 
-include::{page-version}::partial$rust/connection/DatabaseManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/connection/DatabaseManager.adoc[]
 
-include::{page-version}::partial$rust/connection/Database.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/connection/Database.adoc[]
 
 // TODO: Enable when Replicas are introduced
-// include::{page-version}::partial$rust/connection/ReplicaInfo.adoc[]
+// include::{page-version}@external-typedb-driver::partial$rust/connection/ReplicaInfo.adoc[]
 
-include::{page-version}::partial$rust/connection/UserManager.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/connection/UserManager.adoc[]
 
-include::{page-version}::partial$rust/connection/User.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/connection/User.adoc[]
 
 [#_transaction_header]
 == Transaction
 
-include::{page-version}::partial$rust/transaction/Transaction.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/transaction/Transaction.adoc[]
 
-include::{page-version}::partial$rust/transaction/TransactionType.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/transaction/TransactionType.adoc[]
 
 // TODO: Enable when Options are introduced
-// include::{page-version}::partial$rust/transaction/Options.adoc[]
+// include::{page-version}@external-typedb-driver::partial$rust/transaction/Options.adoc[]
 
 [#_answer_header]
 == Answer
 
-include::{page-version}::partial$rust/answer/QueryAnswer.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/QueryAnswer.adoc[]
 
-include::{page-version}::partial$rust/answer/ConceptRow.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/ConceptRow.adoc[]
 
-include::{page-version}::partial$rust/answer/ConceptRowHeader.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/ConceptRowHeader.adoc[]
 
-include::{page-version}::partial$rust/answer/ConceptDocument.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/ConceptDocument.adoc[]
 
-include::{page-version}::partial$rust/answer/ConceptDocumentHeader.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/ConceptDocumentHeader.adoc[]
 
-include::{page-version}::partial$rust/answer/JSON.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/JSON.adoc[]
 
-include::{page-version}::partial$rust/answer/Node.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/Node.adoc[]
 
-include::{page-version}::partial$rust/answer/Leaf.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/Leaf.adoc[]
 
-include::{page-version}::partial$rust/answer/QueryType.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/QueryType.adoc[]
 
-include::{page-version}::partial$rust/answer/Trait_Promise.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/answer/Trait_Promise.adoc[]
 
 [#_concept_header]
 == Concept
 
-include::{page-version}::partial$rust/concept/Concept.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/concept/Concept.adoc[]
 
-include::{page-version}::partial$rust/concept/ConceptCategory.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/concept/ConceptCategory.adoc[]
 
-include::{page-version}::partial$rust/concept/Kind.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/concept/Kind.adoc[]
 
 [#_schema_header]
 == Schema
 
-include::{page-version}::partial$rust/schema/EntityType.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/schema/EntityType.adoc[]
 
-include::{page-version}::partial$rust/schema/RelationType.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/schema/RelationType.adoc[]
 
-include::{page-version}::partial$rust/schema/RoleType.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/schema/RoleType.adoc[]
 
-include::{page-version}::partial$rust/schema/AttributeType.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/schema/AttributeType.adoc[]
 
-include::{page-version}::partial$rust/schema/ValueType.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/schema/ValueType.adoc[]
 
 [#_data_header]
 == Data
 
-include::{page-version}::partial$rust/data/Entity.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/data/Entity.adoc[]
 
-include::{page-version}::partial$rust/data/Relation.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/data/Relation.adoc[]
 
-include::{page-version}::partial$rust/data/Attribute.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/data/Attribute.adoc[]
 
-include::{page-version}::partial$rust/data/Value.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/data/Value.adoc[]
 
 [#_value_header]
 == Value
 
-include::{page-version}::partial$rust/value/Decimal.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/value/Decimal.adoc[]
 
-include::{page-version}::partial$rust/value/Duration.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/value/Duration.adoc[]
 
-include::{page-version}::partial$rust/value/Offset.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/value/Offset.adoc[]
 
-include::{page-version}::partial$rust/value/TimeZone.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/value/TimeZone.adoc[]
 
 // TODO: Enable when Structs are introduced
-// include::{page-version}::partial$rust/value/Struct.adoc[]
+// include::{page-version}@external-typedb-driver::partial$rust/value/Struct.adoc[]
 
 [#_errors_header]
 == Errors
 
-include::{page-version}::partial$rust/errors/Error.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/errors/Error.adoc[]
 
-include::{page-version}::partial$rust/errors/ConnectionError.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/errors/ConnectionError.adoc[]
 
-include::{page-version}::partial$rust/errors/ServerError.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/errors/ServerError.adoc[]
 
-include::{page-version}::partial$rust/errors/DurationParseError.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/errors/DurationParseError.adoc[]
 
-include::{page-version}::partial$rust/errors/InternalError.adoc[]
+include::{page-version}@external-typedb-driver::partial$rust/errors/InternalError.adoc[]


### PR DESCRIPTION
## Usage and product changes

We rename the docs antora module used to host the generated driver references from `api-ref` to `external-typedb-driver`, to support refactoring in the typedb docs repository.