### PR TITLE
Ensure PNPM config in CI matches config locally

### DIFF
--- a/http-ts/.npmrc
+++ b/http-ts/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=false

--- a/tool/http-ts/install-deps.sh
+++ b/tool/http-ts/install-deps.sh
@@ -22,7 +22,7 @@ nvm install 22
 nvm use 22
 npm install --global corepack@0.17.0
 corepack enable
-corepack prepare pnpm@10.12.1 --activate
+corepack prepare pnpm@8.15.9 --activate
 pushd http-ts
 pnpm install
 popd


### PR DESCRIPTION
## Usage and product changes

We add an `.npmrc` file to ensure the PNPM config in local machines and CI match so that installation succeeds in CI.

## Implementation

Add `.npmrc` with `auto-install-peers=true`. Ensure we install the correct version of PNPM in CI.