### PR TITLE
Implement serde traits for JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2737,6 +2737,7 @@ dependencies = [
  "log",
  "maybe-async",
  "prost",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,18 +2207,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2738,6 +2738,7 @@ dependencies = [
  "maybe-async",
  "prost",
  "regex",
+ "serde",
  "serde_json",
  "serial_test",
  "smol",

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -71,7 +71,10 @@ rust_library(
 rust_test(
     name = "typedb_driver_unit_tests",
     crate = ":typedb_driver",
-    deps = ["@crates//:serde_json"],
+    deps = [
+        "@crates//:rand",
+        "@crates//:serde_json",
+    ],
 )
 
 assemble_crate(

--- a/rust/BUILD
+++ b/rust/BUILD
@@ -37,6 +37,7 @@ typedb_driver_deps = [
     "@crates//:itertools",
     "@crates//:log",
     "@crates//:prost",
+    "@crates//:serde",
     "@crates//:tokio",
     "@crates//:tokio-stream",
     "@crates//:tonic",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -69,6 +69,11 @@
 		version = "0.4.27"
 		default-features = false
 
+	[dependencies.serde]
+		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
+		version = "1.0.219"
+		default-features = false
+
 	[dependencies.tokio-stream]
 		features = ["default", "net", "time"]
 		version = "0.1.17"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,6 +16,11 @@
 
 [dev-dependencies]
 
+	[dev-dependencies.rand]
+		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
+		version = "0.8.5"
+		default-features = false
+
 	[dev-dependencies.smol]
 		features = []
 		version = "1.3.0"

--- a/rust/src/answer/json.rs
+++ b/rust/src/answer/json.rs
@@ -288,8 +288,7 @@ mod test {
 
     #[test]
     fn serialize() {
-        let ser = serde_json::to_value(sample_json())
-        .unwrap();
+        let ser = serde_json::to_value(sample_json()).unwrap();
         let value = json!( { "array": [true, "string"], "number": 123.4 });
         assert_eq!(ser, value);
     }


### PR DESCRIPTION
## Usage and product changes

We implement serde's `Serialize` for `ConceptDocument` and our custom `JSON` type. This allows crates like `axum` that rely on `serde` to seamlessly return `Json<ConceptDocument>` from request handlers.

We also implement `Deserialize` for `JSON` for convenience.

## Implementation

Closes #766 