### PR TITLE
Correct link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ See the table below for links to README files, documentation, and source code.
 | Rust            | [README](https://github.com/typedb/typedb-driver/tree/master/rust/README.md)    | [Documentation](https://typedb.com/docs/reference/typedb-grpc-drivers/rust)       | [`rust/`](https://github.com/typedb/typedb-driver/tree/master/rust)      |
 | Python          | [README](https://github.com/typedb/typedb-driver/tree/master/python/README.md)  | [Documentation](https://typedb.com/docs/reference/typedb-grpc-drivers/python)     | [`python/`](https://github.com/typedb/typedb-driver/tree/master/python)  |
 | Java            | [README](https://github.com/typedb/typedb-driver/tree/master/java/README.md)    | [Documentation](https://typedb.com/docs/drivers/java/overview)                    | [`java/`](https://github.com/typedb/typedb-driver/tree/master/java)      |
-| Typescript HTTP | [README](https://github.com/typedb/typedb-driver/tree/master/http-ts/README.md) | [Documentation](https://typedb.com/docs/reference/typedb-http-drivers/typescript) | [`http-ts/`](https://github.com/typedb/typedb-driver/tree/master/nodejs) |
+| Typescript HTTP | [README](https://github.com/typedb/typedb-driver/tree/master/http-ts/README.md) | [Documentation](https://typedb.com/docs/reference/typedb-http-drivers/typescript) | [`http-ts/`](https://github.com/typedb/typedb-driver/tree/master/http-ts) |
 
 There are also some GRPC drivers that are available for TypeDB 2.x but have not been upgraded to 3.x yet. Please contact
 us if you need one of these, or use the [HTTP API](https://typedb.com/docs/reference/typedb-http-api)


### PR DESCRIPTION
## Usage and product changes

Correct a link in the README that linked to `nodejs` instead of `http-ts`

## Implementation

Change the link