### PR TITLE
Enforce explicit https addresses for TLS connections

### DIFF
--- a/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
+++ b/docs/modules/ROOT/partials/rust/errors/ConnectionError.adoc
@@ -8,6 +8,7 @@
 [options="header"]
 |===
 |Variant
+a| `AbsentTlsConfigForTlsConnection`
 a| `AddressTranslationMismatch`
 a| `BrokenPipe`
 a| `ClusterAllNodesFailed`
@@ -23,6 +24,7 @@ a| `InvalidResponseField`
 a| `ListsNotImplemented`
 a| `MissingPort`
 a| `MissingResponseField`
+a| `NonTlsConnectionWithHttps`
 a| `QueryStreamNoResponse`
 a| `RPCMethodUnavailable`
 a| `SSLCertificateNotValidated`
@@ -30,6 +32,7 @@ a| `ServerConnectionFailed`
 a| `ServerConnectionFailedStatusError`
 a| `ServerConnectionFailedWithError`
 a| `ServerConnectionIsClosed`
+a| `TlsConnectionWithoutHttps`
 a| `TokenCredentialInvalid`
 a| `TransactionIsClosed`
 a| `TransactionIsClosedWithErrors`

--- a/python/README.md
+++ b/python/README.md
@@ -40,7 +40,7 @@ class TypeDBExample:
     def typedb_example(self):
         # Open a driver connection. Specify your parameters if needed
         # The connection will be automatically closed on the "with" block exit
-        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver:
             # Create a database
             driver.databases.create("typedb")
             database = driver.databases.get("typedb")

--- a/python/example.py
+++ b/python/example.py
@@ -8,7 +8,7 @@ class TypeDBExample:
     def typedb_example(self):
         # Open a driver connection. Specify your parameters if needed
         # The connection will be automatically closed on the "with" block exit
-        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver:
             # Create a database
             driver.databases.create("typedb")
             database = driver.databases.get("typedb")

--- a/python/tests/behaviour/background/cluster/environment.py
+++ b/python/tests/behaviour/background/cluster/environment.py
@@ -53,7 +53,7 @@ def create_driver(context, host="localhost", port=None, username=None, password=
     if password is None:
         password = "password"
     credentials = Credentials(username, password)
-    return TypeDB.driver(address=f"{host}:{port}", credentials=credentials, driver_options=DriverOptions())
+    return TypeDB.driver(address=f"{host}:{port}", credentials=credentials, driver_options=DriverOptions(is_tls_enabled=False))
 
 
 def after_scenario(context: Context, scenario):

--- a/python/tests/behaviour/background/community/environment.py
+++ b/python/tests/behaviour/background/community/environment.py
@@ -50,7 +50,7 @@ def create_driver(context, host="localhost", port=None, username=None, password=
     if password is None:
         password = "password"
     credentials = Credentials(username, password)
-    return TypeDB.driver(address=f"{host}:{port}", credentials=credentials, driver_options=DriverOptions())
+    return TypeDB.driver(address=f"{host}:{port}", credentials=credentials, driver_options=DriverOptions(is_tls_enabled=False))
 
 
 def after_scenario(context: Context, scenario):

--- a/python/tests/deployment/test.py
+++ b/python/tests/deployment/test.py
@@ -35,7 +35,7 @@ class TestDeployedPythonDriver(TestCase):
     def setUpClass(cls):
         super(TestDeployedPythonDriver, cls).setUpClass()
         global driver
-        driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions())
+        driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False))
 
     @classmethod
     def tearDownClass(cls):

--- a/python/tests/integration/test_debug.py
+++ b/python/tests/integration/test_debug.py
@@ -29,7 +29,7 @@ SCHEMA = TransactionType.SCHEMA
 class TestDebug(TestCase):
 
     def setUp(self):
-        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver:
             if TYPEDB not in [db.name for db in driver.databases.all()]:
                 driver.databases.create(TYPEDB)
 

--- a/python/tests/integration/test_example.py
+++ b/python/tests/integration/test_example.py
@@ -27,7 +27,7 @@ class TestExample(TestCase):
     # EXAMPLE END MARKER
 
     def setUp(self):
-        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver:
             if driver.databases.contains("typedb"):
                 driver.databases.get("typedb").delete()
 
@@ -36,7 +36,7 @@ class TestExample(TestCase):
     def test_example(self):
         # Open a driver connection. Specify your parameters if needed
         # The connection will be automatically closed on the "with" block exit
-        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver:
             # Create a database
             driver.databases.create("typedb")
             database = driver.databases.get("typedb")

--- a/python/tests/integration/test_values.py
+++ b/python/tests/integration/test_values.py
@@ -34,7 +34,7 @@ SCHEMA = TransactionType.SCHEMA
 class TestValues(TestCase):
 
     def setUp(self):
-        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver:
+        with TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver:
             if driver.databases.contains(TYPEDB):
                 driver.databases.get(TYPEDB).delete()
             driver.databases.create(TYPEDB)
@@ -67,7 +67,7 @@ class TestValues(TestCase):
             "expiration": "P1Y10M7DT15H44M5.00394892S"
         }
 
-        with (TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver):
+        with (TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver):
             database = driver.databases.get(TYPEDB)
 
             with driver.transaction(database.name, SCHEMA) as tx:
@@ -184,7 +184,7 @@ class TestValues(TestCase):
         Datetime.fromstring("2024-09-21", tz_name="Asia/Calcutta", datetime_fmt="%Y-%m-%d")
         Datetime.fromstring("21/09/24 18:34", tz_name="Africa/Cairo", datetime_fmt="%d/%m/%y %H:%M")
 
-        with (TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver):
+        with (TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver):
             database = driver.databases.get(TYPEDB)
 
             with driver.transaction(database.name, SCHEMA) as tx:
@@ -374,7 +374,7 @@ class TestValues(TestCase):
         Duration.fromstring("P1Y10M7DT15H44M5.00394892S")
         Duration.fromstring("P55W")
 
-        with (TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions()) as driver):
+        with (TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(is_tls_enabled=False)) as driver):
             database = driver.databases.get(TYPEDB)
 
             with driver.transaction(database.name, SCHEMA) as tx:

--- a/rust/src/common/error.rs
+++ b/rust/src/common/error.rs
@@ -184,6 +184,12 @@ error_messages! { ConnectionError
         32: "The database export channel is closed and no further operation is allowed.",
     DatabaseExportStreamNoResponse =
         33: "Didn't receive any server responses for the database export command.",
+    AbsentTlsConfigForTlsConnection =
+        34: "Could not establish a TLS connection without a TLS config specified. Please verify your driver options.",
+    TlsConnectionWithoutHttps =
+        35: "TLS connections can only be enabled when connecting to HTTPS endpoints, for example using 'https://<ip>:port'. Please modify the address, or disable TLS (WARNING: this will send passwords over plaintext).",
+    NonTlsConnectionWithHttps =
+        36: "Connecting to an https endpoint requires enabling TLS in driver options.",
 }
 
 error_messages! { ConceptError


### PR DESCRIPTION
## Usage and product changes
Drivers return explicit error messages when connection addresses and TLS options are mismatched. TLS connections require addresses to have `https`. Non-TLS connections require addresses not to have `https`.  

## Implementation
Enhance `address.rs` to retrieve URI schemes from the stored addresses. Before creating a single server connection in Rust, validate the addresses based on the requirements described above.